### PR TITLE
Prepare v1.1.0 roadmap and improve Bazzite installer guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable VR Hotspot release planning and release notes are tracked here.
+
+## Unreleased - v1.1.0
+
+Planning status: proposed major update. The current stable release remains
+`v1.0.4`; do not mark the software as `v1.1.0` until the release checklist is
+complete.
+
+Theme: "It Just Works" update for SteamOS, Bazzite, CachyOS, Arch, Ubuntu,
+Fedora, and Pop!_OS users.
+
+### Installer reliability
+
+- Plan installer hardening for distro detection, dependency checks, service
+  setup, firewall integration, and recovery from partial installs.
+- Improve install and uninstall output so beginners can see exactly what was
+  configured and how to open the web UI.
+- Define validation steps for SteamOS, Bazzite, CachyOS, Arch, Ubuntu, Fedora,
+  and Pop!_OS install paths.
+
+### Adapter Intelligence v2
+
+- Plan a second-generation adapter scoring model that explains which adapter is
+  recommended and why.
+- Expand detection for AP mode support, band support, driver constraints,
+  virtual adapters, and known weak built-in adapters.
+- Preserve Basic Mode defaults that guide users toward the most reliable USB
+  adapter without hiding useful advanced diagnostics.
+
+### Wi-Fi 6E readiness diagnostics
+
+- Plan diagnostics that report whether the system, adapter, regulatory domain,
+  driver, and selected channel are ready for 6 GHz operation.
+- Add clear readiness states for supported, blocked, degraded, and unknown
+  environments.
+- Document fallback expectations when 6 GHz is unavailable and 5 GHz or 2.4 GHz
+  should be used instead.
+
+### First-run setup wizard
+
+- Plan a web UI wizard for first launch that walks users through token entry,
+  adapter selection, SSID/passphrase setup, band choice, and first hotspot
+  start.
+- Keep the wizard focused on successful setup while leaving advanced controls
+  available after onboarding.
+- Include failure paths for missing adapters, blocked permissions, firewall
+  issues, and unsupported 6 GHz operation.
+
+### Support bundle export
+
+- Plan a one-click support bundle that collects relevant configuration,
+  platform facts, service status, recent logs, adapter inventory, diagnostics,
+  and sanitized environment metadata.
+- Ensure exported bundles avoid secrets, API tokens, passphrases, and private
+  keys.
+- Define CLI and web UI entry points so support data can be collected even when
+  one surface is unavailable.
+
+### Documentation refresh
+
+- Refresh user-facing setup docs around supported distributions, recommended
+  adapters, first-run expectations, recovery workflows, and diagnostics.
+- Keep versioning guidance explicit: `v1.0.4` remains stable until the release
+  is intentionally bumped.
+- Update troubleshooting docs with clearer install, firewall, adapter, and
+  Wi-Fi 6E readiness decision trees.
+
+### Test coverage
+
+- Plan coverage for installer preflight behavior, adapter scoring, Wi-Fi 6E
+  readiness states, wizard payloads, support bundle sanitization, and release
+  metadata drift prevention.
+- Keep existing `PYTHONPATH=backend pytest` as the required full-suite check
+  before release.
+- Add distro-focused verification notes for SteamOS, Bazzite, CachyOS, Arch,
+  Ubuntu, Fedora, and Pop!_OS.
+

--- a/docs/ROADMAP_v1.1.0.md
+++ b/docs/ROADMAP_v1.1.0.md
@@ -1,0 +1,117 @@
+# VR Hotspot v1.1.0 Roadmap
+
+Planning status: unreleased. The current stable release is `v1.0.4`; this
+document does not mark the software as `v1.1.0` and does not require runtime
+version metadata changes.
+
+## Theme
+
+The v1.1.0 "It Just Works" update is planned to make VR Hotspot easier to
+install, diagnose, and recover across SteamOS, Bazzite, CachyOS, Arch, Ubuntu,
+Fedora, and Pop!_OS.
+
+The release should reduce first-run uncertainty for users who want a dependable
+VR access point from a Linux PC or handheld without needing to understand
+hostapd, dnsmasq, NetworkManager, firewalld, regulatory domains, or adapter
+driver details.
+
+## Goals
+
+- Make installation and first launch clearer, more resilient, and easier to
+  verify.
+- Recommend the best available Wi-Fi adapter with transparent reasoning.
+- Explain Wi-Fi 6E readiness before users spend time debugging 6 GHz failures.
+- Add a guided first-run web UI path for successful hotspot creation.
+- Provide a sanitized support bundle for faster troubleshooting.
+- Refresh docs and tests so release quality is visible before tagging.
+
+## Non-Goals
+
+- Do not bump `pyproject.toml` or `backend/vr_hotspotd/__init__.py` during
+  planning.
+- Do not mark `v1.1.0` as released until implementation, testing, and release
+  checklist work are complete.
+- Do not remove advanced controls that power users already rely on.
+- Do not make distro-specific behavior opaque; explain platform decisions where
+  the system can detect them.
+
+## Phase 1: Release Hygiene and Installer UX
+
+- Audit release metadata so the project consistently reports `v1.0.4` until the
+  final version bump.
+- Improve installer messages for detected distro, dependency decisions, service
+  setup, firewall actions, generated token location, and web UI URL.
+- Harden partial-install recovery and uninstall paths.
+- Validate installer behavior on SteamOS, Bazzite, CachyOS, Arch, Ubuntu,
+  Fedora, and Pop!_OS.
+- Define acceptance tests for install success, install failure messaging, repair
+  guidance, and uninstall cleanup.
+
+## Phase 2: Adapter Intelligence v2
+
+- Design an adapter scoring model that considers interface role, AP support,
+  band support, driver capability, known chipset behavior, and current system
+  constraints.
+- Explain recommendations in the API and web UI with concise reasons such as
+  "USB adapter", "supports AP mode", "supports 6 GHz", or "built-in adapter
+  deprioritized".
+- Preserve advanced visibility into adapters that are not recommended.
+- Add tests for adapter inventory normalization, scoring decisions, fallback
+  behavior, and Basic Mode filtering.
+
+## Phase 3: Wi-Fi 6E Readiness Endpoint
+
+- Add a readiness model that reports whether 6 GHz operation is supported,
+  blocked, degraded, or unknown.
+- Check adapter capabilities, kernel/driver signals, regulatory domain, channel
+  selection, hostapd compatibility, and platform constraints where detectable.
+- Return actionable explanations and suggested fallback bands.
+- Cover SteamOS, Bazzite, CachyOS, Arch, Ubuntu, Fedora, and Pop!_OS in manual
+  verification notes where automated tests cannot fully represent hardware.
+
+## Phase 4: First-Run Web UI Wizard
+
+- Add a first-run path for token entry, adapter selection, SSID/passphrase
+  setup, band selection, optional autostart, and first hotspot start.
+- Use Adapter Intelligence v2 and Wi-Fi 6E readiness results to preselect
+  sensible defaults.
+- Include recovery paths for missing adapters, unsupported AP mode, firewall
+  setup issues, invalid passphrases, and failed starts.
+- Ensure returning users can skip the wizard and continue using the existing
+  control surface.
+
+## Phase 5: Support Bundle Export
+
+- Define support bundle contents: platform facts, package/version metadata,
+  service status, sanitized configuration, adapter inventory, diagnostic
+  results, recent daemon logs, firewall mode, and installer state.
+- Redact API tokens, hotspot passphrases, private keys, IPs where appropriate,
+  and other sensitive environment values.
+- Provide both web UI and CLI export paths.
+- Add tests for redaction, expected file structure, failure tolerance, and
+  bundle generation without elevated access where possible.
+
+## Phase 6: Docs, Tests, and Release Checklist
+
+- Refresh README setup flow, platform compatibility notes, adapter guidance,
+  troubleshooting, versioning guidance, and diagnostics documentation.
+- Add test coverage for installer UX helpers, Adapter Intelligence v2, Wi-Fi 6E
+  readiness states, first-run wizard payloads, support bundle sanitization, and
+  release metadata consistency.
+- Run `PYTHONPATH=backend pytest` before release candidate tagging.
+- Complete a release checklist that confirms no version metadata was bumped
+  prematurely, then performs the intentional release bump only when ready.
+- Publish final release notes from `CHANGELOG.md` after implementation and
+  verification are complete.
+
+## Release Checklist Draft
+
+- `CHANGELOG.md` has final v1.1.0 notes and no planning-only placeholders.
+- `docs/versioning.md` reflects the release source of truth.
+- `pyproject.toml`, `backend/vr_hotspotd/__init__.py`, UI fallback metadata, and
+  version metadata tests are updated together only at release time.
+- Full suite passes with `PYTHONPATH=backend pytest`.
+- Installer smoke tests pass on the target distro set.
+- Support bundle redaction tests pass.
+- GitHub Release notes match the final changelog.
+

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,46 @@ _apt_update_with_retry() {
     return 1
 }
 
+_rpm_ostree_already_requested_output() {
+    local output_lower
+    output_lower="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+    [[ "$output_lower" == *"already requested"* ]] && \
+        [[ "$output_lower" == *"package/capability"* ]] && \
+        [[ "$output_lower" == *"rpm-ostree"* ]]
+}
+
+_run_rpm_ostree_install() {
+    local output status errexit_was_set=0
+
+    case "$-" in
+        *e*) errexit_was_set=1 ;;
+    esac
+
+    set +e
+    output="$(rpm-ostree install "$@" 2>&1)"
+    status=$?
+    if [ "$errexit_was_set" -eq 1 ]; then
+        set -e
+    else
+        set +e
+    fi
+
+    if [ -n "$output" ]; then
+        if [ "$status" -ne 0 ]; then
+            printf '%s\n' "$output" >&2
+        else
+            printf '%s\n' "$output"
+        fi
+    fi
+
+    if [ "$status" -ne 0 ] && _rpm_ostree_already_requested_output "$output"; then
+        print_warning "rpm-ostree reports that this package is already requested. Reboot your system, then rerun the VR Hotspot installer."
+        return 2
+    fi
+
+    return "$status"
+}
+
 # --- Pre-flight & Cleanup ---
 check_root() {
     if [ "$EUID" -ne 0 ]; then
@@ -365,9 +405,23 @@ install_dependencies() {
             
             if [ ${#needed[@]} -gt 0 ]; then
                 print_info "Installing missing dependencies: ${needed[*]}"
-                if ! rpm-ostree install --apply-live "${needed[@]}"; then
+                if _run_rpm_ostree_install --apply-live "${needed[@]}"; then
+                    :
+                else
+                    local rpm_ostree_status=$?
+                    if [ "$rpm_ostree_status" -eq 2 ]; then
+                        exit 0
+                    fi
                     print_warning "Live install failed. Trying standard install..."
-                    rpm-ostree install "${needed[@]}"
+                    if _run_rpm_ostree_install "${needed[@]}"; then
+                        :
+                    else
+                        rpm_ostree_status=$?
+                        if [ "$rpm_ostree_status" -eq 2 ]; then
+                            exit 0
+                        fi
+                        return "$rpm_ostree_status"
+                    fi
                     print_warning "Dependencies installed. Please REBOOT your system and run this installer again."
                     exit 0
                 fi
@@ -618,5 +672,6 @@ main() {
     fi
 }
 
-main "$@"
-
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/tests/test_installer_rpm_ostree.py
+++ b/tests/test_installer_rpm_ostree.py
@@ -1,0 +1,80 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+
+
+def run_bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_rpm_ostree_already_requested_detector_requires_expected_terms():
+    positive = run_bash(
+        f"""
+        source {INSTALLER}
+        if _rpm_ostree_already_requested_output 'error: Package/capability python3 is already requested by rpm-ostree'; then
+          echo matched
+        else
+          echo missed
+        fi
+        """
+    )
+
+    negative = run_bash(
+        f"""
+        source {INSTALLER}
+        if _rpm_ostree_already_requested_output 'error: Package/capability python3 is already requested'; then
+          echo matched
+        else
+          echo missed
+        fi
+        """
+    )
+
+    assert positive.returncode == 0
+    assert positive.stdout.strip() == "matched"
+    assert negative.returncode == 0
+    assert negative.stdout.strip() == "missed"
+
+
+def test_rpm_ostree_install_wrapper_reports_reboot_guidance(tmp_path):
+    fake_rpm_ostree = tmp_path / "rpm-ostree"
+    fake_rpm_ostree.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'error: Package/capability iw is already requested by rpm-ostree' >&2\n"
+        "exit 1\n"
+    )
+    fake_rpm_ostree.chmod(fake_rpm_ostree.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        set +e
+        _run_rpm_ostree_install --apply-live iw
+        rc=$?
+        echo "rc=$rc"
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "rc=2" in result.stdout
+    assert (
+        "rpm-ostree reports that this package is already requested. "
+        "Reboot your system, then rerun the VR Hotspot installer."
+    ) in result.stdout
+    assert "Package/capability iw is already requested" in result.stderr


### PR DESCRIPTION
## Summary

- Adds v1.1.0 roadmap and changelog planning docs for the “It Just Works” update.
- Documents planned work for installer reliability, Adapter Intelligence v2, Wi-Fi 6E readiness, first-run wizard, support bundle export, docs, and test coverage.
- Improves Bazzite/rpm-ostree installer guidance when rpm-ostree reports that a package is already requested.
- Adds pytest coverage for the rpm-ostree already-requested detection path.

## Tests

- PYTHONPATH=backend pytest
- 167 passed