### PR TITLE
feat: expose Adapter Intelligence v2 readiness API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Enter the **API token** shown during installation to access the interface.
 - `GET /v1/status` - Current hotspot status
 - `GET /v1/status?include_logs=1` - Status with logs
 - `GET /v1/adapters` - List available WiFi adapters
+- `GET /v1/adapters/readiness` - Adapter Intelligence v2 readiness model
 
 **Diagnostics:**
 - `GET /v1/diagnostics/clients` - Connected clients

--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, Tuple
 from urllib.parse import parse_qs, quote, urlsplit
 
 from vr_hotspotd.adapters.inventory import get_adapters
+from vr_hotspotd.adapters.readiness import build_readiness_model
 from vr_hotspotd.config import load_config, write_config_file
 from vr_hotspotd.lifecycle import (
     repair,
@@ -1070,6 +1071,21 @@ class APIHandler(BaseHTTPRequestHandler):
             if not self._require_auth(cid):
                 return
             self._respond(200, self._envelope(correlation_id=cid, data=get_adapters()))
+            return
+
+        if path == "/v1/adapters/readiness":
+            if not self._require_auth(cid):
+                return
+            inventory = get_adapters()
+            warnings = ["adapter_inventory_error"] if isinstance(inventory, dict) and inventory.get("error") else []
+            self._respond(
+                200,
+                self._envelope(
+                    correlation_id=cid,
+                    data=build_readiness_model(inventory),
+                    warnings=warnings,
+                ),
+            )
             return
 
         if path == "/v1/config":

--- a/tests/test_api_adapter_readiness.py
+++ b/tests/test_api_adapter_readiness.py
@@ -1,0 +1,124 @@
+import io
+import json
+from email.message import Message
+
+import vr_hotspotd.api as api
+from vr_hotspotd.api import APIHandler
+
+
+def _make_handler(path: str = "/v1/adapters/readiness"):
+    handler = APIHandler.__new__(APIHandler)
+    handler.rfile = io.BytesIO()
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.command = "GET"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"GET {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    def send_header(_key, _value):
+        return
+
+    def end_headers():
+        return
+
+    handler.send_response = send_response
+    handler.send_header = send_header
+    handler.end_headers = end_headers
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_adapter_readiness_endpoint_exists(monkeypatch):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setattr(api, "get_adapters", lambda: {"adapters": [], "recommended": None})
+
+    handler = _make_handler()
+    handler.do_GET()
+
+    payload = _response_json(handler)
+    assert handler._last_code == 200
+    assert payload["result_code"] == "ok"
+    assert payload["data"]["adapters"] == []
+    assert payload["data"]["summary"]["reason_codes"] == ["no_adapter_found"]
+
+
+def test_adapter_readiness_requires_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+
+    handler = _make_handler()
+    handler.do_GET()
+
+    assert handler._last_code == 401
+    assert _response_json(handler)["result_code"] == "unauthorized"
+
+
+def test_adapter_readiness_calls_model_with_inventory(monkeypatch):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    inventory = {
+        "recommended": "wlan1",
+        "global_regdom": {"country": "US"},
+        "adapters": [{"ifname": "wlan1", "supports_ap": True}],
+    }
+    seen = {}
+
+    def fake_build_readiness_model(arg):
+        seen["inventory"] = arg
+        return {"sentinel": True}
+
+    monkeypatch.setattr(api, "get_adapters", lambda: inventory)
+    monkeypatch.setattr(api, "build_readiness_model", fake_build_readiness_model)
+
+    handler = _make_handler()
+    handler.do_GET()
+
+    assert handler._last_code == 200
+    assert seen["inventory"] is inventory
+    assert _response_json(handler)["data"] == {"sentinel": True}
+
+
+def test_adapter_readiness_no_adapter_response_shape(monkeypatch):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setattr(
+        api,
+        "get_adapters",
+        lambda: {
+            "recommended": None,
+            "adapters": [],
+            "global_regdom": {"country": "US", "raw": "country US: DFS-FCC"},
+        },
+    )
+
+    handler = _make_handler()
+    handler.do_GET()
+
+    data = _response_json(handler)["data"]
+    assert handler._last_code == 200
+    assert data["recommended"] is None
+    assert data["basic_mode_recommended"] is None
+    assert data["adapters"] == []
+    assert data["global_regulatory_domain"]["country"] == "US"
+    assert data["summary"]["readiness_state"] == "unsupported"
+    assert data["summary"]["six_ghz_state"] == "unknown"
+    assert data["summary"]["recommendation_score"] == 0
+    assert data["summary"]["reason_codes"] == ["no_adapter_found"]
+
+
+def test_adapters_endpoint_output_unchanged(monkeypatch):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    inventory = {"recommended": "wlan1", "adapters": [{"ifname": "wlan1"}]}
+    monkeypatch.setattr(api, "get_adapters", lambda: inventory)
+
+    handler = _make_handler("/v1/adapters")
+    handler.do_GET()
+
+    assert handler._last_code == 200
+    assert _response_json(handler)["data"] is not inventory
+    assert _response_json(handler)["data"] == inventory


### PR DESCRIPTION
## Summary

- Adds GET /v1/adapters/readiness.
- Uses the existing adapter inventory and Adapter Intelligence v2 readiness model.
- Keeps GET /v1/adapters unchanged.
- Uses the existing API auth/envelope behavior.
- Adds API tests for endpoint existence, auth, inventory handoff, no-adapter response shape, and /v1/adapters stability.
- Documents the new endpoint in README.

## Tests

- PYTHONPATH=backend pytest
- 178 passed