### PR TITLE
feat: show Adapter Readiness in web UI

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -145,6 +145,42 @@
             <div id="dirtyBasic" class="small mt-6 warning-text"></div>
           </div>
         </div>
+
+        <div class="card basic-card adapter-readiness-card" data-adapter-readiness-card>
+          <div class="card-header">
+            <h2>Adapter Readiness</h2>
+          </div>
+          <div class="card-body">
+            <div class="kv-grid adapter-readiness-grid">
+              <div class="kv-item">
+                <div class="kv-label">Recommended</div>
+                <div class="kv-value" data-readiness-field="recommended">Loading...</div>
+              </div>
+              <div class="kv-item">
+                <div class="kv-label">Readiness</div>
+                <div class="kv-value" data-readiness-field="state">--</div>
+              </div>
+              <div class="kv-item">
+                <div class="kv-label">Score</div>
+                <div class="kv-value" data-readiness-field="score">--</div>
+              </div>
+              <div class="kv-item">
+                <div class="kv-label">6 GHz</div>
+                <div class="kv-value" data-readiness-field="six-ghz">--</div>
+              </div>
+              <div class="kv-item kv-span">
+                <div class="kv-label">Basic Mode</div>
+                <div class="kv-value" data-readiness-field="basic-recommended">--</div>
+              </div>
+            </div>
+            <div class="mt-12">
+              <div class="small muted">Top Reasons</div>
+              <div class="badge-row adapter-readiness-reasons" data-readiness-field="reasons"></div>
+            </div>
+            <div class="small mt-10 adapter-readiness-explanation" data-readiness-field="explanation"></div>
+            <div class="small mt-8 warning-text" data-readiness-field="fallback" style="display:none"></div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -315,6 +351,42 @@
                     </div>
                   </details>
                 </div>
+              </div>
+            </div>
+
+            <div class="card adapter-readiness-card" data-adapter-readiness-card>
+              <div class="card-header">
+                <h2>Adapter Readiness</h2>
+              </div>
+              <div class="card-body">
+                <div class="kv-grid adapter-readiness-grid">
+                  <div class="kv-item">
+                    <div class="kv-label">Recommended</div>
+                    <div class="kv-value" data-readiness-field="recommended">Loading...</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">Readiness</div>
+                    <div class="kv-value" data-readiness-field="state">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">Score</div>
+                    <div class="kv-value" data-readiness-field="score">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">6 GHz</div>
+                    <div class="kv-value" data-readiness-field="six-ghz">--</div>
+                  </div>
+                  <div class="kv-item kv-span">
+                    <div class="kv-label">Basic Mode</div>
+                    <div class="kv-value" data-readiness-field="basic-recommended">--</div>
+                  </div>
+                </div>
+                <div class="mt-12">
+                  <div class="small muted">Top Reasons</div>
+                  <div class="badge-row adapter-readiness-reasons" data-readiness-field="reasons"></div>
+                </div>
+                <div class="small mt-10 adapter-readiness-explanation" data-readiness-field="explanation"></div>
+                <div class="small mt-8 warning-text" data-readiness-field="fallback" style="display:none"></div>
               </div>
             </div>
 

--- a/assets/ui.css
+++ b/assets/ui.css
@@ -243,6 +243,27 @@ input:checked + .slider:before {
   align-self: start;
 }
 
+.adapter-readiness-card {
+  align-self: start;
+}
+
+.adapter-readiness-grid {
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+}
+
+.adapter-readiness-card .kv-item {
+  padding: 9px;
+}
+
+.adapter-readiness-card .kv-value {
+  font-size: 12px;
+}
+
+.adapter-readiness-explanation {
+  line-height: 1.45;
+}
+
 /* Layout for Advanced Mode */
 .advanced-layout {
   display: flex;

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -1328,6 +1328,76 @@ function renderBadges(container, items) {
   }
 }
 
+function readinessPanels() {
+  return Array.from(document.querySelectorAll('[data-adapter-readiness-card]'));
+}
+
+function setReadinessField(panel, field, value, fallback = '--') {
+  if (!panel) return;
+  const el = panel.querySelector(`[data-readiness-field="${field}"]`);
+  if (!el) return;
+  const text = (value === null || value === undefined || value === '') ? fallback : String(value);
+  el.textContent = text;
+}
+
+function formatReadinessLabel(value) {
+  if (!value) return '--';
+  return labelizeKey(value);
+}
+
+function pickReadinessAdapter(data) {
+  if (!data || !Array.isArray(data.adapters) || data.adapters.length === 0) return null;
+  const recommended = data.recommended || '';
+  if (recommended) {
+    const found = data.adapters.find((adapter) => adapter && adapter.interface === recommended);
+    if (found) return found;
+  }
+  return data.adapters[0] || null;
+}
+
+function renderAdapterReadiness(data) {
+  const adapter = pickReadinessAdapter(data);
+  const summary = (data && data.summary) || adapter || {};
+  const reasons = (
+    summary.reason_messages ||
+    summary.reasons ||
+    summary.reason_codes ||
+    []
+  ).slice(0, 6);
+  const explanation = summary.explanation || 'Adapter readiness data is available, but no explanation was provided.';
+  for (const panel of readinessPanels()) {
+    setReadinessField(panel, 'recommended', data && data.recommended);
+    setReadinessField(panel, 'state', formatReadinessLabel(summary.readiness_state));
+    setReadinessField(panel, 'score', summary.recommendation_score);
+    setReadinessField(panel, 'six-ghz', formatReadinessLabel(summary.six_ghz_state));
+    setReadinessField(panel, 'basic-recommended', data && data.basic_mode_recommended, 'Not available');
+    renderBadges(panel.querySelector('[data-readiness-field="reasons"]'), reasons);
+    setReadinessField(panel, 'explanation', explanation, '');
+    const fallback = panel.querySelector('[data-readiness-field="fallback"]');
+    if (fallback) {
+      fallback.textContent = '';
+      fallback.style.display = 'none';
+    }
+  }
+}
+
+function renderAdapterReadinessFallback() {
+  for (const panel of readinessPanels()) {
+    setReadinessField(panel, 'recommended', 'Unavailable');
+    setReadinessField(panel, 'state', '--');
+    setReadinessField(panel, 'score', '--');
+    setReadinessField(panel, 'six-ghz', '--');
+    setReadinessField(panel, 'basic-recommended', '--');
+    renderBadges(panel.querySelector('[data-readiness-field="reasons"]'), []);
+    setReadinessField(panel, 'explanation', 'Adapter readiness is not available from this service version.', '');
+    const fallback = panel.querySelector('[data-readiness-field="fallback"]');
+    if (fallback) {
+      fallback.textContent = 'The rest of the UI will continue to work normally.';
+      fallback.style.display = 'block';
+    }
+  }
+}
+
 async function copyToClipboard(text) {
   if (!text) return false;
   try {
@@ -2759,6 +2829,23 @@ async function loadAdapters() {
   maybeAutoPickAdapterForBand();
 }
 
+async function loadAdapterReadiness() {
+  if (!isAuthenticated) return;
+  let r;
+  try {
+    r = await api('/v1/adapters/readiness');
+  } catch {
+    renderAdapterReadinessFallback();
+    return;
+  }
+  if (!isAuthenticated) return;
+  if (!r.ok || !r.json || !r.json.data) {
+    renderAdapterReadinessFallback();
+    return;
+  }
+  renderAdapterReadiness(r.json.data || {});
+}
+
 async function refresh() {
   if (!isAuthenticated) return;
   const requestSeq = ++refreshRequestSeq;
@@ -2856,6 +2943,10 @@ async function refresh() {
   renderTelemetry(s.telemetry);
 }
 
+async function refreshVisibleUi() {
+  await Promise.all([refresh(), loadAdapterReadiness()]);
+}
+
 function applyAutoRefresh() {
   const autoEl = document.getElementById('autoRefresh');
   const everyEl = document.getElementById('refreshEvery');
@@ -2890,12 +2981,13 @@ function applyPrivacyMode() {
   if (basic) basic.checked = v;
 }
 
-document.getElementById('btnRefresh').addEventListener('click', refresh);
+document.getElementById('btnRefresh').addEventListener('click', refreshVisibleUi);
 const btnRefreshBasic = document.getElementById('btnRefreshBasic');
-if (btnRefreshBasic) btnRefreshBasic.addEventListener('click', refresh);
+if (btnRefreshBasic) btnRefreshBasic.addEventListener('click', refreshVisibleUi);
 
 document.getElementById('btnReloadAdapters').addEventListener('click', async () => {
   await loadAdapters();
+  await loadAdapterReadiness();
   await refresh();
 });
 
@@ -3303,6 +3395,7 @@ function bootstrapAuthenticatedUi() {
 
   // Load adapters first so the adapter select is populated before applying config.
   loadAdapters()
+    .then(loadAdapterReadiness)
     .then(refresh)
     .then(() => {
       applyAutoRefresh();

--- a/tests/test_ui_basic_mode_payload.py
+++ b/tests/test_ui_basic_mode_payload.py
@@ -62,3 +62,27 @@ class TestUiBasicModePayload(unittest.TestCase):
         self.assertIn('body[data-ui-mode="basic"] #btnCopyPass', css)
         self.assertIn('body[data-ui-mode="basic"] #btnSavePassBasic', css)
         self.assertIn('.basic-passphrase-actions .basic-qr-toggle', css)
+
+    def test_adapter_readiness_ui_contract(self):
+        html = Path("assets/index.html").read_text(encoding="utf-8")
+        self.assertIn("<h2>Adapter Readiness</h2>", html)
+        for field in (
+            "recommended",
+            "state",
+            "score",
+            "six-ghz",
+            "basic-recommended",
+            "reasons",
+            "explanation",
+            "fallback",
+        ):
+            self.assertIn(f'data-readiness-field="{field}"', html)
+        self.assertIn("Basic Mode", html)
+        self.assertIn("Top Reasons", html)
+
+        src = Path("assets/ui.js").read_text(encoding="utf-8")
+        self.assertIn("async function loadAdapterReadiness", src)
+        self.assertIn("api('/v1/adapters/readiness')", src)
+        self.assertIn("function renderAdapterReadinessFallback", src)
+        self.assertIn("Adapter readiness is not available from this service version.", src)
+        self.assertIn("refreshVisibleUi", src)


### PR DESCRIPTION
## Summary

- Adds an Adapter Readiness card to the Basic and Pro web UI.
- Fetches GET /v1/adapters/readiness through the existing authenticated API helper.
- Shows recommended adapter, readiness state, score, 6 GHz state, Basic Mode recommendation, top reasons, and explanation.
- Adds a friendly fallback when the endpoint is unavailable.
- Adds frontend contract coverage.
- Does not change backend behavior.

## Tests

- PYTHONPATH=backend pytest
- 179 passed