### PR TITLE
feat: add support bundle redaction helpers

### DIFF
--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -1,0 +1,123 @@
+"""Redaction helpers for future diagnostics support bundles."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import Any, Dict
+
+
+SECRET_PLACEHOLDER = "<redacted-secret>"
+AUTHORIZATION_PLACEHOLDER = "<redacted-authorization>"
+PRIVATE_KEY_PLACEHOLDER = "<redacted-private-key>"
+
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_AUTHORIZATION_RE = re.compile(r"(?im)(\bAuthorization\s*:\s*)[^\r\n]+")
+_QUERY_TOKEN_RE = re.compile(
+    r"(?i)([?&](?:api[_-]?token|access[_-]?token|auth[_-]?token|token)=)[^&\s\"']+"
+)
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_HOME_USER_RE = re.compile(r"(?P<prefix>/home/)(?P<user>[^/\s:]+)")
+_MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b")
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_LINE_SECRET_RE = re.compile(
+    r"(?im)^(\s*(?:export\s+)?[A-Za-z0-9_.-]*(?:"
+    r"VR_HOTSPOTD_API_TOKEN|wpa_passphrase|sae_password|passphrase|password|secret|token|psk"
+    r")[A-Za-z0-9_.-]*\s*[:=]\s*)[^\r\n#]+"
+)
+_JSON_SECRET_RE = re.compile(
+    r'(?i)("?[A-Za-z0-9_.-]*(?:'
+    r'VR_HOTSPOTD_API_TOKEN|wpa_passphrase|sae_password|passphrase|password|secret|token|psk'
+    r')[A-Za-z0-9_.-]*"?\s*:\s*)(".*?"|[^,\r\n}]+)'
+)
+
+
+def redact_support_bundle_text(text: str) -> str:
+    """Return redacted support-bundle text with stable placeholders per call."""
+    return _RedactionRun().redact_text(text)
+
+
+def redact_support_bundle_data(value: Any) -> Any:
+    """Return a redacted copy of nested support-bundle data."""
+    return _RedactionRun().redact_data(value)
+
+
+def is_sensitive_key(key: Any) -> bool:
+    """Return True when a config/log key should be treated as secret-bearing."""
+    if not isinstance(key, str):
+        return False
+    normalized = key.strip().lower().replace("-", "_")
+    if normalized in {"psk", "wpa_passphrase", "sae_password", "vr_hotspotd_api_token"}:
+        return True
+    return normalized.endswith(
+        ("_psk", "_password", "_passphrase", "_secret", "_token")
+    ) or normalized in {"password", "passphrase", "secret", "token", "api_token"}
+
+
+class _RedactionRun:
+    def __init__(self) -> None:
+        self._email_placeholders: Dict[str, str] = {}
+        self._mac_placeholders: Dict[str, str] = {}
+        self._user_placeholders: Dict[str, str] = {}
+        self._ipv4_placeholders: Dict[str, str] = {}
+
+    def redact_data(self, value: Any) -> Any:
+        if isinstance(value, str):
+            return self.redact_text(value)
+        if isinstance(value, dict):
+            redacted: Dict[Any, Any] = {}
+            for key, item in value.items():
+                redacted_key = self.redact_text(key) if isinstance(key, str) else key
+                if is_sensitive_key(key):
+                    redacted[redacted_key] = SECRET_PLACEHOLDER
+                else:
+                    redacted[redacted_key] = self.redact_data(item)
+            return redacted
+        if isinstance(value, list):
+            return [self.redact_data(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self.redact_data(item) for item in value)
+        return value
+
+    def redact_text(self, text: str) -> str:
+        redacted = _PRIVATE_KEY_RE.sub(PRIVATE_KEY_PLACEHOLDER, text)
+        redacted = _AUTHORIZATION_RE.sub(r"\1" + AUTHORIZATION_PLACEHOLDER, redacted)
+        redacted = _QUERY_TOKEN_RE.sub(r"\1" + SECRET_PLACEHOLDER, redacted)
+        redacted = _LINE_SECRET_RE.sub(r"\1" + SECRET_PLACEHOLDER, redacted)
+        redacted = _JSON_SECRET_RE.sub(r"\1" + '"' + SECRET_PLACEHOLDER + '"', redacted)
+        redacted = _EMAIL_RE.sub(self._email_placeholder, redacted)
+        redacted = _HOME_USER_RE.sub(self._home_user_placeholder, redacted)
+        redacted = _MAC_RE.sub(self._mac_placeholder, redacted)
+        redacted = _IPV4_RE.sub(self._ipv4_placeholder, redacted)
+        return redacted
+
+    def _email_placeholder(self, match: re.Match[str]) -> str:
+        return self._stable_placeholder(self._email_placeholders, match.group(0), "email")
+
+    def _mac_placeholder(self, match: re.Match[str]) -> str:
+        value = match.group(0).lower().replace("-", ":")
+        return self._stable_placeholder(self._mac_placeholders, value, "mac")
+
+    def _home_user_placeholder(self, match: re.Match[str]) -> str:
+        user = match.group("user")
+        placeholder = self._stable_placeholder(self._user_placeholders, user, "user")
+        return match.group("prefix") + placeholder
+
+    def _ipv4_placeholder(self, match: re.Match[str]) -> str:
+        value = match.group(0)
+        try:
+            ip = ipaddress.ip_address(value)
+        except ValueError:
+            return value
+        if not ip.is_global:
+            return value
+        return self._stable_placeholder(self._ipv4_placeholders, value, "ipv4")
+
+    @staticmethod
+    def _stable_placeholder(placeholders: Dict[str, str], value: str, label: str) -> str:
+        if value not in placeholders:
+            placeholders[value] = f"<redacted-{label}-{len(placeholders) + 1}>"
+        return placeholders[value]

--- a/tests/test_support_bundle_redaction.py
+++ b/tests/test_support_bundle_redaction.py
@@ -1,0 +1,131 @@
+from vr_hotspotd.diagnostics.support_bundle import (
+    AUTHORIZATION_PLACEHOLDER,
+    PRIVATE_KEY_PLACEHOLDER,
+    SECRET_PLACEHOLDER,
+    redact_support_bundle_data,
+    redact_support_bundle_text,
+)
+
+
+def test_redacts_api_tokens_and_authorization_headers():
+    text = "\n".join(
+        [
+            "VR_HOTSPOTD_API_TOKEN=super-secret-token",
+            "curl http://127.0.0.1/v1/status?token=copied-token",
+            "Authorization: Bearer copied-token",
+        ]
+    )
+
+    redacted = redact_support_bundle_text(text)
+
+    assert "super-secret-token" not in redacted
+    assert "copied-token" not in redacted
+    assert f"VR_HOTSPOTD_API_TOKEN={SECRET_PLACEHOLDER}" in redacted
+    assert f"?token={SECRET_PLACEHOLDER}" in redacted
+    assert f"Authorization: {AUTHORIZATION_PLACEHOLDER}" in redacted
+
+
+def test_redacts_wifi_passphrases_and_psks_in_text_and_dicts():
+    text = "\n".join(
+        [
+            "wpa2_passphrase=quest-hotspot-secret",
+            "wpa_passphrase=legacy-secret",
+            "psk=0123456789abcdef",
+            "sae_password=wpa3-secret",
+        ]
+    )
+    data = {
+        "ssid": "VRHotspot",
+        "wpa2_passphrase": "quest-hotspot-secret",
+        "nested": {
+            "psk": "0123456789abcdef",
+            "sae_password": "wpa3-secret",
+        },
+    }
+
+    redacted_text = redact_support_bundle_text(text)
+    redacted_data = redact_support_bundle_data(data)
+
+    for secret in ("quest-hotspot-secret", "legacy-secret", "0123456789abcdef", "wpa3-secret"):
+        assert secret not in redacted_text
+    assert redacted_text.count(SECRET_PLACEHOLDER) == 4
+    assert redacted_data == {
+        "ssid": "VRHotspot",
+        "wpa2_passphrase": SECRET_PLACEHOLDER,
+        "nested": {
+            "psk": SECRET_PLACEHOLDER,
+            "sae_password": SECRET_PLACEHOLDER,
+        },
+    }
+
+
+def test_redacts_private_key_blocks():
+    text = """before
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAA
+-----END OPENSSH PRIVATE KEY-----
+after"""
+
+    redacted = redact_support_bundle_text(text)
+
+    assert "b3BlbnNzaC1rZXktdjE" not in redacted
+    assert PRIVATE_KEY_PLACEHOLDER in redacted
+    assert redacted.startswith("before")
+    assert redacted.endswith("after")
+
+
+def test_redacts_emails_home_users_public_ipv4_and_macs_with_stable_placeholders():
+    text = "\n".join(
+        [
+            "alice@example.com opened /home/alice/.config/vr-hotspot/config.json",
+            "client aa:bb:cc:dd:ee:ff connected from 8.8.8.8",
+            "repeat alice@example.com /home/alice aa-bb-cc-dd-ee-ff 8.8.8.8",
+            "other bob@example.com /home/bob 1.1.1.1 11:22:33:44:55:66",
+        ]
+    )
+
+    redacted = redact_support_bundle_text(text)
+
+    assert "alice@example.com" not in redacted
+    assert "bob@example.com" not in redacted
+    assert "/home/alice" not in redacted
+    assert "/home/bob" not in redacted
+    assert "aa:bb:cc:dd:ee:ff" not in redacted
+    assert "aa-bb-cc-dd-ee-ff" not in redacted
+    assert "11:22:33:44:55:66" not in redacted
+    assert "8.8.8.8" not in redacted
+    assert "1.1.1.1" not in redacted
+    assert redacted.count("<redacted-email-1>") == 2
+    assert redacted.count("<redacted-user-1>") == 2
+    assert redacted.count("<redacted-mac-1>") == 2
+    assert redacted.count("<redacted-ipv4-1>") == 2
+    assert "<redacted-email-2>" in redacted
+    assert "<redacted-user-2>" in redacted
+    assert "<redacted-mac-2>" in redacted
+    assert "<redacted-ipv4-2>" in redacted
+
+
+def test_preserves_useful_non_sensitive_diagnostic_values():
+    data = {
+        "interfaces": ["wlan0", "wlan1"],
+        "driver": "ath11k_pci",
+        "local_ips": ["192.168.50.1", "10.42.0.1", "172.16.0.5", "127.0.0.1"],
+        "readiness": {
+            "ready": False,
+            "reason_code": "adapter_missing_ap_mode",
+            "recommendation": "Use wlan1",
+        },
+        "log": "iface wlan0 driver ath11k_pci local 192.168.50.1 public 8.8.4.4",
+    }
+
+    redacted = redact_support_bundle_data(data)
+
+    assert redacted["interfaces"] == ["wlan0", "wlan1"]
+    assert redacted["driver"] == "ath11k_pci"
+    assert redacted["local_ips"] == ["192.168.50.1", "10.42.0.1", "172.16.0.5", "127.0.0.1"]
+    assert redacted["readiness"]["reason_code"] == "adapter_missing_ap_mode"
+    assert "iface wlan0" in redacted["log"]
+    assert "driver ath11k_pci" in redacted["log"]
+    assert "192.168.50.1" in redacted["log"]
+    assert "8.8.4.4" not in redacted["log"]
+    assert "<redacted-ipv4-1>" in redacted["log"]


### PR DESCRIPTION
## Summary

- Adds pure redaction helpers for future diagnostics support bundles.
- Supports redacting text and nested data structures.
- Redacts API tokens, authorization headers, Wi-Fi passphrases, PSKs, SAE passwords, private keys, emails, home usernames, public IPv4 addresses, and MAC addresses.
- Preserves useful non-sensitive diagnostic values such as interface names, driver names, private/local IPs, and readiness reason codes.
- Uses stable placeholders within one redaction run.
- Does not add the support bundle endpoint yet.
- Does not change UI behavior.

## Tests

- PYTHONPATH=backend pytest
- 184 passed