### PR TITLE
feat: add support bundle manifest helpers

### DIFF
--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -1,15 +1,52 @@
-"""Redaction helpers for future diagnostics support bundles."""
+"""Pure helpers for future diagnostics support bundles."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
 import ipaddress
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Union
+
+from vr_hotspotd import __version__
 
 
 SECRET_PLACEHOLDER = "<redacted-secret>"
 AUTHORIZATION_PLACEHOLDER = "<redacted-authorization>"
 PRIVATE_KEY_PLACEHOLDER = "<redacted-private-key>"
+SUPPORT_BUNDLE_SCHEMA_VERSION = 1
+
+
+class CollectorStatus:
+    """Documented support-bundle collector result states."""
+
+    OK = "ok"
+    MISSING_COMMAND = "missing_command"
+    PERMISSION_DENIED = "permission_denied"
+    TIMEOUT = "timeout"
+    NOT_APPLICABLE = "not_applicable"
+    FAILED = "failed"
+    REDACTION_FAILED = "redaction_failed"
+
+
+SUPPORT_BUNDLE_RESULT_STATES = (
+    CollectorStatus.OK,
+    CollectorStatus.MISSING_COMMAND,
+    CollectorStatus.PERMISSION_DENIED,
+    CollectorStatus.TIMEOUT,
+    CollectorStatus.NOT_APPLICABLE,
+    CollectorStatus.FAILED,
+    CollectorStatus.REDACTION_FAILED,
+)
+
+
+SUPPORT_BUNDLE_REDACTION_POLICY = {
+    "secrets": "redacted",
+    "emails_usernames": "redacted_when_detected",
+    "public_ips": "redacted",
+    "mac_addresses": "redacted_by_default",
+}
+
 
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
@@ -18,6 +55,11 @@ _PRIVATE_KEY_RE = re.compile(
 _AUTHORIZATION_RE = re.compile(r"(?im)(\bAuthorization\s*:\s*)[^\r\n]+")
 _QUERY_TOKEN_RE = re.compile(
     r"(?i)([?&](?:api[_-]?token|access[_-]?token|auth[_-]?token|token)=)[^&\s\"']+"
+)
+_INLINE_SECRET_RE = re.compile(
+    r"(?i)(\b[A-Za-z0-9_.-]*(?:"
+    r"VR_HOTSPOTD_API_TOKEN|wpa_passphrase|sae_password|passphrase|password|secret|token|psk"
+    r")[A-Za-z0-9_.-]*\s*=\s*)[^\s;&\"']+"
 )
 _EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
 _HOME_USER_RE = re.compile(r"(?P<prefix>/home/)(?P<user>[^/\s:]+)")
@@ -33,6 +75,144 @@ _JSON_SECRET_RE = re.compile(
     r'VR_HOTSPOTD_API_TOKEN|wpa_passphrase|sae_password|passphrase|password|secret|token|psk'
     r')[A-Za-z0-9_.-]*"?\s*:\s*)(".*?"|[^,\r\n}]+)'
 )
+
+
+@dataclass(frozen=True)
+class ArchiveFileMetadata:
+    """Static metadata for a support-bundle archive member."""
+
+    path: str
+    collector: str
+    content_type: str = "text/plain"
+
+    def to_manifest_dict(self) -> Dict[str, Any]:
+        return {
+            "path": self.path,
+            "collector": self.collector,
+            "content_type": self.content_type,
+        }
+
+
+@dataclass(frozen=True)
+class SupportBundleFileResult:
+    """Manifest metadata for one sanitized archive file."""
+
+    path: str
+    collector: str
+    status: str = CollectorStatus.OK
+    content_type: str = "text/plain"
+    size_bytes: int = 0
+    error_summary: Optional[str] = None
+
+    def to_manifest_dict(self) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "path": self.path,
+            "collector": self.collector,
+            "status": self.status,
+            "content_type": self.content_type,
+            "size_bytes": self.size_bytes,
+        }
+        if self.error_summary:
+            item["error_summary"] = self.error_summary
+        return item
+
+
+@dataclass(frozen=True)
+class SupportBundleCommandResult:
+    """Manifest metadata for one command collector outcome."""
+
+    command: Union[str, Sequence[str]]
+    status: str = CollectorStatus.OK
+    exit_code: Optional[int] = 0
+    timed_out: bool = False
+    permission_denied: bool = False
+    error_summary: Optional[str] = None
+
+    def to_manifest_dict(self) -> Dict[str, Any]:
+        item: Dict[str, Any] = {
+            "command": _format_command(self.command),
+            "status": self.status,
+        }
+        if self.exit_code is not None:
+            item["exit_code"] = self.exit_code
+        if self.timed_out:
+            item["timed_out"] = True
+        if self.permission_denied:
+            item["permission_denied"] = True
+        if self.error_summary:
+            item["error_summary"] = self.error_summary
+        return item
+
+
+SUPPORT_BUNDLE_ARCHIVE_LAYOUT = (
+    ArchiveFileMetadata("manifest.json", "manifest", "application/json"),
+    ArchiveFileMetadata("README.txt", "readme"),
+    ArchiveFileMetadata("system/os-release.txt", "os release"),
+    ArchiveFileMetadata("system/kernel.txt", "kernel"),
+    ArchiveFileMetadata("system/command-results.json", "command results", "application/json"),
+    ArchiveFileMetadata("service/status.txt", "systemctl status"),
+    ArchiveFileMetadata("service/show.json", "systemctl show", "application/json"),
+    ArchiveFileMetadata("service/journal.txt", "journalctl"),
+    ArchiveFileMetadata("vr-hotspot/version.json", "vr hotspot version", "application/json"),
+    ArchiveFileMetadata("vr-hotspot/status.json", "vr hotspot status", "application/json"),
+    ArchiveFileMetadata("vr-hotspot/adapters.json", "vr hotspot adapters", "application/json"),
+    ArchiveFileMetadata("vr-hotspot/readiness.json", "vr hotspot readiness", "application/json"),
+    ArchiveFileMetadata("vr-hotspot/config.redacted.json", "vr hotspot config", "application/json"),
+    ArchiveFileMetadata("wireless/iw-dev.txt", "iw dev"),
+    ArchiveFileMetadata("wireless/iw-list.txt", "iw list"),
+    ArchiveFileMetadata("wireless/iw-reg-get.txt", "iw reg get"),
+    ArchiveFileMetadata("wireless/rfkill-list.txt", "rfkill list"),
+    ArchiveFileMetadata("network/nmcli-device-status.txt", "nmcli device status"),
+    ArchiveFileMetadata("network/firewall.txt", "firewall"),
+    ArchiveFileMetadata("network/ufw-status.txt", "ufw status verbose"),
+)
+
+
+def default_support_bundle_archive_layout() -> list[Dict[str, Any]]:
+    """Return the documented archive member metadata."""
+    return [item.to_manifest_dict() for item in SUPPORT_BUNDLE_ARCHIVE_LAYOUT]
+
+
+def default_support_bundle_redaction_policy() -> Dict[str, str]:
+    """Return the manifest redaction policy."""
+    return dict(SUPPORT_BUNDLE_REDACTION_POLICY)
+
+
+def make_support_bundle_manifest(
+    *,
+    files: Iterable[SupportBundleFileResult] = (),
+    command_results: Iterable[SupportBundleCommandResult] = (),
+    generated_at: Optional[datetime] = None,
+    vr_hotspot_version: str = __version__,
+    platform_summary: Optional[Mapping[str, Any]] = None,
+    hostname_redacted: Optional[bool] = None,
+    hostname_note: Optional[str] = "hostname_not_collected",
+    warnings: Iterable[str] = (),
+    redaction_policy: Optional[Mapping[str, Any]] = None,
+    bundle_schema_version: int = SUPPORT_BUNDLE_SCHEMA_VERSION,
+) -> Dict[str, Any]:
+    """Build a redacted support-bundle manifest from already-collected results."""
+    when = generated_at or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    generated_at_text = when.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    manifest: Dict[str, Any] = {
+        "bundle_schema_version": bundle_schema_version,
+        "generated_at": generated_at_text,
+        "vr_hotspot_version": vr_hotspot_version,
+        "platform_summary": dict(platform_summary or {}),
+        "redaction_policy": dict(redaction_policy or SUPPORT_BUNDLE_REDACTION_POLICY),
+        "files": [item.to_manifest_dict() for item in files],
+        "command_results": [item.to_manifest_dict() for item in command_results],
+        "warnings": list(warnings),
+    }
+    if hostname_redacted is None:
+        manifest["hostname_note"] = hostname_note or "hostname_not_collected"
+    else:
+        manifest["hostname_redacted"] = hostname_redacted
+
+    return _RedactionRun().redact_data(manifest)
 
 
 def redact_support_bundle_text(text: str) -> str:
@@ -55,6 +235,12 @@ def is_sensitive_key(key: Any) -> bool:
     return normalized.endswith(
         ("_psk", "_password", "_passphrase", "_secret", "_token")
     ) or normalized in {"password", "passphrase", "secret", "token", "api_token"}
+
+
+def _format_command(command: Union[str, Sequence[str]]) -> str:
+    if isinstance(command, str):
+        return command
+    return " ".join(str(part) for part in command)
 
 
 class _RedactionRun:
@@ -86,6 +272,7 @@ class _RedactionRun:
         redacted = _PRIVATE_KEY_RE.sub(PRIVATE_KEY_PLACEHOLDER, text)
         redacted = _AUTHORIZATION_RE.sub(r"\1" + AUTHORIZATION_PLACEHOLDER, redacted)
         redacted = _QUERY_TOKEN_RE.sub(r"\1" + SECRET_PLACEHOLDER, redacted)
+        redacted = _INLINE_SECRET_RE.sub(r"\1" + SECRET_PLACEHOLDER, redacted)
         redacted = _LINE_SECRET_RE.sub(r"\1" + SECRET_PLACEHOLDER, redacted)
         redacted = _JSON_SECRET_RE.sub(r"\1" + '"' + SECRET_PLACEHOLDER + '"', redacted)
         redacted = _EMAIL_RE.sub(self._email_placeholder, redacted)

--- a/tests/test_support_bundle_manifest.py
+++ b/tests/test_support_bundle_manifest.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timezone
+
+from vr_hotspotd import __version__
+from vr_hotspotd.diagnostics.support_bundle import (
+    CollectorStatus,
+    SECRET_PLACEHOLDER,
+    SupportBundleCommandResult,
+    SupportBundleFileResult,
+    default_support_bundle_archive_layout,
+    make_support_bundle_manifest,
+)
+
+
+def _manifest(**kwargs):
+    kwargs.setdefault("generated_at", datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc))
+    return make_support_bundle_manifest(**kwargs)
+
+
+def test_manifest_includes_bundle_schema_version():
+    manifest = _manifest()
+
+    assert manifest["bundle_schema_version"] == 1
+
+
+def test_manifest_includes_generated_at():
+    manifest = _manifest()
+
+    assert manifest["generated_at"] == "2026-05-09T12:00:00Z"
+
+
+def test_manifest_includes_vr_hotspot_version():
+    manifest = _manifest()
+
+    assert manifest["vr_hotspot_version"] == __version__
+
+
+def test_manifest_includes_redaction_policy():
+    manifest = _manifest()
+
+    assert manifest["redaction_policy"] == {
+        "secrets": "redacted",
+        "emails_usernames": "redacted_when_detected",
+        "public_ips": "redacted",
+        "mac_addresses": "redacted_by_default",
+    }
+
+
+def test_manifest_includes_file_metadata_and_archive_layout_metadata():
+    file_result = SupportBundleFileResult(
+        path="wireless/iw-dev.txt",
+        collector="iw dev",
+        status=CollectorStatus.OK,
+        content_type="text/plain",
+        size_bytes=842,
+    )
+
+    manifest = _manifest(files=[file_result])
+    layout = default_support_bundle_archive_layout()
+
+    assert manifest["files"] == [
+        {
+            "path": "wireless/iw-dev.txt",
+            "collector": "iw dev",
+            "status": "ok",
+            "content_type": "text/plain",
+            "size_bytes": 842,
+        }
+    ]
+    assert {
+        "path": "manifest.json",
+        "collector": "manifest",
+        "content_type": "application/json",
+    } in layout
+    assert {
+        "path": "wireless/iw-dev.txt",
+        "collector": "iw dev",
+        "content_type": "text/plain",
+    } in layout
+
+
+def test_manifest_records_missing_command():
+    manifest = _manifest(
+        command_results=[
+            SupportBundleCommandResult(
+                command=["iw", "dev"],
+                status=CollectorStatus.MISSING_COMMAND,
+                exit_code=None,
+                error_summary="iw not found",
+            )
+        ]
+    )
+
+    assert manifest["command_results"] == [
+        {
+            "command": "iw dev",
+            "status": "missing_command",
+            "error_summary": "iw not found",
+        }
+    ]
+
+
+def test_manifest_records_permission_denied():
+    manifest = _manifest(
+        command_results=[
+            SupportBundleCommandResult(
+                command="journalctl -u vr-hotspotd.service -n 300 --no-pager",
+                status=CollectorStatus.PERMISSION_DENIED,
+                exit_code=1,
+                permission_denied=True,
+                error_summary="permission denied reading journal",
+            )
+        ]
+    )
+
+    assert manifest["command_results"][0] == {
+        "command": "journalctl -u vr-hotspotd.service -n 300 --no-pager",
+        "status": "permission_denied",
+        "exit_code": 1,
+        "permission_denied": True,
+        "error_summary": "permission denied reading journal",
+    }
+
+
+def test_manifest_records_timeout():
+    manifest = _manifest(
+        command_results=[
+            SupportBundleCommandResult(
+                command="systemctl status vr-hotspotd.service --no-pager",
+                status=CollectorStatus.TIMEOUT,
+                exit_code=None,
+                timed_out=True,
+                error_summary="collector timed out after 2s",
+            )
+        ]
+    )
+
+    assert manifest["command_results"][0] == {
+        "command": "systemctl status vr-hotspotd.service --no-pager",
+        "status": "timeout",
+        "timed_out": True,
+        "error_summary": "collector timed out after 2s",
+    }
+
+
+def test_manifest_records_failed():
+    manifest = _manifest(
+        command_results=[
+            SupportBundleCommandResult(
+                command="nmcli device status",
+                status=CollectorStatus.FAILED,
+                exit_code=10,
+                error_summary="nmcli failed for alice@example.com",
+            )
+        ]
+    )
+
+    assert manifest["command_results"][0] == {
+        "command": "nmcli device status",
+        "status": "failed",
+        "exit_code": 10,
+        "error_summary": "nmcli failed for <redacted-email-1>",
+    }
+
+
+def test_manifest_records_redaction_failed():
+    manifest = _manifest(
+        files=[
+            SupportBundleFileResult(
+                path="vr-hotspot/config.redacted.json",
+                collector="vr hotspot config",
+                status=CollectorStatus.REDACTION_FAILED,
+                content_type="application/json",
+                size_bytes=0,
+                error_summary="could not sanitize token=super-secret-token",
+            )
+        ],
+        command_results=[
+            SupportBundleCommandResult(
+                command="cat /etc/vr-hotspot/config.json",
+                status=CollectorStatus.REDACTION_FAILED,
+                exit_code=0,
+                error_summary="redaction failed for VR_HOTSPOTD_API_TOKEN=super-secret-token",
+            )
+        ],
+        warnings=["redaction failed; raw output omitted"],
+    )
+
+    assert manifest["files"][0] == {
+        "path": "vr-hotspot/config.redacted.json",
+        "collector": "vr hotspot config",
+        "status": "redaction_failed",
+        "content_type": "application/json",
+        "size_bytes": 0,
+        "error_summary": f"could not sanitize token={SECRET_PLACEHOLDER}",
+    }
+    assert manifest["command_results"][0] == {
+        "command": "cat /etc/vr-hotspot/config.json",
+        "status": "redaction_failed",
+        "exit_code": 0,
+        "error_summary": f"redaction failed for VR_HOTSPOTD_API_TOKEN={SECRET_PLACEHOLDER}",
+    }
+    assert manifest["warnings"] == ["redaction failed; raw output omitted"]


### PR DESCRIPTION
## Summary

- Adds pure support bundle manifest/helper support.
- Adds collector status constants for ok, missing_command, permission_denied, timeout, not_applicable, failed, and redaction_failed.
- Adds dataclass helpers for command results, file results, and archive layout metadata.
- Adds make_support_bundle_manifest() with schema version, generated_at, VR Hotspot version, redaction policy, files, command results, warnings, and hostname handling.
- Reuses the existing redaction helpers for manifest data.
- Tightens inline secret redaction for snippets like token=....
- Does not add the support bundle endpoint yet.
- Does not create archives.
- Does not change UI behavior.

## Tests

- PYTHONPATH=backend pytest
- 194 passed