### PR TITLE
feat: add support bundle collector helpers

### DIFF
--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -7,9 +7,13 @@ from datetime import datetime, timezone
 from io import BytesIO
 import ipaddress
 import json
+from pathlib import Path
 import posixpath
 import re
-from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Union
+import shlex
+import subprocess
+from subprocess import CompletedProcess, TimeoutExpired
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence, Union
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
 from vr_hotspotd import __version__
@@ -154,6 +158,23 @@ class SupportBundleCommandResult:
         return item
 
 
+@dataclass(frozen=True)
+class CollectedCommand:
+    """Sanitized command collector output plus manifest metadata."""
+
+    result: SupportBundleCommandResult
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class CollectedFile:
+    """Sanitized file collector output plus manifest metadata."""
+
+    result: SupportBundleFileResult
+    content: str = ""
+
+
 SUPPORT_BUNDLE_ARCHIVE_LAYOUT = (
     ArchiveFileMetadata("manifest.json", "manifest", "application/json"),
     ArchiveFileMetadata("README.txt", "readme"),
@@ -235,6 +256,276 @@ def redact_support_bundle_data(value: Any) -> Any:
     return _RedactionRun().redact_data(value)
 
 
+def command_collection_result(
+    command: Union[str, Sequence[str]],
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: Optional[int] = 0,
+    status: str = CollectorStatus.OK,
+    timed_out: bool = False,
+    permission_denied: bool = False,
+    error_summary: Optional[str] = None,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Create a sanitized command collection result."""
+    try:
+        redact = redactor or _RedactionRun().redact_text
+        sanitized_stdout = redact(_text_from_subprocess_value(stdout))
+        sanitized_stderr = redact(_text_from_subprocess_value(stderr))
+        sanitized_error = redact(error_summary) if error_summary else None
+    except Exception:
+        return CollectedCommand(
+            result=SupportBundleCommandResult(
+                command=command,
+                status=CollectorStatus.REDACTION_FAILED,
+                exit_code=exit_code,
+                timed_out=timed_out,
+                permission_denied=permission_denied,
+                error_summary="redaction failed; raw command output omitted",
+            )
+        )
+
+    return CollectedCommand(
+        result=SupportBundleCommandResult(
+            command=command,
+            status=status,
+            exit_code=exit_code,
+            timed_out=timed_out,
+            permission_denied=permission_denied,
+            error_summary=sanitized_error,
+        ),
+        stdout=sanitized_stdout,
+        stderr=sanitized_stderr,
+    )
+
+
+def missing_command_result(
+    command: Union[str, Sequence[str]],
+    *,
+    error_summary: Optional[str] = None,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Create a missing-command collector result."""
+    return command_collection_result(
+        command,
+        exit_code=None,
+        status=CollectorStatus.MISSING_COMMAND,
+        error_summary=error_summary or f"{_command_name(command)} not found",
+        redactor=redactor,
+    )
+
+
+def permission_denied_command_result(
+    command: Union[str, Sequence[str]],
+    *,
+    exit_code: Optional[int] = None,
+    stdout: str = "",
+    stderr: str = "",
+    error_summary: Optional[str] = None,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Create a permission-denied command collector result."""
+    return command_collection_result(
+        command,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        status=CollectorStatus.PERMISSION_DENIED,
+        permission_denied=True,
+        error_summary=error_summary or "permission denied",
+        redactor=redactor,
+    )
+
+
+def timeout_command_result(
+    command: Union[str, Sequence[str]],
+    *,
+    timeout: float,
+    stdout: Union[str, bytes, None] = "",
+    stderr: Union[str, bytes, None] = "",
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Create a timed-out command collector result."""
+    return command_collection_result(
+        command,
+        stdout=_text_from_subprocess_value(stdout),
+        stderr=_text_from_subprocess_value(stderr),
+        exit_code=None,
+        status=CollectorStatus.TIMEOUT,
+        timed_out=True,
+        error_summary=f"collector timed out after {timeout:g}s",
+        redactor=redactor,
+    )
+
+
+def failed_command_result(
+    command: Union[str, Sequence[str]],
+    *,
+    exit_code: Optional[int],
+    stdout: str = "",
+    stderr: str = "",
+    error_summary: Optional[str] = None,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Create a failed command collector result."""
+    return command_collection_result(
+        command,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        status=CollectorStatus.FAILED,
+        error_summary=error_summary or f"command exited with status {exit_code}",
+        redactor=redactor,
+    )
+
+
+def collect_command(
+    command: Union[str, Sequence[str]],
+    *,
+    timeout: float,
+    runner: Callable[..., CompletedProcess[str]] = subprocess.run,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedCommand:
+    """Run a bounded command collector and return sanitized output metadata."""
+    args = _command_args(command)
+    try:
+        completed = runner(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return missing_command_result(command, error_summary=str(exc), redactor=redactor)
+    except PermissionError as exc:
+        return permission_denied_command_result(
+            command,
+            error_summary=str(exc),
+            redactor=redactor,
+        )
+    except TimeoutExpired as exc:
+        return timeout_command_result(
+            command,
+            timeout=timeout,
+            stdout=exc.output,
+            stderr=exc.stderr,
+            redactor=redactor,
+        )
+
+    stdout = _text_from_subprocess_value(completed.stdout)
+    stderr = _text_from_subprocess_value(completed.stderr)
+    exit_code = completed.returncode
+    if exit_code == 0:
+        return command_collection_result(
+            command,
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+            status=CollectorStatus.OK,
+            redactor=redactor,
+        )
+
+    if _looks_permission_denied(stderr) or _looks_permission_denied(stdout):
+        return permission_denied_command_result(
+            command,
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            error_summary="permission denied",
+            redactor=redactor,
+        )
+
+    return failed_command_result(
+        command,
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        redactor=redactor,
+    )
+
+
+def file_collection_result(
+    path: str,
+    collector: str,
+    *,
+    content: str = "",
+    status: str = CollectorStatus.OK,
+    content_type: str = "text/plain",
+    error_summary: Optional[str] = None,
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedFile:
+    """Create a sanitized file collection result."""
+    try:
+        redact = redactor or _RedactionRun().redact_text
+        sanitized_content = redact(content)
+        sanitized_error = redact(error_summary) if error_summary else None
+    except Exception:
+        return CollectedFile(
+            result=SupportBundleFileResult(
+                path=path,
+                collector=collector,
+                status=CollectorStatus.REDACTION_FAILED,
+                content_type=content_type,
+                size_bytes=0,
+                error_summary="redaction failed; raw file content omitted",
+            )
+        )
+
+    return CollectedFile(
+        result=SupportBundleFileResult(
+            path=path,
+            collector=collector,
+            status=status,
+            content_type=content_type,
+            size_bytes=len(sanitized_content.encode("utf-8")),
+            error_summary=sanitized_error,
+        ),
+        content=sanitized_content,
+    )
+
+
+def collect_file(
+    source_path: Union[str, Path],
+    bundle_path: str,
+    *,
+    collector: Optional[str] = None,
+    content_type: str = "text/plain",
+    redactor: Optional[Callable[[str], str]] = None,
+) -> CollectedFile:
+    """Read and sanitize one text file for a future support bundle."""
+    source = Path(source_path)
+    collector_name = collector or str(source)
+    try:
+        content = source.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return file_collection_result(
+            bundle_path,
+            collector_name,
+            status=CollectorStatus.NOT_APPLICABLE,
+            content_type=content_type,
+            error_summary=f"file not found: {source}",
+        )
+    except PermissionError:
+        return file_collection_result(
+            bundle_path,
+            collector_name,
+            status=CollectorStatus.PERMISSION_DENIED,
+            content_type=content_type,
+            error_summary=f"permission denied reading {source}",
+        )
+
+    return file_collection_result(
+        bundle_path,
+        collector_name,
+        content=content,
+        status=CollectorStatus.OK,
+        content_type=content_type,
+        redactor=redactor,
+    )
+
+
 def build_support_bundle_archive(
     manifest: Mapping[str, Any],
     files: Union[Mapping[str, Union[str, bytes]], Iterable[tuple[str, Union[str, bytes]]]],
@@ -281,6 +572,29 @@ def _format_command(command: Union[str, Sequence[str]]) -> str:
     if isinstance(command, str):
         return command
     return " ".join(str(part) for part in command)
+
+
+def _command_args(command: Union[str, Sequence[str]]) -> Sequence[str]:
+    if isinstance(command, str):
+        return shlex.split(command)
+    return [str(part) for part in command]
+
+
+def _command_name(command: Union[str, Sequence[str]]) -> str:
+    args = _command_args(command)
+    return args[0] if args else ""
+
+
+def _text_from_subprocess_value(value: Union[str, bytes, None]) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _looks_permission_denied(text: str) -> bool:
+    return "permission denied" in text.lower()
 
 
 def _iter_archive_files(

--- a/tests/test_support_bundle_collectors.py
+++ b/tests/test_support_bundle_collectors.py
@@ -1,0 +1,215 @@
+import sys
+from subprocess import CompletedProcess, TimeoutExpired
+
+from vr_hotspotd.diagnostics.support_bundle import (
+    CollectorStatus,
+    SECRET_PLACEHOLDER,
+    collect_command,
+    collect_file,
+)
+
+
+def test_successful_command_collection():
+    collected = collect_command(
+        [sys.executable, "-c", "print('collector ok')"],
+        timeout=5,
+    )
+
+    assert collected.result.status == CollectorStatus.OK
+    assert collected.result.exit_code == 0
+    assert collected.result.timed_out is False
+    assert collected.result.permission_denied is False
+    assert collected.stdout == "collector ok\n"
+    assert collected.stderr == ""
+
+
+def test_missing_command():
+    def runner(*args, **kwargs):
+        raise FileNotFoundError("missing collector")
+
+    collected = collect_command(["missing-vr-hotspot-helper"], timeout=1, runner=runner)
+
+    assert collected.result.status == CollectorStatus.MISSING_COMMAND
+    assert collected.result.exit_code is None
+    assert collected.result.error_summary == "missing collector"
+
+
+def test_permission_denied_command():
+    def runner(*args, **kwargs):
+        raise PermissionError("permission denied running collector")
+
+    collected = collect_command(["journalctl"], timeout=1, runner=runner)
+
+    assert collected.result.status == CollectorStatus.PERMISSION_DENIED
+    assert collected.result.exit_code is None
+    assert collected.result.permission_denied is True
+    assert collected.result.error_summary == "permission denied running collector"
+
+
+def test_timeout():
+    def runner(*args, **kwargs):
+        raise TimeoutExpired(
+            cmd=args[0],
+            timeout=kwargs["timeout"],
+            output="VR_HOTSPOTD_API_TOKEN=secret-token\n",
+            stderr="still running\n",
+        )
+
+    collected = collect_command(["slow-command"], timeout=2, runner=runner)
+
+    assert collected.result.status == CollectorStatus.TIMEOUT
+    assert collected.result.exit_code is None
+    assert collected.result.timed_out is True
+    assert collected.result.error_summary == "collector timed out after 2s"
+    assert collected.stdout == f"VR_HOTSPOTD_API_TOKEN={SECRET_PLACEHOLDER}\n"
+    assert collected.stderr == "still running\n"
+
+
+def test_failed_command():
+    def runner(*args, **kwargs):
+        return CompletedProcess(
+            args=args[0],
+            returncode=42,
+            stdout="partial output\n",
+            stderr="collector failed\n",
+        )
+
+    collected = collect_command(["nmcli", "device", "status"], timeout=1, runner=runner)
+
+    assert collected.result.status == CollectorStatus.FAILED
+    assert collected.result.exit_code == 42
+    assert collected.result.error_summary == "command exited with status 42"
+    assert collected.stdout == "partial output\n"
+    assert collected.stderr == "collector failed\n"
+
+
+def test_command_redaction_applied_to_stdout_and_stderr():
+    def runner(*args, **kwargs):
+        return CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="VR_HOTSPOTD_API_TOKEN=stdout-secret\n",
+            stderr="wpa_passphrase=stderr-secret\n",
+        )
+
+    collected = collect_command(["print-secrets"], timeout=1, runner=runner)
+
+    assert "stdout-secret" not in collected.stdout
+    assert "stderr-secret" not in collected.stderr
+    assert collected.stdout == f"VR_HOTSPOTD_API_TOKEN={SECRET_PLACEHOLDER}\n"
+    assert collected.stderr == f"wpa_passphrase={SECRET_PLACEHOLDER}\n"
+
+
+def test_command_redaction_failure_omits_raw_output():
+    def runner(*args, **kwargs):
+        return CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="VR_HOTSPOTD_API_TOKEN=raw-secret\n",
+            stderr="raw stderr\n",
+        )
+
+    def broken_redactor(value):
+        raise RuntimeError("redactor unavailable")
+
+    collected = collect_command(
+        ["print-secrets"],
+        timeout=1,
+        runner=runner,
+        redactor=broken_redactor,
+    )
+
+    assert collected.result.status == CollectorStatus.REDACTION_FAILED
+    assert collected.result.exit_code == 0
+    assert collected.result.error_summary == "redaction failed; raw command output omitted"
+    assert collected.stdout == ""
+    assert collected.stderr == ""
+
+
+def test_file_collection_success(tmp_path):
+    source = tmp_path / "os-release"
+    source.write_text("ID=steamos\n", encoding="utf-8")
+
+    collected = collect_file(
+        source,
+        "system/os-release.txt",
+        collector="os release",
+    )
+
+    assert collected.result.status == CollectorStatus.OK
+    assert collected.result.path == "system/os-release.txt"
+    assert collected.result.collector == "os release"
+    assert collected.result.size_bytes == len("ID=steamos\n")
+    assert collected.content == "ID=steamos\n"
+
+
+def test_file_missing(tmp_path):
+    collected = collect_file(
+        tmp_path / "missing",
+        "system/os-release.txt",
+        collector="os release",
+    )
+
+    assert collected.result.status == CollectorStatus.NOT_APPLICABLE
+    assert collected.result.size_bytes == 0
+    assert collected.result.error_summary.startswith("file not found:")
+    assert collected.content == ""
+
+
+def test_file_permission_denied(monkeypatch, tmp_path):
+    source = tmp_path / "protected"
+    source.write_text("secret\n", encoding="utf-8")
+
+    def denied(self, *args, **kwargs):
+        raise PermissionError
+
+    monkeypatch.setattr("pathlib.Path.read_text", denied)
+
+    collected = collect_file(
+        source,
+        "service/journal.txt",
+        collector="journal",
+    )
+
+    assert collected.result.status == CollectorStatus.PERMISSION_DENIED
+    assert collected.result.size_bytes == 0
+    assert collected.result.error_summary == f"permission denied reading {source}"
+    assert collected.content == ""
+
+
+def test_file_redaction_applied(tmp_path):
+    source = tmp_path / "config.env"
+    source.write_text(
+        "ssid=VRHotspot\nwpa_passphrase=file-secret\n",
+        encoding="utf-8",
+    )
+
+    collected = collect_file(
+        source,
+        "vr-hotspot/config.redacted.env",
+        collector="config",
+    )
+
+    assert "file-secret" not in collected.content
+    assert collected.content == f"ssid=VRHotspot\nwpa_passphrase={SECRET_PLACEHOLDER}\n"
+    assert collected.result.size_bytes == len(collected.content.encode("utf-8"))
+
+
+def test_file_redaction_failure_omits_raw_content(tmp_path):
+    source = tmp_path / "config.env"
+    source.write_text("VR_HOTSPOTD_API_TOKEN=raw-secret\n", encoding="utf-8")
+
+    def broken_redactor(value):
+        raise RuntimeError("redactor unavailable")
+
+    collected = collect_file(
+        source,
+        "vr-hotspot/config.redacted.env",
+        collector="config",
+        redactor=broken_redactor,
+    )
+
+    assert collected.result.status == CollectorStatus.REDACTION_FAILED
+    assert collected.result.size_bytes == 0
+    assert collected.result.error_summary == "redaction failed; raw file content omitted"
+    assert collected.content == ""


### PR DESCRIPTION
## Summary

- Adds support bundle collector helpers.
- Adds CollectedCommand and CollectedFile result objects.
- Adds bounded command collection with timeout, stdout/stderr sanitization, exit code tracking, and collector status.
- Adds file collection with redaction and metadata.
- Handles missing commands, permission denied, timeouts, failed commands, and redaction failures.
- Omits raw command/file output when redaction fails.
- Does not add the support bundle endpoint yet.
- Does not change UI behavior.

## Tests

- PYTHONPATH=backend pytest
- 211 passed