### PR TITLE
feat: add support bundle assembly helper

### DIFF
--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -141,6 +141,8 @@ class SupportBundleCommandResult:
     timed_out: bool = False
     permission_denied: bool = False
     error_summary: Optional[str] = None
+    stdout_path: Optional[str] = None
+    stderr_path: Optional[str] = None
 
     def to_manifest_dict(self) -> Dict[str, Any]:
         item: Dict[str, Any] = {
@@ -155,6 +157,10 @@ class SupportBundleCommandResult:
             item["permission_denied"] = True
         if self.error_summary:
             item["error_summary"] = self.error_summary
+        if self.stdout_path:
+            item["stdout_path"] = self.stdout_path
+        if self.stderr_path:
+            item["stderr_path"] = self.stderr_path
         return item
 
 
@@ -173,6 +179,15 @@ class CollectedFile:
 
     result: SupportBundleFileResult
     content: str = ""
+
+
+@dataclass(frozen=True)
+class AssembledSupportBundle:
+    """In-memory support bundle archive plus response metadata."""
+
+    archive_bytes: bytes
+    filename: str
+    manifest: Dict[str, Any]
 
 
 SUPPORT_BUNDLE_ARCHIVE_LAYOUT = (
@@ -244,6 +259,123 @@ def make_support_bundle_manifest(
         manifest["hostname_redacted"] = hostname_redacted
 
     return _RedactionRun().redact_data(manifest)
+
+
+def assemble_support_bundle(
+    *,
+    commands: Iterable[CollectedCommand] = (),
+    files: Iterable[CollectedFile] = (),
+    generated_at: Optional[datetime] = None,
+    vr_hotspot_version: str = __version__,
+    platform_summary: Optional[Mapping[str, Any]] = None,
+    hostname_redacted: Optional[bool] = None,
+    hostname_note: Optional[str] = "hostname_not_collected",
+    warnings: Iterable[str] = (),
+    redaction_policy: Optional[Mapping[str, Any]] = None,
+    readme: Optional[Union[str, bytes]] = None,
+) -> AssembledSupportBundle:
+    """Assemble a support bundle from already-sanitized collector results.
+
+    This helper is intentionally pure: it does not run collectors, read source
+    files, or inspect the host system. Callers are responsible for passing only
+    sanitized command/file content.
+    """
+    when = generated_at or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    when_utc = when.astimezone(timezone.utc)
+
+    archive_files: list[tuple[str, Union[str, bytes]]] = []
+    manifest_files: list[SupportBundleFileResult] = []
+    manifest_commands: list[SupportBundleCommandResult] = []
+
+    for collected_file in files:
+        file_result = collected_file.result
+        archive_path = _safe_archive_path(file_result.path)
+        manifest_files.append(
+            SupportBundleFileResult(
+                path=archive_path,
+                collector=file_result.collector,
+                status=file_result.status,
+                content_type=file_result.content_type,
+                size_bytes=file_result.size_bytes,
+                error_summary=file_result.error_summary,
+            )
+        )
+        if file_result.status != CollectorStatus.REDACTION_FAILED:
+            archive_files.append((archive_path, collected_file.content))
+
+    for index, collected_command in enumerate(commands, start=1):
+        command_result = collected_command.result
+        collector_name = _format_command(command_result.command)
+        stdout_path: Optional[str] = None
+        stderr_path: Optional[str] = None
+
+        if command_result.status != CollectorStatus.REDACTION_FAILED:
+            if collected_command.stdout:
+                stdout_path = _command_output_archive_path(
+                    index, command_result.command, "stdout"
+                )
+                archive_files.append((stdout_path, collected_command.stdout))
+                manifest_files.append(
+                    SupportBundleFileResult(
+                        path=stdout_path,
+                        collector=collector_name,
+                        status=command_result.status,
+                        content_type="text/plain",
+                        size_bytes=len(collected_command.stdout.encode("utf-8")),
+                    )
+                )
+            if collected_command.stderr:
+                stderr_path = _command_output_archive_path(
+                    index, command_result.command, "stderr"
+                )
+                archive_files.append((stderr_path, collected_command.stderr))
+                manifest_files.append(
+                    SupportBundleFileResult(
+                        path=stderr_path,
+                        collector=collector_name,
+                        status=command_result.status,
+                        content_type="text/plain",
+                        size_bytes=len(collected_command.stderr.encode("utf-8")),
+                    )
+                )
+
+        manifest_commands.append(
+            SupportBundleCommandResult(
+                command=command_result.command,
+                status=command_result.status,
+                exit_code=command_result.exit_code,
+                timed_out=command_result.timed_out,
+                permission_denied=command_result.permission_denied,
+                error_summary=command_result.error_summary,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+            )
+        )
+
+    manifest = make_support_bundle_manifest(
+        files=manifest_files,
+        command_results=manifest_commands,
+        generated_at=when_utc,
+        vr_hotspot_version=vr_hotspot_version,
+        platform_summary=platform_summary,
+        hostname_redacted=hostname_redacted,
+        hostname_note=hostname_note,
+        warnings=warnings,
+        redaction_policy=redaction_policy,
+    )
+    archive_bytes = build_support_bundle_archive(
+        manifest,
+        archive_files,
+        readme=readme,
+    )
+    filename = f"vr-hotspot-support-bundle-{when_utc:%Y%m%d-%H%M%S}.zip"
+    return AssembledSupportBundle(
+        archive_bytes=archive_bytes,
+        filename=filename,
+        manifest=manifest,
+    )
 
 
 def redact_support_bundle_text(text: str) -> str:
@@ -615,6 +747,20 @@ def _content_bytes(content: Union[str, bytes]) -> bytes:
     if isinstance(content, str):
         return content.encode("utf-8")
     raise TypeError("support bundle archive content must be str or bytes")
+
+
+def _command_output_archive_path(
+    index: int,
+    command: Union[str, Sequence[str]],
+    stream_name: str,
+) -> str:
+    slug = _archive_slug(_format_command(command))
+    return _safe_archive_path(f"commands/{index:03d}-{slug}-{stream_name}.txt")
+
+
+def _archive_slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug[:80] or "command"
 
 
 def _safe_archive_path(path: str) -> str:

--- a/tests/test_support_bundle_assembly.py
+++ b/tests/test_support_bundle_assembly.py
@@ -1,0 +1,173 @@
+import json
+import re
+from datetime import datetime, timezone
+from io import BytesIO
+from zipfile import ZipFile
+
+import pytest
+
+from vr_hotspotd.diagnostics.support_bundle import (
+    CollectorStatus,
+    CollectedCommand,
+    CollectedFile,
+    SupportBundleCommandResult,
+    SupportBundleFileResult,
+    assemble_support_bundle,
+)
+
+
+def _read_archive(data):
+    with ZipFile(BytesIO(data)) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def test_assembled_bundle_filename_format():
+    bundle = assemble_support_bundle(
+        generated_at=datetime(2026, 5, 9, 12, 34, 56, tzinfo=timezone.utc)
+    )
+
+    assert bundle.filename == "vr-hotspot-support-bundle-20260509-123456.zip"
+    assert re.fullmatch(
+        r"vr-hotspot-support-bundle-\d{8}-\d{6}\.zip",
+        bundle.filename,
+    )
+
+
+def test_assembled_bundle_contains_manifest_readme_file_and_command_output():
+    bundle = assemble_support_bundle(
+        generated_at=datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc),
+        files=[
+            CollectedFile(
+                result=SupportBundleFileResult(
+                    path="system/os-release.txt",
+                    collector="os release",
+                    status=CollectorStatus.OK,
+                    content_type="text/plain",
+                    size_bytes=len("ID=steamos\n"),
+                ),
+                content="ID=steamos\n",
+            )
+        ],
+        commands=[
+            CollectedCommand(
+                result=SupportBundleCommandResult(
+                    command=["iw", "dev"],
+                    status=CollectorStatus.OK,
+                    exit_code=0,
+                ),
+                stdout="Interface wlan0\nssid=<redacted-secret>\n",
+                stderr="warning: <redacted-mac-1>\n",
+            )
+        ],
+        readme="README for assembly test\n",
+    )
+
+    members = _read_archive(bundle.archive_bytes)
+    manifest = json.loads(members["manifest.json"])
+
+    assert "manifest.json" in members
+    assert members["README.txt"] == b"README for assembly test\n"
+    assert members["system/os-release.txt"] == b"ID=steamos\n"
+    assert members["commands/001-iw-dev-stdout.txt"] == (
+        b"Interface wlan0\nssid=<redacted-secret>\n"
+    )
+    assert members["commands/001-iw-dev-stderr.txt"] == b"warning: <redacted-mac-1>\n"
+    assert manifest == bundle.manifest
+    assert manifest["command_results"] == [
+        {
+            "command": "iw dev",
+            "status": "ok",
+            "exit_code": 0,
+            "stdout_path": "commands/001-iw-dev-stdout.txt",
+            "stderr_path": "commands/001-iw-dev-stderr.txt",
+        }
+    ]
+    assert {
+        "path": "system/os-release.txt",
+        "collector": "os release",
+        "status": "ok",
+        "content_type": "text/plain",
+        "size_bytes": len("ID=steamos\n"),
+    } in manifest["files"]
+    assert {
+        "path": "commands/001-iw-dev-stdout.txt",
+        "collector": "iw dev",
+        "status": "ok",
+        "content_type": "text/plain",
+        "size_bytes": len("Interface wlan0\nssid=<redacted-secret>\n"),
+    } in manifest["files"]
+
+
+def test_assembled_bundle_omits_redaction_failed_raw_content_files():
+    bundle = assemble_support_bundle(
+        generated_at=datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc),
+        files=[
+            CollectedFile(
+                result=SupportBundleFileResult(
+                    path="vr-hotspot/config.redacted.env",
+                    collector="config",
+                    status=CollectorStatus.REDACTION_FAILED,
+                    size_bytes=0,
+                    error_summary="redaction failed; raw file content omitted",
+                ),
+                content="VR_HOTSPOTD_API_TOKEN=raw-file-secret\n",
+            )
+        ],
+        commands=[
+            CollectedCommand(
+                result=SupportBundleCommandResult(
+                    command=["print-secrets"],
+                    status=CollectorStatus.REDACTION_FAILED,
+                    exit_code=0,
+                    error_summary="redaction failed; raw command output omitted",
+                ),
+                stdout="VR_HOTSPOTD_API_TOKEN=raw-command-secret\n",
+                stderr="wpa_passphrase=raw-stderr-secret\n",
+            )
+        ],
+    )
+
+    members = _read_archive(bundle.archive_bytes)
+    manifest = json.loads(members["manifest.json"])
+    combined_content = b"".join(members.values())
+
+    assert "vr-hotspot/config.redacted.env" not in members
+    assert not any(name.startswith("commands/") for name in members)
+    assert b"raw-file-secret" not in combined_content
+    assert b"raw-command-secret" not in combined_content
+    assert b"raw-stderr-secret" not in combined_content
+    assert manifest["files"] == [
+        {
+            "path": "vr-hotspot/config.redacted.env",
+            "collector": "config",
+            "status": "redaction_failed",
+            "content_type": "text/plain",
+            "size_bytes": 0,
+            "error_summary": "redaction failed; raw file content omitted",
+        }
+    ]
+    assert manifest["command_results"] == [
+        {
+            "command": "print-secrets",
+            "status": "redaction_failed",
+            "exit_code": 0,
+            "error_summary": "redaction failed; raw command output omitted",
+        }
+    ]
+
+
+def test_assembled_bundle_rejects_unsafe_collected_file_paths():
+    with pytest.raises(ValueError, match="traversal"):
+        assemble_support_bundle(
+            files=[
+                CollectedFile(
+                    result=SupportBundleFileResult(
+                        path="../raw-secret.txt",
+                        collector="unsafe",
+                        status=CollectorStatus.OK,
+                        size_bytes=9,
+                    ),
+                    content="sanitized\n",
+                )
+            ]
+        )


### PR DESCRIPTION
## Summary

- Adds an in-memory support bundle assembly helper.
- Combines manifest generation, collected file results, collected command results, sanitized command stdout/stderr content, and archive generation.
- Returns archive bytes, filename, and manifest metadata.
- Adds stdout_path and stderr_path metadata for command output files.
- Skips raw content for redaction_failed command/file results.
- Rejects unsafe archive paths.
- Does not add the support bundle endpoint yet.
- Does not change UI behavior.

## Tests

- PYTHONPATH=backend pytest
- 215 passed