### PR TITLE
feat: expose diagnostics support bundle endpoint

### DIFF
--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -27,6 +27,12 @@ from vr_hotspotd.diagnostics.ping import run_ping, ping_available
 from vr_hotspotd.diagnostics.load import LoadGenerator
 from vr_hotspotd.diagnostics.udp_latency import run_udp_latency_test
 from vr_hotspotd.diagnostics.platform import collect_platform_matrix
+from vr_hotspotd.diagnostics.support_bundle import (
+    CollectorStatus,
+    assemble_support_bundle,
+    file_collection_result,
+    redact_support_bundle_data,
+)
 from vr_hotspotd import __version__
 from vr_hotspotd import telemetry
 from vr_hotspotd.state import load_state
@@ -409,6 +415,23 @@ class APIHandler(BaseHTTPRequestHandler):
     def _respond_raw(self, code: int, raw: bytes, content_type: str = "application/octet-stream"):
         self.send_response(code)
         self._send_common_headers(content_type, len(raw))
+        self.end_headers()
+        try:
+            self.wfile.write(raw)
+        except (BrokenPipeError, ConnectionResetError):
+            return
+
+    def _respond_attachment(
+        self,
+        code: int,
+        raw: bytes,
+        *,
+        content_type: str,
+        filename: str,
+    ):
+        self.send_response(code)
+        self._send_common_headers(content_type, len(raw))
+        self.send_header("Content-Disposition", f'attachment; filename="{filename}"')
         self.end_headers()
         try:
             self.wfile.write(raw)
@@ -902,6 +925,109 @@ class APIHandler(BaseHTTPRequestHandler):
         out["_wpa2_passphrase_redacted"] = passphrase_set
         return out
 
+    def _support_bundle_json_file(
+        self,
+        path: str,
+        collector: str,
+        data: Any,
+        *,
+        status: str = CollectorStatus.OK,
+        error_summary: Optional[str] = None,
+    ):
+        redacted = redact_support_bundle_data(data)
+        return file_collection_result(
+            path,
+            collector,
+            content=json.dumps(redacted, indent=2, sort_keys=True) + "\n",
+            status=status,
+            content_type="application/json",
+            error_summary=error_summary,
+        )
+
+    def _build_support_bundle(self):
+        files = [
+            self._support_bundle_json_file(
+                "vr-hotspot/version.json",
+                "vr hotspot version",
+                {
+                    "version": APP_VERSION,
+                    "server_version": SERVER_VERSION,
+                    "token_configured": bool(self._env_token()),
+                },
+            )
+        ]
+        warnings: list[str] = []
+
+        try:
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/status.json",
+                    "vr hotspot status",
+                    self._status_view(include_logs=False),
+                )
+            )
+        except Exception as exc:
+            warnings.append("status_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/status.json",
+                    "vr hotspot status",
+                    {},
+                    status=CollectorStatus.FAILED,
+                    error_summary=f"status unavailable: {exc}",
+                )
+            )
+
+        inventory: Any = None
+        try:
+            inventory = get_adapters()
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/adapters.json",
+                    "vr hotspot adapters",
+                    inventory,
+                )
+            )
+        except Exception as exc:
+            warnings.append("adapter_inventory_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/adapters.json",
+                    "vr hotspot adapters",
+                    {},
+                    status=CollectorStatus.FAILED,
+                    error_summary=f"adapter inventory unavailable: {exc}",
+                )
+            )
+
+        try:
+            if inventory is None:
+                inventory = get_adapters()
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/readiness.json",
+                    "vr hotspot readiness",
+                    build_readiness_model(inventory),
+                )
+            )
+        except Exception as exc:
+            warnings.append("adapter_readiness_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/readiness.json",
+                    "vr hotspot readiness",
+                    {},
+                    status=CollectorStatus.FAILED,
+                    error_summary=f"adapter readiness unavailable: {exc}",
+                )
+            )
+
+        return assemble_support_bundle(
+            files=files,
+            vr_hotspot_version=APP_VERSION,
+            warnings=warnings,
+        )
+
     def _handle_config_update(self, cid: str, body: Dict[str, Any], body_warnings: list[str]):
         if not self._require_auth(cid):
             return
@@ -1121,6 +1247,18 @@ class APIHandler(BaseHTTPRequestHandler):
                 ap_interface_hint=st.get("ap_interface"),
             )
             self._respond(200, self._envelope(correlation_id=cid, data=snapshot))
+            return
+
+        if path == "/v1/diagnostics/support_bundle":
+            if not self._require_auth(cid):
+                return
+            bundle = self._build_support_bundle()
+            self._respond_attachment(
+                200,
+                bundle.archive_bytes,
+                content_type="application/zip",
+                filename=bundle.filename,
+            )
             return
 
         self._respond(

--- a/tests/test_api_support_bundle.py
+++ b/tests/test_api_support_bundle.py
@@ -1,0 +1,126 @@
+import io
+import json
+import zipfile
+from email.message import Message
+
+import vr_hotspotd.api as api
+from vr_hotspotd.api import APIHandler
+
+
+def _make_handler(path: str = "/v1/diagnostics/support_bundle"):
+    handler = APIHandler.__new__(APIHandler)
+    handler.rfile = io.BytesIO()
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.command = "GET"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"GET {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+    handler._sent_headers = []
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    def send_header(key, value):
+        handler._sent_headers.append((key, value))
+
+    def end_headers():
+        return
+
+    handler.send_response = send_response
+    handler.send_header = send_header
+    handler.end_headers = end_headers
+    return handler
+
+
+def _headers(handler):
+    return {key.lower(): value for key, value in handler._sent_headers}
+
+
+def _zip_members(handler):
+    with zipfile.ZipFile(io.BytesIO(handler.wfile.getvalue())) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def _stub_bundle_sources(monkeypatch):
+    monkeypatch.setattr(
+        APIHandler,
+        "_status_view",
+        lambda self, include_logs: {
+            "running": True,
+            "wpa2_passphrase": "raw-wifi-passphrase",
+            "config_text": "wpa_passphrase=raw-config-passphrase\n",
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "get_adapters",
+        lambda: {
+            "recommended": "wlan1",
+            "adapters": [
+                {
+                    "ifname": "wlan1",
+                    "mac": "aa:bb:cc:dd:ee:ff",
+                    "api_token": "raw-adapter-token",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "build_readiness_model",
+        lambda inventory: {
+            "recommended": inventory.get("recommended"),
+            "secret": "raw-readiness-secret",
+        },
+    )
+
+
+def test_support_bundle_requires_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+
+    handler = _make_handler()
+    handler.do_GET()
+
+    assert handler._last_code == 401
+
+
+def test_support_bundle_returns_zip_headers_and_required_members(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    _stub_bundle_sources(monkeypatch)
+
+    handler = _make_handler()
+    handler.headers["X-Api-Token"] = "secret"
+    handler.do_GET()
+
+    headers = _headers(handler)
+    members = _zip_members(handler)
+
+    assert handler._last_code == 200
+    assert headers["content-type"] == "application/zip"
+    assert "filename=\"vr-hotspot-support-bundle-" in headers["content-disposition"]
+    assert headers["content-disposition"].endswith(".zip\"")
+    assert "manifest.json" in members
+    assert "README.txt" in members
+    assert json.loads(members["manifest.json"].decode("utf-8"))
+
+
+def test_support_bundle_archive_does_not_leak_raw_tokens_or_passphrases(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "raw-api-token")
+    _stub_bundle_sources(monkeypatch)
+
+    handler = _make_handler()
+    handler.headers["Authorization"] = "Bearer raw-api-token"
+    handler.do_GET()
+
+    archive_bytes = handler.wfile.getvalue()
+    members = _zip_members(handler)
+    all_member_bytes = b"".join(members.values())
+
+    assert b"raw-api-token" not in archive_bytes
+    assert b"raw-api-token" not in all_member_bytes
+    assert b"raw-wifi-passphrase" not in all_member_bytes
+    assert b"raw-config-passphrase" not in all_member_bytes
+    assert b"raw-adapter-token" not in all_member_bytes
+    assert b"raw-readiness-secret" not in all_member_bytes


### PR DESCRIPTION
## Summary

- Adds GET /v1/diagnostics/support_bundle.
- Requires existing API authentication.
- Returns an application/zip attachment with a generated support bundle filename.
- Includes manifest.json and README.txt.
- Includes safe VR Hotspot version/status, adapter inventory, and Adapter Intelligence readiness data.
- Uses existing support bundle redaction and assembly helpers.
- Adds API tests for auth, zip headers, archive members, manifest JSON, and secret redaction.
- Does not change UI behavior.

## Tests

- PYTHONPATH=backend pytest
- 218 passed