### PR TITLE
docs: polish v1.1.0 release notes and UI copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ complete.
 Theme: "It Just Works" update for SteamOS, Bazzite, CachyOS, Arch, Ubuntu,
 Fedora, and Pop!_OS users.
 
+### Completed v1.1.0 work in this branch
+
+- Add authenticated `GET /v1/adapters/readiness` endpoint for Adapter
+  Intelligence v2 summaries, reason codes, Basic Mode recommendation data, and
+  no-adapter responses.
+- Add Adapter Readiness panels to Basic and Pro web UI surfaces.
+- Add authenticated `GET /v1/diagnostics/support_bundle` endpoint that returns
+  a sanitized `.zip` support bundle with version, status, adapter inventory, and
+  readiness data.
+- Add Pro web UI support-bundle download action.
+- Add support bundle redaction, manifest, archive assembly, API, and UI
+  contract tests.
+
 ### Installer reliability
 
 - Plan installer hardening for distro detection, dependency checks, service
@@ -76,4 +89,3 @@ Fedora, and Pop!_OS users.
   before release.
 - Add distro-focused verification notes for SteamOS, Bazzite, CachyOS, Arch,
   Ubuntu, Fedora, and Pop!_OS.
-

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Enter the **API token** shown during installation to access the interface.
 **Basic Usage:**
 1. Open the web UI
 2. Enter your API token
-3. Select your WiFi adapter (wlan1 recommended over wlan0)
+3. Select your Wi-Fi adapter (wlan1 recommended over wlan0)
 4. Click **Start** to create your hotspot
 5. Connect your VR headset to the new network
 
 ---
 
-## Supported WiFi Adapters
+## Supported Wi-Fi Adapters
 
 ### ✅ Recommended (Tested & Working)
 - **BrosTrend AXE3000 Tri-Band** (Best Choice) - https://www.amazon.com/dp/B0F6MY7H62
@@ -88,7 +88,7 @@ Enter the **API token** shown during installation to access the interface.
 
 ### 🔧 Smart Adapter Management
 
-- Auto-detects WiFi adapters and recommends the best one
+- Auto-detects Wi-Fi adapters and recommends the best one
 - **Prioritizes wlan1+** over wlan0 (avoids Intel AX200 issues)
 - Hides problematic adapters in Basic Mode
 - Supports multiple bands: 2.4 GHz, 5 GHz, 6 GHz (Wi-Fi 6E)
@@ -102,13 +102,14 @@ Enter the **API token** shown during installation to access the interface.
 **Status & Monitoring:**
 - `GET /v1/status` - Current hotspot status
 - `GET /v1/status?include_logs=1` - Status with logs
-- `GET /v1/adapters` - List available WiFi adapters
+- `GET /v1/adapters` - List available Wi-Fi adapters
 - `GET /v1/adapters/readiness` - Adapter Intelligence v2 readiness model
 
 **Diagnostics:**
 - `GET /v1/diagnostics/clients` - Connected clients
 - `POST /v1/diagnostics/ping` - Ping test
 - `POST /v1/diagnostics/ping_under_load` - Performance under load
+- `GET /v1/diagnostics/support_bundle` - Download a sanitized support bundle
 
 ### 🔥 Firewalld Integration (SteamOS-Friendly)
 
@@ -134,7 +135,7 @@ All binaries are bundled for consistent, portable installations.
 Enable in the web UI under Advanced Mode:
 
 **System Tuning:**
-- `wifi_power_save_disable` - Disable power saving on WiFi
+- `wifi_power_save_disable` - Disable power saving on Wi-Fi
 - `cpu_governor_performance` - Set CPU to performance mode
 - `usb_autosuspend_disable` - Prevent USB adapter suspension
 - `sysctl_tuning` - Kernel network stack optimizations
@@ -269,7 +270,7 @@ curl -s "http://127.0.0.1:8732/v1/status?include_logs=1" -H "X-Api-Token: $TOKEN
 
 ### Common Issues
 
-**1. No WiFi adapters found:**
+**1. No Wi-Fi adapters found:**
 - Check: `iw dev`
 - Ensure adapter supports AP mode: `iw list | grep -A10 "Supported interface modes"`
 
@@ -296,6 +297,19 @@ If the hotspot gets stuck, use the **Repair** button in the web UI or:
 TOKEN=$(sudo awk -F= '/VR_HOTSPOTD_API_TOKEN/{print $2}' /etc/vr-hotspot/env)
 curl -X POST "http://127.0.0.1:8732/v1/repair" -H "X-Api-Token: $TOKEN"
 ```
+
+### Support Bundle
+
+For bug reports, use **Download support bundle** in Pro mode or call the
+authenticated endpoint directly:
+
+```bash
+TOKEN=$(sudo awk -F= '/VR_HOTSPOTD_API_TOKEN/{print $2}' /etc/vr-hotspot/env)
+curl -OJ "http://127.0.0.1:8732/v1/diagnostics/support_bundle" -H "X-Api-Token: $TOKEN"
+```
+
+The bundle is a sanitized `.zip` with version, status, adapter inventory, and
+readiness data. Review it before attaching it to a public issue.
 
 ---
 
@@ -373,10 +387,13 @@ Issues and pull requests are welcome!
 
 **When filing a bug, please include:**
 - OS/distro + kernel version
-- WiFi adapter chipset/model
-- Output of: `sudo journalctl -u vr-hotspotd.service -n 200`
-- Output of: `curl http://127.0.0.1:8732/v1/status?include_logs=1`
-- Redact any API tokens or passwords
+- Wi-Fi adapter chipset/model
+- A sanitized support bundle from Pro mode or
+  `GET /v1/diagnostics/support_bundle`
+- If you cannot generate a support bundle, include
+  `sudo journalctl -u vr-hotspotd.service -n 200` and
+  `curl http://127.0.0.1:8732/v1/status?include_logs=1`
+- Redact any API tokens or passwords from manually collected output
 
 See `CONTRIBUTING.md` for more details.
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -637,9 +637,10 @@
               <div class="form-group support-bundle-action">
                 <label>Support Bundle</label>
                 <div class="support-bundle-row">
-                  <button class="btn sm secondary" id="btnDownloadSupportBundle" type="button">Download Support Bundle</button>
+                  <button class="btn sm secondary" id="btnDownloadSupportBundle" type="button">Download support bundle</button>
                   <div class="small" id="supportBundleMsg" role="status"></div>
                 </div>
+                <div class="small faded mt-6">Sanitized ZIP for bug reports.</div>
               </div>
               <div class="form-group" data-field="ap_ready_timeout_s">
                 <label for="ap_ready_timeout_s">Startup Timeout (s)</label>
@@ -656,7 +657,7 @@
                   <label class="tog"><input type="checkbox" id="wifi_power_save_disable" /> Disable Wi-Fi Power
                     Save</label>
                   <label class="tog"><input type="checkbox" id="usb_autosuspend_disable" /> Disable USB
-                    Autosusiend</label>
+                    autosuspend</label>
                   <label class="tog"><input type="checkbox" id="cpu_governor_performance" /> CPU Performance
                     Mode</label>
                   <label class="tog"><input type="checkbox" id="sysctl_tuning" /> Enable sysctl tuning</label>

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -718,7 +718,7 @@ function applyUiMode(mode, opts = {}) {
   const adapterLbl = document.querySelector('label[for="ap_adapter"]');
   const adapterTip = document.getElementById('adapterLabelTip');
   if (adapterLbl) {
-    adapterLbl.textContent = (mode === 'basic') ? 'USB WiFi Adapter' : 'AP adapter';
+    adapterLbl.textContent = (mode === 'basic') ? 'USB Wi-Fi adapter' : 'AP adapter';
   }
   if (adapterTip) {
     const tipText = (mode === 'basic')
@@ -2908,7 +2908,7 @@ async function loadAdapters() {
     if (mode === 'basic') {
       basicUsbCount++;
       const recStr = (a.ifname === rec) ? ' (Recommended)' : '';
-      opt.textContent = `USB WiFi ${basicUsbCount}${recStr}`;
+      opt.textContent = `USB Wi-Fi ${basicUsbCount}${recStr}`;
     } else {
       const ap = a.supports_ap ? 'AP' : 'no-AP';
       const caps = capsLabel(a);

--- a/docs/ROADMAP_v1.1.0.md
+++ b/docs/ROADMAP_v1.1.0.md
@@ -35,6 +35,21 @@ driver details.
 - Do not make distro-specific behavior opaque; explain platform decisions where
   the system can detect them.
 
+## Current Implementation Snapshot
+
+This branch includes early v1.1.0 implementation work while the release remains
+unreleased:
+
+- `GET /v1/adapters/readiness` exposes Adapter Intelligence v2 readiness data
+  from the existing adapter inventory.
+- Basic and Pro UI surfaces show Adapter Readiness summaries.
+- `GET /v1/diagnostics/support_bundle` returns a sanitized `.zip` support
+  bundle with VR Hotspot version, status, adapter inventory, and readiness JSON.
+- Pro UI includes a support bundle download action.
+
+The installer hardening, first-run wizard, full CLI support-bundle helper, and
+full platform collector set still need completion before release.
+
 ## Phase 1: Release Hygiene and Installer UX
 
 - Audit release metadata so the project consistently reports `v1.0.4` until the
@@ -114,4 +129,3 @@ driver details.
 - Installer smoke tests pass on the target distro set.
 - Support bundle redaction tests pass.
 - GitHub Release notes match the final changelog.
-

--- a/docs/adapter-intelligence-v2.md
+++ b/docs/adapter-intelligence-v2.md
@@ -1,6 +1,9 @@
 # Adapter Intelligence v2 Design
 
-Status: documentation-only design. This document describes a future adapter readiness and scoring model for VR Hotspot v1.1.0. It does not require runtime or test changes yet.
+Status: implementation-backed design for unreleased VR Hotspot v1.1.0 work.
+The current branch includes the read-only readiness model and endpoint, while
+future work may extend host capability probes, chipset guesses, and UI
+decisioning. This document does not mark v1.1.0 as released.
 
 ## Goals
 
@@ -419,15 +422,17 @@ Reason codes should be stable, lowercase strings. Proposed codes:
 }
 ```
 
-## Future Endpoint
+## Current Endpoint
 
-Adapter Intelligence v2 can become:
+Adapter Intelligence v2 is exposed as an authenticated read-only endpoint:
 
 ```text
 GET /v1/adapters/readiness
 ```
 
-The endpoint should use the existing authenticated API envelope and should not replace `/v1/adapters` immediately. A future response shape:
+The endpoint uses the existing authenticated API envelope and does not replace
+`/v1/adapters`. The implemented response follows this shape, with fields
+populated from the currently available adapter inventory facts:
 
 ```json
 {
@@ -452,18 +457,16 @@ The endpoint should use the existing authenticated API envelope and should not r
 }
 ```
 
-Implementation path:
+Remaining implementation path:
 
-1. Add a pure normalization/scoring module that accepts inventory, `iw` text, regdomain data, hostapd capability probes, and current config.
-2. Add focused unit tests for state mapping, score ordering, reason codes, and no-adapter behavior.
-3. Wire `/v1/adapters/readiness` as read-only.
-4. Update Basic Mode UI to consume `basic_mode_visibility` and explanations.
-5. Keep `/v1/adapters` stable until the UI and tests have migrated.
+1. Extend host capability inputs with hostapd capability probes and current
+   config where useful.
+2. Add stronger chipset/vendor evidence only when sourced from reliable local
+   IDs or maintained tables.
+3. Continue keeping `/v1/adapters` stable while readiness data evolves.
+4. Use readiness fields more deeply in future first-run wizard flows.
 
 ## Non-Goals for This Design Step
 
-- No runtime code changes.
-- No test changes.
-- No change to existing `/v1/adapters` response.
 - No adapter blocklist unless it is backed by local evidence and tests.
 - No claim that a chipset guess is authoritative without a reliable source.

--- a/docs/first-run-wizard.md
+++ b/docs/first-run-wizard.md
@@ -8,8 +8,8 @@ or version metadata changes.
 
 - Help a new user move from API-token login to a working VR hotspot with safe
   defaults.
-- Use Adapter Intelligence v2 and `GET /v1/adapters/readiness` to choose the
-  best adapter and explain why.
+- Use the implemented Adapter Intelligence v2 endpoint,
+  `GET /v1/adapters/readiness`, to choose the best adapter and explain why.
 - Keep Basic Mode simple by hiding risky choices when a clearly better adapter
   exists.
 - Give Advanced and Developer users enough context to understand tradeoffs
@@ -85,7 +85,7 @@ The selected level should map to the persisted selected mode:
 
 ### 3. Adapter Selection
 
-The wizard should call `GET /v1/adapters/readiness` and use Adapter
+The wizard should call the current `GET /v1/adapters/readiness` endpoint and use Adapter
 Intelligence v2 fields:
 
 - `recommended`
@@ -527,4 +527,3 @@ Manual hardware checks:
 - 6 GHz-capable adapter with valid readiness.
 - 6 GHz-capable adapter blocked by global or no-IR regulatory state.
 - Headless/MiniPC access from a phone browser.
-

--- a/docs/support-bundle.md
+++ b/docs/support-bundle.md
@@ -1,8 +1,9 @@
 # Diagnostics Support Bundle Design
 
-Status: documentation-only design for the planned VR Hotspot v1.1.0 "It Just
-Works" update. This document does not require runtime code, UI, backend, test,
-or version metadata changes.
+Status: implementation-backed design for unreleased VR Hotspot v1.1.0 work.
+The current branch includes a limited authenticated web endpoint and Pro UI
+download action. Full system collectors and a CLI helper remain future work.
+This document does not mark v1.1.0 as released.
 
 ## Goals
 
@@ -18,13 +19,30 @@ or version metadata changes.
 
 ## Non-Goals
 
-- Do not implement bundle generation as part of this design step.
-- Do not add or change API routes yet.
 - Do not add or change CLI commands yet.
-- Do not change runtime code, tests, UI, backend behavior, installer behavior,
-  or version metadata.
+- Do not change installer behavior or version metadata as part of support
+  bundle planning.
 - Do not collect packet captures, browser storage, raw credentials, private
   keys, full home-directory listings, or unrelated application logs.
+
+## Current v1.1.0 Implementation
+
+The implemented web support bundle is intentionally limited but useful:
+
+- `GET /v1/diagnostics/support_bundle` requires the same API token as other
+  diagnostics endpoints.
+- The endpoint returns a `.zip` archive with `Content-Type: application/zip`
+  and a timestamped `vr-hotspot-support-bundle-YYYYMMDD-HHMMSS.zip` filename.
+- Current archive content includes `manifest.json`, `README.txt`,
+  `vr-hotspot/version.json`, `vr-hotspot/status.json`,
+  `vr-hotspot/adapters.json`, and `vr-hotspot/readiness.json`.
+- API tokens, passphrases, private keys, PSKs, emails, usernames, public IPs,
+  and MAC addresses are redacted before files enter the archive.
+- The Pro web UI includes a "Download support bundle" action.
+
+Not yet implemented: CLI export, full systemd/journal/firewall/wireless command
+collectors, tar.gz output, query parameters, and user opt-ins for expanded
+client identifiers.
 
 ## Collection Scope
 
@@ -238,9 +256,9 @@ Example manifest shape:
 }
 ```
 
-## Future API Endpoint
+## Current API Endpoint
 
-Future authenticated endpoint:
+Authenticated endpoint:
 
 ```text
 GET /v1/diagnostics/support_bundle
@@ -250,8 +268,7 @@ Expected behavior:
 
 - Requires the same authentication model as other sensitive diagnostics routes.
 - Streams the archive as a download.
-- Uses `Content-Type: application/zip` for `.zip` output or
-  `application/gzip` for `.tar.gz`.
+- Uses `Content-Type: application/zip` for the current `.zip` output.
 - Sets a filename with `Content-Disposition`.
 - Generates the bundle on demand.
 - Applies redaction before response streaming.
@@ -397,4 +414,3 @@ Manual tests:
 - System with internal `wlan0` plus external USB adapter.
 - Permission-limited non-root collection followed by elevated CLI collection.
 - User review of a generated archive before attaching it to a GitHub issue.
-


### PR DESCRIPTION
## Summary

- Updates the Unreleased changelog with completed Adapter Readiness and support bundle work.
- Updates roadmap and design docs to distinguish implemented v1.1.0 work from remaining release work.
- Documents GET /v1/diagnostics/support_bundle in README and bug-report guidance.
- Clarifies current support bundle scope.
- Fixes small UI copy issues: WiFi → Wi-Fi and Autosusiend → autosuspend.
- Adds a short support bundle UI hint.
- Does not bump version numbers.
- Does not mark v1.1.0 as released.
- Does not change backend behavior.

## Tests

- PYTHONPATH=backend pytest
- 219 passed