### PR TITLE
fix: fall back from broken vendor dnsmasq

### DIFF
--- a/backend/vr_hotspotd/engine/supervisor.py
+++ b/backend/vr_hotspotd/engine/supervisor.py
@@ -213,6 +213,67 @@ def _which_in_path(exe: str, path: str) -> Optional[str]:
     return None
 
 
+def _sanitize_probe_reason(value: object) -> str:
+    text = str(value or "").replace("\r", "\n")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    reason = lines[0] if lines else "unknown"
+    return reason[:240]
+
+
+def _probe_dnsmasq_executable(path: Optional[str], *, vendor_lib: Optional[str] = None) -> Tuple[bool, Optional[str]]:
+    if not path:
+        return False, "dnsmasq_not_found"
+    env = os.environ.copy()
+    env.setdefault("LC_ALL", "C")
+    env.setdefault("LANG", "C")
+    if vendor_lib and os.path.isdir(vendor_lib):
+        ld = env.get("LD_LIBRARY_PATH", "")
+        if vendor_lib not in ld.split(":"):
+            env["LD_LIBRARY_PATH"] = f"{vendor_lib}:{ld}" if ld else vendor_lib
+    try:
+        p = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "dnsmasq_probe_timeout"
+    except OSError as exc:
+        return False, _sanitize_probe_reason(exc)
+    except Exception as exc:
+        return False, _sanitize_probe_reason(exc)
+
+    out = (p.stdout or "") + ("\n" + p.stderr if p.stderr else "")
+    if p.returncode != 0:
+        return False, f"rc={p.returncode}:{_sanitize_probe_reason(out)}"
+    return True, None
+
+
+def _build_selected_binary_path(
+    *,
+    chosen_hostapd: Optional[str],
+    chosen_dnsmasq: Optional[str],
+    sys_path: str,
+    vendor_bin_path: str,
+) -> str:
+    shim = tempfile.mkdtemp(prefix="vrhs-bin-")
+    for name, target in (("hostapd", chosen_hostapd), ("dnsmasq", chosen_dnsmasq)):
+        if not target:
+            continue
+        try:
+            os.symlink(target, os.path.join(shim, name))
+        except FileExistsError:
+            pass
+        except Exception as exc:
+            _note(f"binary_shim_failed name={name} target={target} err={_sanitize_probe_reason(exc)}")
+    pieces = [shim, sys_path]
+    if vendor_bin_path:
+        pieces.append(vendor_bin_path)
+    return ":".join(pieces)
+
+
 def _split_tokens(value: Optional[str]) -> List[str]:
     if not value:
         return []
@@ -227,7 +288,7 @@ def _prefer_vendor_for_platform() -> bool:
     return "cachyos" in tokens
 
 
-def _build_engine_env() -> Dict[str, str]:
+def _build_engine_env(*, require_hostapd: bool = True, require_dnsmasq: bool = True) -> Dict[str, str]:
     """
     Environment for lnxrouter execution.
 
@@ -250,6 +311,7 @@ def _build_engine_env() -> Dict[str, str]:
 
     sys_hostapd = _which_in_path("hostapd", sys_path)
     sys_dnsmasq = _which_in_path("dnsmasq", sys_path)
+    vendor_dnsmasq_reject_reason: Optional[str] = None
 
     force_vendor = env.get("VR_HOTSPOT_FORCE_VENDOR_BIN", "").strip().lower() in (
         "1",
@@ -273,6 +335,16 @@ def _build_engine_env() -> Dict[str, str]:
     vendor_hostapd_ok = bool(vendor_hostapd)
     vendor_dnsmasq_ok = bool(vendor_dnsmasq)
     force_vendor_effective = force_vendor or strict_vendor
+
+    if vendor_dnsmasq_ok:
+        dnsmasq_probe_ok, dnsmasq_probe_reason = _probe_dnsmasq_executable(
+            vendor_dnsmasq,
+            vendor_lib=str(vendor_lib_dir) if vendor_lib_dir else None,
+        )
+        if not dnsmasq_probe_ok:
+            vendor_dnsmasq_ok = False
+            vendor_dnsmasq_reject_reason = dnsmasq_probe_reason or "dnsmasq_probe_failed"
+            _note(f"vendor_dnsmasq_rejected path={vendor_dnsmasq} reason={vendor_dnsmasq_reject_reason}")
 
     prefer_vendor_platform = _prefer_vendor_for_platform()
     prefer_vendor = False
@@ -334,13 +406,14 @@ def _build_engine_env() -> Dict[str, str]:
         chosen_hostapd = sys_hostapd
         chosen_dnsmasq = sys_dnsmasq
     elif force_vendor_effective:
-        if not vendor_hostapd_ok or not vendor_dnsmasq_ok:
+        if not vendor_hostapd_ok or (not vendor_dnsmasq_ok and not sys_dnsmasq):
             selection_result = {
                 "vendor_profile": vendor_profile,
                 "force_vendor": force_vendor_effective,
                 "force_system": force_system,
                 "vendor_hostapd": vendor_hostapd,
                 "vendor_dnsmasq": vendor_dnsmasq,
+                "vendor_dnsmasq_reject_reason": vendor_dnsmasq_reject_reason,
                 "sys_hostapd": sys_hostapd,
                 "sys_dnsmasq": sys_dnsmasq,
                 "chosen_hostapd": None,
@@ -359,7 +432,7 @@ def _build_engine_env() -> Dict[str, str]:
                 }
             )
         chosen_hostapd = vendor_hostapd
-        chosen_dnsmasq = vendor_dnsmasq
+        chosen_dnsmasq = vendor_dnsmasq if vendor_dnsmasq_ok else sys_dnsmasq
         chosen_lib_dir = str(vendor_lib_dir) if vendor_lib_dir else None
     else:
         if prefer_vendor:
@@ -421,6 +494,7 @@ def _build_engine_env() -> Dict[str, str]:
         "force_system": force_system,
         "vendor_hostapd": vendor_hostapd,
         "vendor_dnsmasq": vendor_dnsmasq,
+        "vendor_dnsmasq_reject_reason": vendor_dnsmasq_reject_reason,
         "sys_hostapd": sys_hostapd,
         "sys_dnsmasq": sys_dnsmasq,
         "chosen_hostapd": chosen_hostapd,
@@ -437,6 +511,28 @@ def _build_engine_env() -> Dict[str, str]:
         f"hostapd_select={chosen_hostapd or 'none'} "
         f"dnsmasq_select={chosen_dnsmasq or 'none'} "
         f"LD_LIBRARY_PATH_prefix={vendor_lib_path or 'none'}"
+    )
+
+    required_selected = []
+    if require_hostapd:
+        required_selected.append(("hostapd", chosen_hostapd))
+    if require_dnsmasq:
+        required_selected.append(("dnsmasq", chosen_dnsmasq))
+    missing_selected = [name for name, path in required_selected if not path]
+    if missing_selected:
+        raise VendorSelectionError(
+            {
+                "error": "binary_missing",
+                "missing": missing_selected,
+                "selection": selection_result,
+            }
+        )
+
+    env["PATH"] = _build_selected_binary_path(
+        chosen_hostapd=chosen_hostapd,
+        chosen_dnsmasq=chosen_dnsmasq,
+        sys_path=sys_path,
+        vendor_bin_path=vendor_bin_path,
     )
 
     if chosen_hostapd:

--- a/backend/vr_hotspotd/preflight.py
+++ b/backend/vr_hotspotd/preflight.py
@@ -133,7 +133,7 @@ def _check_regdom(
 
 
 def _resolve_hostapd_path() -> Optional[str]:
-    env = supervisor._build_engine_env()
+    env = supervisor._build_engine_env(require_hostapd=False, require_dnsmasq=False)
     override = env.get("HOSTAPD")
     if override and os.path.isfile(override) and os.access(override, os.X_OK):
         return override

--- a/install.sh
+++ b/install.sh
@@ -286,7 +286,7 @@ calculate_dependency_list() {
         pacman)
             DEPENDENCIES=(python python-pip iw iproute2)
             if [[ "$OS_ID" != "steamos" ]]; then
-                DEPENDENCIES+=("iptables")
+                DEPENDENCIES+=("dnsmasq" "iptables")
             fi
             ;;
         apt)
@@ -322,6 +322,7 @@ install_dependencies() {
             if [[ "$OS_ID" == "steamos" ]]; then
                 : # SteamOS ships iptables-nft by default; don't install iptables packages.
             else
+                deps+=("dnsmasq")
                 if pacman -Qi iptables-nft &>/dev/null || pacman -Si iptables-nft &>/dev/null; then
                     deps+=("iptables-nft")
                 elif pacman -Qi nftables &>/dev/null || command -v nft &>/dev/null; then

--- a/tests/test_installer_rpm_ostree.py
+++ b/tests/test_installer_rpm_ostree.py
@@ -78,3 +78,20 @@ def test_rpm_ostree_install_wrapper_reports_reboot_guidance(tmp_path):
         "Reboot your system, then rerun the VR Hotspot installer."
     ) in result.stdout
     assert "Package/capability iw is already requested" in result.stderr
+
+
+def test_cachyos_dependency_plan_installs_dnsmasq_fallback():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        PKG_MANAGER=pacman
+        OS_ID=cachyos
+        calculate_dependency_list
+        printf '%s\n' "${{DEPENDENCIES[*]}}"
+        """
+    )
+
+    assert result.returncode == 0
+    deps = result.stdout.strip().split()
+    assert "dnsmasq" in deps
+    assert "hostapd" not in deps

--- a/tests/test_supervisor_env.py
+++ b/tests/test_supervisor_env.py
@@ -1,5 +1,8 @@
 import os
 import sys
+from types import SimpleNamespace
+
+import pytest
 
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
@@ -32,3 +35,122 @@ def test_build_engine_env_sets_unbuffered_python(monkeypatch):
 
     assert env.get("PYTHONUNBUFFERED") == "1"
     assert env.get("PYTHONIOENCODING") == "utf-8"
+
+
+def _make_exe(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+    return str(path)
+
+
+def _common_selection_patches(monkeypatch, supervisor, tmp_path, *, vendor_dnsmasq, sys_dnsmasq):
+    vendor_hostapd = _make_exe(tmp_path / "vendor" / "hostapd")
+    sys_hostapd = _make_exe(tmp_path / "system" / "hostapd")
+    vendor_dnsmasq_path = None
+    sys_dnsmasq_path = None
+    if vendor_dnsmasq:
+        vendor_dnsmasq_path = _make_exe(tmp_path / "vendor" / "dnsmasq")
+    if sys_dnsmasq:
+        sys_dnsmasq_path = _make_exe(tmp_path / "system" / "dnsmasq")
+
+    monkeypatch.setattr(supervisor, "vendor_bin_dirs", lambda: [tmp_path / "vendor"])
+    monkeypatch.setattr(
+        supervisor,
+        "resolve_vendor_required",
+        lambda _names: (
+            {"hostapd": vendor_hostapd, "dnsmasq": vendor_dnsmasq_path},
+            tmp_path / "vendor-lib",
+            None,
+            [] if vendor_dnsmasq_path else ["dnsmasq"],
+        ),
+    )
+    monkeypatch.setattr(supervisor, "vendor_lib_dirs", lambda preferred_profile=None: [tmp_path / "vendor-lib"])
+    monkeypatch.setattr(
+        supervisor,
+        "_which_in_path",
+        lambda exe, _path: {"hostapd": sys_hostapd, "dnsmasq": sys_dnsmasq_path}.get(exe),
+    )
+    monkeypatch.setattr(supervisor, "_hostapd_supports_ht_vht", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(supervisor.os_release, "read_os_release", lambda: {"id": "cachyos"})
+    monkeypatch.delenv("VR_HOTSPOT_FORCE_VENDOR_BIN", raising=False)
+    monkeypatch.delenv("VR_HOTSPOT_VENDOR_STRICT", raising=False)
+    monkeypatch.delenv("VR_HOTSPOT_FORCE_SYSTEM_BIN", raising=False)
+    supervisor._stderr_tail.clear()
+    return vendor_hostapd, vendor_dnsmasq_path, sys_hostapd, sys_dnsmasq_path
+
+
+def test_build_engine_env_selects_usable_vendor_dnsmasq(monkeypatch, tmp_path):
+    import vr_hotspotd.engine.supervisor as supervisor
+
+    _vendor_hostapd, vendor_dnsmasq, _sys_hostapd, _sys_dnsmasq = _common_selection_patches(
+        monkeypatch,
+        supervisor,
+        tmp_path,
+        vendor_dnsmasq=True,
+        sys_dnsmasq=True,
+    )
+    monkeypatch.setattr(supervisor, "_probe_dnsmasq_executable", lambda *_args, **_kwargs: (True, None))
+
+    env = supervisor._build_engine_env()
+
+    assert env["DNSMASQ"] == vendor_dnsmasq
+    shim_dnsmasq = os.path.join(env["PATH"].split(":")[0], "dnsmasq")
+    assert os.path.realpath(shim_dnsmasq) == vendor_dnsmasq
+
+
+def test_build_engine_env_rejects_vendor_dnsmasq_missing_shared_libs(monkeypatch, tmp_path):
+    import vr_hotspotd.engine.supervisor as supervisor
+
+    _vendor_hostapd, vendor_dnsmasq, _sys_hostapd, sys_dnsmasq = _common_selection_patches(
+        monkeypatch,
+        supervisor,
+        tmp_path,
+        vendor_dnsmasq=True,
+        sys_dnsmasq=True,
+    )
+
+    def fake_run(cmd, **_kwargs):
+        if cmd == [vendor_dnsmasq, "--version"]:
+            return SimpleNamespace(
+                returncode=127,
+                stdout="",
+                stderr=(
+                    f"{vendor_dnsmasq}: error while loading shared libraries: "
+                    "libhogweed.so.6: cannot open shared object file: No such file or directory\n"
+                    "libnettle.so.8 => not found\n"
+                ),
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(supervisor.subprocess, "run", fake_run)
+
+    env = supervisor._build_engine_env()
+
+    assert env["DNSMASQ"] == sys_dnsmasq
+    shim_dnsmasq = os.path.join(env["PATH"].split(":")[0], "dnsmasq")
+    assert os.path.realpath(shim_dnsmasq) == sys_dnsmasq
+    notes = "\n".join(supervisor._stderr_tail)
+    assert "vendor_dnsmasq_rejected" in notes
+    assert "libhogweed.so.6" in notes
+    assert f"dnsmasq_select={sys_dnsmasq}" in notes
+
+
+def test_build_engine_env_errors_when_dnsmasq_missing_everywhere(monkeypatch, tmp_path):
+    import vr_hotspotd.engine.supervisor as supervisor
+
+    _common_selection_patches(
+        monkeypatch,
+        supervisor,
+        tmp_path,
+        vendor_dnsmasq=False,
+        sys_dnsmasq=False,
+    )
+
+    with pytest.raises(supervisor.VendorSelectionError) as exc:
+        supervisor._build_engine_env()
+
+    payload = exc.value.to_payload()
+    assert payload["error"] == "binary_missing"
+    assert "dnsmasq" in payload["missing"]
+    assert payload["selection"]["chosen_dnsmasq"] is None


### PR DESCRIPTION
## Summary

- Probes vendor dnsmasq before selection.
- Rejects vendor dnsmasq when it cannot execute, including missing shared libraries such as libhogweed.so.6 or libnettle.so.8.
- Falls back to system dnsmasq when available.
- Adds a per-start PATH shim so lnxrouter resolves the selected hostapd and dnsmasq.
- Preserves vendor hostapd behavior.
- Keeps hostapd-only preflight from failing when dnsmasq is unavailable.
- Installs dnsmasq as the Arch/CachyOS fallback dependency without adding system hostapd.
- Adds tests for usable vendor dnsmasq, broken vendor dnsmasq fallback, missing dnsmasq failure, and CachyOS dependency planning.

## Tests

- PYTHONPATH=backend pytest
- 223 passed