### PR TITLE
fix: make installer interactivity explicit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,79 @@ print_warning() { echo -e "${YELLOW}⚠ $1${NC}"; }
 print_error() { echo -e "${RED}✗ $1${NC}"; }
 print_info() { echo -e "${CYAN}ℹ $1${NC}"; }
 
+usage() {
+    cat <<'USAGE'
+VR Hotspot Installer
+
+Usage:
+  sudo ./install.sh [options]
+  curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh | sudo bash
+
+Options:
+  --interactive       Prompt for installer choices when a real TTY is available
+  --non-interactive   Disable prompts and use safe defaults
+  --yes, -y           Alias for --non-interactive
+  --check-os          Detect OS and print dependency plan only
+  --no-clear          Do not clear the terminal before output
+  -h, --help          Show this help
+USAGE
+}
+
+is_truthy() {
+    case "$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on|y) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_ci_environment() {
+    is_truthy "${CI:-}" || \
+        is_truthy "${GITHUB_ACTIONS:-}" || \
+        is_truthy "${GITLAB_CI:-}" || \
+        is_truthy "${BUILDKITE:-}" || \
+        is_truthy "${TF_BUILD:-}"
+}
+
+prompt_tty_available() {
+    [ -t 0 ] && [ -t 1 ] && [ -r /dev/tty ]
+}
+
+resolve_interactive_mode() {
+    local requested_mode="${1:-auto}"
+
+    INTERACTIVE=0
+    NON_INTERACTIVE_REASON=""
+
+    if is_ci_environment; then
+        NON_INTERACTIVE_REASON="CI environment detected"
+        return 0
+    fi
+
+    case "$requested_mode" in
+        interactive)
+            if prompt_tty_available; then
+                INTERACTIVE=1
+            else
+                NON_INTERACTIVE_REASON="--interactive requested, but no usable terminal was detected"
+            fi
+            ;;
+        non-interactive)
+            NON_INTERACTIVE_REASON="requested by command-line flag"
+            ;;
+        auto)
+            if prompt_tty_available; then
+                INTERACTIVE=1
+            else
+                NON_INTERACTIVE_REASON="no usable terminal detected"
+            fi
+            ;;
+        *)
+            print_error "Internal error: unknown interactive mode '$requested_mode'."
+            exit 1
+            ;;
+    esac
+}
+
 interactive_read() {
     if [ -c /dev/tty ]; then
         read -r "$@" < /dev/tty
@@ -620,25 +693,41 @@ show_completion() {
 main() {
     CHECK_ONLY=0
     SKIP_CLEAR=0
+    REQUESTED_INTERACTIVE_MODE="auto"
+
     for arg in "$@"; do
         case "$arg" in
+            --interactive)
+                REQUESTED_INTERACTIVE_MODE="interactive"
+                ;;
+            --non-interactive|--yes|-y)
+                REQUESTED_INTERACTIVE_MODE="non-interactive"
+                ;;
             --check-os)
                 CHECK_ONLY=1
                 ;;
             --no-clear)
                 SKIP_CLEAR=1
                 ;;
+            -h|--help)
+                usage
+                return 0
+                ;;
             *)
                 ;;
         esac
     done
 
-    [ -t 1 ] && INTERACTIVE=1 || INTERACTIVE=0
+    resolve_interactive_mode "$REQUESTED_INTERACTIVE_MODE"
     
-    if [ "$SKIP_CLEAR" -eq 0 ]; then
+    if [ "$SKIP_CLEAR" -eq 0 ] && [ -t 1 ]; then
         clear
     fi
     print_header
+
+    if [ "$INTERACTIVE" -eq 0 ] && [ -n "$NON_INTERACTIVE_REASON" ]; then
+        print_info "Non-interactive mode selected ($NON_INTERACTIVE_REASON); prompts are disabled and defaults will be used."
+    fi
 
     if [ "$CHECK_ONLY" -eq 1 ]; then
         detect_os

--- a/tests/test_installer_rpm_ostree.py
+++ b/tests/test_installer_rpm_ostree.py
@@ -95,3 +95,69 @@ def test_cachyos_dependency_plan_installs_dnsmasq_fallback():
     deps = result.stdout.strip().split()
     assert "dnsmasq" in deps
     assert "hostapd" not in deps
+
+
+def test_installer_auto_mode_is_non_interactive_without_tty():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        unset CI GITHUB_ACTIONS GITLAB_CI BUILDKITE TF_BUILD
+        resolve_interactive_mode auto
+        echo "interactive=$INTERACTIVE"
+        echo "reason=$NON_INTERACTIVE_REASON"
+        """
+    )
+
+    assert result.returncode == 0
+    assert "interactive=0" in result.stdout
+    assert "reason=no usable terminal detected" in result.stdout
+
+
+def test_installer_non_interactive_flags_disable_prompts():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        unset CI GITHUB_ACTIONS GITLAB_CI BUILDKITE TF_BUILD
+        resolve_interactive_mode non-interactive
+        echo "interactive=$INTERACTIVE"
+        echo "reason=$NON_INTERACTIVE_REASON"
+        """
+    )
+
+    assert result.returncode == 0
+    assert "interactive=0" in result.stdout
+    assert "reason=requested by command-line flag" in result.stdout
+
+
+def test_installer_ci_overrides_requested_interactive_mode():
+    env = os.environ.copy()
+    env["CI"] = "true"
+
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        resolve_interactive_mode interactive
+        echo "interactive=$INTERACTIVE"
+        echo "reason=$NON_INTERACTIVE_REASON"
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "interactive=0" in result.stdout
+    assert "reason=CI environment detected" in result.stdout
+
+
+def test_installer_help_documents_interactivity_flags():
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "--interactive" in result.stdout
+    assert "--non-interactive" in result.stdout
+    assert "--yes" in result.stdout


### PR DESCRIPTION
## Summary

- Makes installer interactive mode detection explicit.
- Uses prompts only when stdin and stdout are TTYs and /dev/tty is readable.
- Keeps CI and piped installs non-interactive.
- Adds --interactive, --non-interactive, --yes, and -y flags.
- Logs why non-interactive mode was selected.
- Adds help text for installer mode flags.
- Adds installer tests.
- Does not change runtime hotspot behavior.
- Does not change version metadata.

## Tests

- bash -n install.sh
- bash -n backend/scripts/install.sh
- PYTHONPATH=backend pytest
- 227 passed