### PR TITLE
Integrate pr28 endeavouros

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install
 ```
 
 **Features:**
-- ✅ Auto-detects your OS (SteamOS, Bazzite, CachyOS, Arch, Ubuntu, Fedora)
+- ✅ Auto-detects your OS (SteamOS, Bazzite, CachyOS, Arch, EndeavourOS, Ubuntu, Fedora)
 - ✅ Installs all dependencies automatically (iw, python, libnl, etc.)
 - ✅ Configures NetworkManager to prevent interference
 - ✅ Starts service and shows you the web UI URL and API token

--- a/backend/scripts/install.sh
+++ b/backend/scripts/install.sh
@@ -205,7 +205,7 @@ enable_firewalld_uplink_forwarding() {
     log "Warning: failed to enable forward for zone $zone (permanent)"
 }
 
-if [[ "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID_LIKE" == *"fedora"* ]]; then
+if [[ "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID" == "endeavouros" || "$OS_ID_LIKE" == *"fedora"* ]]; then
   enable_firewalld_uplink_forwarding
 fi
 

--- a/docs/PLATFORM_COMPATIBILITY.md
+++ b/docs/PLATFORM_COMPATIBILITY.md
@@ -1,12 +1,12 @@
 # Platform Compatibility Guide
 
-This project targets multiple Linux distros (Bazzite, CachyOS, SteamOS, Arch, Fedora, Ubuntu). The goal is to avoid fixes for one OS breaking another.
+This project targets multiple Linux distros (Bazzite, CachyOS, SteamOS, Arch, EndeavourOS, Fedora, Ubuntu). The goal is to avoid fixes for one OS breaking another.
 
 ## Checklist for OS-Specific Changes
 
 - [ ] Does the change modify `install.sh` or distro detection logic?
 - [ ] Are package names/differences accounted for across apt/dnf/pacman/rpm-ostree?
-- [ ] For SteamOS/CachyOS/Arch: do we keep the pacman-specific logic intact?
+- [ ] For SteamOS/CachyOS/Arch/EndeavourOS: do we keep the pacman-specific logic intact while treating immutable SteamOS separately?
 - [ ] For Bazzite (rpm-ostree): do we avoid breaking vendor-bundle or live-layering logic?
 - [ ] If a fix is OS-specific, is it guarded by an OS check or feature flag?
 - [ ] For CachyOS: verify vendor hostapd/dnsmasq preference to avoid system package regressions.

--- a/install.sh
+++ b/install.sh
@@ -341,7 +341,7 @@ detect_os() {
         exit 1
     fi
     case "$OS_ID" in
-        steamos|cachyos|arch) PKG_MANAGER="pacman" ;;
+        steamos|cachyos|arch|endeavouros) PKG_MANAGER="pacman" ;;
         ubuntu|debian|pop) PKG_MANAGER="apt" ;;
         fedora) PKG_MANAGER="dnf" ;;
         bazzite) PKG_MANAGER="rpm-ostree" ;;
@@ -634,6 +634,29 @@ install_daemon() {
     print_success "Daemon installation complete."
 }
 
+validate_endeavouros_runtime_dependencies() {
+    if [[ "$OS_ID" != "endeavouros" ]]; then
+        return 0
+    fi
+
+    local vendor_bin_dir="$TEMP_INSTALL_DIR/backend/vendor/bin"
+    local -a missing=()
+
+    if ! command -v hostapd >/dev/null 2>&1 && [ ! -x "$vendor_bin_dir/hostapd" ]; then
+        missing+=("hostapd (system or bundled)")
+    fi
+    if ! command -v dnsmasq >/dev/null 2>&1; then
+        missing+=("dnsmasq")
+    fi
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        print_error "EndeavourOS is missing required runtime dependencies: ${missing[*]}"
+        return 1
+    fi
+
+    print_success "EndeavourOS runtime dependencies found (hostapd and dnsmasq)."
+}
+
 enable_firewalld_uplink_forwarding() {
     if ! command -v firewall-cmd >/dev/null 2>&1; then
         print_info "firewalld not installed; skipping uplink forwarding setup"
@@ -767,9 +790,10 @@ main() {
     detect_os
     install_dependencies
     get_source_files
+    validate_endeavouros_runtime_dependencies
     configure_install
     install_daemon
-    if [[ "$OS_ID" == "steamos" || "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID_LIKE" == *"fedora"* ]]; then
+    if [[ "$OS_ID" == "steamos" || "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID" == "endeavouros" || "$OS_ID_LIKE" == *"fedora"* ]]; then
         enable_firewalld_uplink_forwarding
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -606,7 +606,7 @@ main() {
     get_source_files
     configure_install
     install_daemon
-    if [[ "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID_LIKE" == *"fedora"* ]]; then
+    if [[ "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID" == "endeavouros" || "$OS_ID_LIKE" == *"fedora"* ]]; then
         enable_firewalld_uplink_forwarding
     fi
     

--- a/install.sh
+++ b/install.sh
@@ -228,7 +228,7 @@ detect_os() {
         exit 1
     fi
     case "$OS_ID" in
-        steamos|cachyos|arch) PKG_MANAGER="pacman" ;;
+        steamos|cachyos|arch|endeavouros) PKG_MANAGER="pacman" ;;
         ubuntu|debian|pop) PKG_MANAGER="apt" ;;
         fedora) PKG_MANAGER="dnf" ;;
         bazzite) PKG_MANAGER="rpm-ostree" ;;

--- a/tests/test_installer_endeavouros.py
+++ b/tests/test_installer_endeavouros.py
@@ -1,0 +1,237 @@
+import os
+from pathlib import Path
+import stat
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+
+
+def make_executable(path: Path, contents: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def run_bash(
+    script: str,
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def detect_endeavouros() -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "VR_HOTSPOT_OS_ID": "endeavouros",
+            "VR_HOTSPOT_OS_NAME": "EndeavourOS",
+            "VR_HOTSPOT_OS_ID_LIKE": "arch",
+        }
+    )
+    return run_bash(
+        f"""
+        source {INSTALLER}
+        detect_os
+        printf 'os_id=%s\n' "$OS_ID"
+        printf 'package_manager=%s\n' "$PKG_MANAGER"
+        """,
+        env=env,
+    )
+
+
+def test_endeavouros_os_detection_is_supported():
+    result = detect_endeavouros()
+
+    assert result.returncode == 0
+    assert "os_id=endeavouros" in result.stdout
+    assert "Detected EndeavourOS" in result.stdout
+
+
+def test_endeavouros_selects_pacman():
+    result = detect_endeavouros()
+
+    assert result.returncode == 0
+    assert "package_manager=pacman" in result.stdout
+
+
+def test_endeavouros_dependency_plan_keeps_vendor_hostapd_and_system_dnsmasq():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=endeavouros
+        PKG_MANAGER=pacman
+        calculate_dependency_list
+        printf '%s\n' "${{DEPENDENCIES[*]}}"
+        """
+    )
+
+    assert result.returncode == 0
+    dependencies = result.stdout.strip().split()
+    assert {"python", "python-pip", "iw", "iproute2", "dnsmasq", "iptables"} <= set(
+        dependencies
+    )
+    assert "hostapd" not in dependencies
+
+
+def test_endeavouros_runtime_validation_accepts_bundled_hostapd_and_system_dnsmasq(
+    tmp_path,
+):
+    vendor_bin = tmp_path / "source" / "backend" / "vendor" / "bin"
+    vendor_bin.mkdir(parents=True)
+    make_executable(vendor_bin / "hostapd")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    make_executable(fake_bin / "dnsmasq")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=endeavouros
+        TEMP_INSTALL_DIR={tmp_path / "source"}
+        validate_endeavouros_runtime_dependencies
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "runtime dependencies found (hostapd and dnsmasq)" in result.stdout
+
+
+def test_endeavouros_pacman_install_includes_system_dnsmasq_fallback(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    pacman_log = tmp_path / "pacman.log"
+    make_executable(
+        fake_bin / "pacman",
+        (
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$*\" >> \"$PACMAN_LOG\"\n"
+            "[ \"$1\" = '-Sy' ]\n"
+        ),
+    )
+    make_executable(fake_bin / "pacman-key")
+    make_executable(fake_bin / "install")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["PACMAN_LOG"] = str(pacman_log)
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=endeavouros
+        PKG_MANAGER=pacman
+        install_dependencies
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    install_args = next(
+        line.split()
+        for line in pacman_log.read_text(encoding="utf-8").splitlines()
+        if line.startswith("-Sy ")
+    )
+    assert "dnsmasq" in install_args
+
+
+def test_steamos_dependency_plan_remains_separate_from_mutable_pacman_distros():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=steamos
+        PKG_MANAGER=pacman
+        calculate_dependency_list
+        printf '%s\n' "${{DEPENDENCIES[*]}}"
+        """
+    )
+
+    assert result.returncode == 0
+    dependencies = result.stdout.strip().split()
+    assert "hostapd" not in dependencies
+    assert "dnsmasq" not in dependencies
+    assert "iptables" not in dependencies
+
+
+def test_endeavouros_full_install_flow_uses_firewalld_forwarding_path():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        check_root() {{ :; }}
+        cleanup_previous_install() {{ :; }}
+        detect_os() {{
+            OS_ID=endeavouros
+            OS_NAME=EndeavourOS
+            OS_ID_LIKE=arch
+            PKG_MANAGER=pacman
+        }}
+        install_dependencies() {{ :; }}
+        get_source_files() {{ TEMP_INSTALL_DIR="$PWD"; }}
+        validate_endeavouros_runtime_dependencies() {{ :; }}
+        configure_install() {{ :; }}
+        install_daemon() {{ :; }}
+        enable_firewalld_uplink_forwarding() {{ echo firewalld-forwarding-called; }}
+        show_completion() {{ :; }}
+        main --non-interactive --no-clear
+        """
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.count("firewalld-forwarding-called") == 1
+
+
+def test_firewalld_forwarding_enables_runtime_and_permanent_rules(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    firewalld_log = tmp_path / "firewalld.log"
+    make_executable(
+        fake_bin / "firewall-cmd",
+        (
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$*\" >> \"$FIREWALLD_LOG\"\n"
+            "case \"$1\" in\n"
+            "  --state) exit 0 ;;\n"
+            "  --get-zone-of-interface=*) echo public ;;\n"
+            "esac\n"
+            "exit 0\n"
+        ),
+    )
+    make_executable(
+        fake_bin / "ip",
+        (
+            "#!/bin/sh\n"
+            "if [ \"$1 $2 $3\" = 'route show default' ]; then\n"
+            "  echo 'default via 192.0.2.1 dev enp1s0'\n"
+            "fi\n"
+        ),
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FIREWALLD_LOG"] = str(firewalld_log)
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        enable_firewalld_uplink_forwarding
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    calls = firewalld_log.read_text(encoding="utf-8").splitlines()
+    assert "--zone public --add-masquerade" in calls
+    assert "--zone public --add-forward" in calls
+    assert "--permanent --zone public --add-masquerade" in calls
+    assert "--permanent --zone public --add-forward" in calls

--- a/tools/ci/install_matrix_check.sh
+++ b/tools/ci/install_matrix_check.sh
@@ -6,6 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 declare -A OS_NAMES=(
   ["arch"]="Arch Linux"
   ["cachyos"]="CachyOS"
+  ["endeavouros"]="EndeavourOS"
   ["steamos"]="SteamOS"
   ["ubuntu"]="Ubuntu"
   ["fedora"]="Fedora"


### PR DESCRIPTION
appreciate you AuTune !

- Adds EndeavourOS as a pacman-based supported distribution.
- Keeps SteamOS immutable/vendor-stack behavior separate.
- Ensures hostapd/dnsmasq dependency validation remains correct.
- Enables the appropriate firewalld forwarding/masquerade path for EndeavourOS.
- Adds installer/platform regression coverage.
- Updates platform compatibility docs.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `262 passed, 4 subtests passed`