### PR TITLE
refactor: consolidate read-only host probes

### DIFF
--- a/backend/vr_hotspotd/adapters/inventory.py
+++ b/backend/vr_hotspotd/adapters/inventory.py
@@ -5,6 +5,8 @@ import re
 from functools import lru_cache
 from typing import Dict, List, Optional, Tuple
 
+from vr_hotspotd import host_probes
+
 
 def _iw_bin() -> str:
     iw = shutil.which("iw")
@@ -17,7 +19,21 @@ def _iw_bin() -> str:
 
 
 def _run(cmd: List[str]) -> str:
-    return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+    result = host_probes.run_command(
+        cmd,
+        timeout_s=None,
+        merge_stderr=True,
+    )
+    out = result.stdout or ""
+    if result.exception is not None:
+        raise result.exception
+    if result.exit_status != 0:
+        raise subprocess.CalledProcessError(
+            result.exit_status,
+            cmd,
+            output=out,
+        )
+    return out
 
 
 def _run_iw(args: List[str]) -> str:
@@ -28,20 +44,7 @@ def _parse_iw_dev() -> List[Dict]:
     """
     Parse `iw dev` into a list of interfaces with their phy (phy0, phy1, ...).
     """
-    out = _run_iw(["dev"])
-    items: List[Dict] = []
-    current_phy: Optional[str] = None
-
-    for line in out.splitlines():
-        s = line.strip()
-        if s.startswith("phy#"):
-            n = s.split("#", 1)[1].strip()
-            current_phy = f"phy{n}"
-        elif s.startswith("Interface") and current_phy:
-            ifname = s.split()[1].strip()
-            items.append({"ifname": ifname, "phy": current_phy})
-
-    return items
+    return host_probes.parse_iw_dev_interfaces(_run_iw(["dev"]))
 
 
 def _phy_supports_ap(phy: str) -> bool:
@@ -65,12 +68,12 @@ def _phy_supports_ap(phy: str) -> bool:
                 if mode == "AP" or mode.startswith("AP/") or mode.startswith("AP-"):
                     return True
             elif s and not s.startswith("*"):
-                # Heuristic exit: we've likely left the modes section
+                # Preserve inventory's legacy behavior: leave this block but
+                # continue scanning in case a later modes block is present.
                 in_modes = False
     return False
 
 
-_HE_IFTYPES_RE = re.compile(r"^\s*HE Iftypes:\s*(.+)$", re.IGNORECASE)
 _VIRT_IFACE_RE = re.compile(r"^x\d+.+$")
 
 
@@ -80,28 +83,11 @@ def _he_iftypes_has_ap(iw_text: str) -> Optional[bool]:
     Return False if HE Iftypes exists but does not include AP.
     Return None if HE Iftypes is not present in the output.
     """
-    seen = False
-    for raw in iw_text.splitlines():
-        m = _HE_IFTYPES_RE.search(raw)
-        if not m:
-            continue
-        seen = True
-        for token in m.group(1).split(","):
-            t = token.strip().upper()
-            if t in ("AP", "AP/VLAN", "AP-VLAN"):
-                return True
-    return False if seen else None
+    return host_probes.he_iftypes_has_ap(iw_text)
 
 
 def _supports_wifi6_from_iw(iw_text: str) -> bool:
-    he_ap = _he_iftypes_has_ap(iw_text)
-    if he_ap is True:
-        return True
-    if he_ap is False:
-        return False
-
-    s = iw_text.lower()
-    return ("802.11ax" in s) or ("he capabilities" in s)
+    return host_probes.supports_wifi6(iw_text)
 
 
 @lru_cache(maxsize=64)
@@ -127,28 +113,7 @@ def _phy_supports_80mhz(phy: str) -> bool:
     except Exception:
         return False
     
-    # 1. Check HE (Wi-Fi 6) - HE80
-    if re.search(r"HE40/HE80/5GHz", out, re.IGNORECASE):
-        return True
-    
-    # 2. Check VHT (Wi-Fi 5)
-    vht_section = re.search(r"VHT Capabilities \(.*?\):(.*?)(?:\n\s*[A-Za-z]|\Z)", out, re.DOTALL | re.IGNORECASE)
-    if vht_section:
-        content = vht_section.group(1)
-        width_line = re.search(r"Supported Channel Width:(.*)", content, re.IGNORECASE)
-        if width_line:
-            val = width_line.group(1).strip().lower()
-            if "160" in val or "neither 160 nor 80+80" in val:
-                return True
-            if "20/40" in val:
-                return False
-        # Default VHT usually implies 80MHz support if not explicitly restricted
-        return True
-        
-    return False
-
-
-_FREQ_LINE_RE = re.compile(r"^\s*\*\s+(\d+(?:\.\d+)?)\s+MHz\s+\[(\d+)\].*$")
+    return host_probes.supports_80mhz(out)
 
 
 def _phy_band_support(phy: str) -> Dict[str, bool]:
@@ -163,50 +128,15 @@ def _phy_band_support(phy: str) -> Dict[str, bool]:
     5 GHz:   4900-5900 MHz
     6 GHz:   5925-7125 MHz (covers 6E ranges; some outputs show 5955+)
     """
-    supports = {"supports_2ghz": False, "supports_5ghz": False, "supports_6ghz": False}
-
     try:
         out = _run_iw(["phy", phy, "info"])
     except Exception:
-        return supports
-
-    in_freqs = False
-    for raw in out.splitlines():
-        s = raw.strip()
-
-        if s.startswith("Frequencies:"):
-            in_freqs = True
-            continue
-
-        # Exiting frequencies list (next section header)
-        if in_freqs and s and not s.startswith("*"):
-            in_freqs = False
-
-        if not in_freqs:
-            continue
-
-        m = _FREQ_LINE_RE.match(s)
-        if not m:
-            continue
-
-        try:
-            mhz = int(float(m.group(1)))
-        except Exception:
-            continue
-        line_lower = s.lower()
-        disabled = ("disabled" in line_lower) or ("no ir" in line_lower) or ("no-ir" in line_lower)
-
-        if disabled:
-            continue
-
-        if 2400 <= mhz <= 2500:
-            supports["supports_2ghz"] = True
-        elif 4900 <= mhz <= 5900:
-            supports["supports_5ghz"] = True
-        elif 5925 <= mhz <= 7125:
-            supports["supports_6ghz"] = True
-
-    return supports
+        return {
+            "supports_2ghz": False,
+            "supports_5ghz": False,
+            "supports_6ghz": False,
+        }
+    return host_probes.parse_band_support(out)
 
 
 def _parse_iw_reg_get() -> Dict:
@@ -223,50 +153,7 @@ def _parse_iw_reg_get() -> Dict:
         }
       }
     """
-    out = _run_iw(["reg", "get"])
-
-    global_country: Optional[str] = None
-    global_header: Optional[str] = None
-    phys: Dict[str, Dict] = {}
-
-    current_section = "global"
-    current_phy: Optional[str] = None
-    current_phy_source: str = "unknown"
-
-    for line in out.splitlines():
-        s = line.strip()
-
-        # start of a phy section: "phy#0 (self-managed)"
-        if s.startswith("phy#"):
-            current_section = "phy"
-            # phy#0 -> phy0
-            phy_num = s.split()[0].split("#", 1)[1]
-            current_phy = f"phy{phy_num}"
-            current_phy_source = "self-managed" if "self-managed" in s else "kernel-managed"
-            if current_phy not in phys:
-                phys[current_phy] = {"country": None, "source": current_phy_source, "raw_header": None}
-            else:
-                phys[current_phy]["source"] = current_phy_source
-            continue
-
-        # country line applies to whichever section we're in
-        if s.startswith("country "):
-            parts = s.split()
-            cc = parts[1].rstrip(":") if len(parts) >= 2 else None
-
-            if current_section == "global":
-                global_country = cc
-                global_header = s
-            elif current_section == "phy" and current_phy:
-                phys.setdefault(current_phy, {})
-                phys[current_phy]["country"] = cc
-                phys[current_phy]["raw_header"] = s
-                phys[current_phy].setdefault("source", current_phy_source)
-
-    return {
-        "global": {"country": global_country or "unknown", "raw_header": global_header},
-        "phys": phys
-    }
+    return host_probes.parse_regulatory_domains(_run_iw(["reg", "get"]))
 
 
 def _score_adapter(

--- a/backend/vr_hotspotd/diagnostics/platform.py
+++ b/backend/vr_hotspotd/diagnostics/platform.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from vr_hotspotd import host_probes
 
 try:
     from vr_hotspotd import os_release as os_release_mod
@@ -21,11 +22,10 @@ except Exception:
 
 def _run_cmd(cmd: List[str], timeout_s: float = 0.5) -> tuple[int, str]:
     """Run a command with timeout, returning (exit_code, stdout). Never raises."""
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
-        return proc.returncode, (proc.stdout or "").strip()
-    except Exception:
+    result = host_probes.run_command(cmd, timeout_s=timeout_s)
+    if result.timed_out or result.error:
         return 127, ""
+    return result.exit_status, result.stdout.strip()
 
 
 def _strip_quotes(value: str) -> str:
@@ -36,6 +36,8 @@ def _strip_quotes(value: str) -> str:
 
 
 def _parse_os_release_text(text: str) -> Dict[str, str]:
+    if os_release_mod and hasattr(os_release_mod, "parse_os_release"):
+        return os_release_mod.parse_os_release(text)
     data: Dict[str, str] = {}
     for raw in text.splitlines():
         line = raw.strip()
@@ -65,18 +67,7 @@ def _read_os_release() -> Dict[str, str]:
 
 
 def _split_like(value: Optional[Any]) -> List[str]:
-    if not value:
-        return []
-    if isinstance(value, list):
-        tokens: List[str] = []
-        for item in value:
-            if item is None:
-                continue
-            tokens.extend(str(item).replace(",", " ").split())
-        return [item.strip().lower() for item in tokens if item.strip()]
-    if not isinstance(value, str):
-        value = str(value)
-    return [item.strip().lower() for item in value.replace(",", " ").split() if item.strip()]
+    return host_probes.split_tokens(value)
 
 
 def _probe_os() -> Dict[str, Any]:

--- a/backend/vr_hotspotd/engine/hostapd6_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd6_engine.py
@@ -10,6 +10,8 @@ import tempfile
 import time
 from typing import Optional, List, Tuple
 
+from vr_hotspotd import host_probes
+
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 
 
@@ -48,15 +50,7 @@ def _is_firewalld_active() -> bool:
 
 def _default_uplink_iface() -> Optional[str]:
     # ip route show default -> "default via X.X.X.X dev eth0 proto ..."
-    ip = shutil.which("ip") or "/usr/sbin/ip"
-    p = subprocess.run([ip, "route", "show", "default"], capture_output=True, text=True)
-    for raw in (p.stdout or "").splitlines():
-        parts = raw.strip().split()
-        if "dev" in parts:
-            idx = parts.index("dev")
-            if idx + 1 < len(parts):
-                return parts[idx + 1]
-    return None
+    return host_probes.probe_default_uplink(raise_on_execution_error=True)
 
 
 def _maybe_set_regdom(country: Optional[str]) -> None:

--- a/backend/vr_hotspotd/engine/hostapd_bridge_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd_bridge_engine.py
@@ -9,6 +9,8 @@ import tempfile
 import time
 from typing import List, Optional, Tuple
 
+from vr_hotspotd import host_probes
+
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 
 
@@ -70,15 +72,7 @@ def _ensure_ctrl_interface_dir(conf_path: str) -> None:
 
 
 def _default_uplink_iface() -> Optional[str]:
-    ip = shutil.which("ip") or "/usr/sbin/ip"
-    p = subprocess.run([ip, "route", "show", "default"], capture_output=True, text=True)
-    for raw in (p.stdout or "").splitlines():
-        parts = raw.strip().split()
-        if "dev" in parts:
-            idx = parts.index("dev")
-            if idx + 1 < len(parts):
-                return parts[idx + 1]
-    return None
+    return host_probes.probe_default_uplink(raise_on_execution_error=True)
 
 
 def _maybe_set_regdom(country: Optional[str]) -> None:

--- a/backend/vr_hotspotd/engine/hostapd_nat_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd_nat_engine.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import Optional, List, Tuple
 
-from vr_hotspotd import os_release
+from vr_hotspotd import host_probes, os_release
 
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 _CMD_TIMEOUT_S = 4.0
@@ -87,15 +87,7 @@ def _is_firewalld_active() -> bool:
 
 
 def _default_uplink_iface() -> Optional[str]:
-    ip = shutil.which("ip") or "/usr/sbin/ip"
-    p = subprocess.run([ip, "route", "show", "default"], capture_output=True, text=True)
-    for raw in (p.stdout or "").splitlines():
-        parts = raw.strip().split()
-        if "dev" in parts:
-            idx = parts.index("dev")
-            if idx + 1 < len(parts):
-                return parts[idx + 1]
-    return None
+    return host_probes.probe_default_uplink(raise_on_execution_error=True)
 
 
 def _resolve_lnxrouter_tmp_root() -> Path:

--- a/backend/vr_hotspotd/host_probes.py
+++ b/backend/vr_hotspotd/host_probes.py
@@ -1,0 +1,644 @@
+"""Reusable, read-only host probes and pure output parsers.
+
+This module is deliberately limited to observing host state.  It must not
+contain commands that change interfaces, services, firewall rules, or files.
+Callers keep their existing policy and result shapes while sharing this
+bounded execution and parsing layer.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+Runner = Callable[..., Any]
+Which = Callable[[str], Optional[str]]
+
+_IW_WIPHY_RE = re.compile(r"^Wiphy\s+(phy\d+)")
+_IW_FREQ_LINE_RE = re.compile(
+    r"^\s*\*\s+(\d+(?:\.\d+)?)\s+MHz\s+\[(\d+)\](.*)$",
+    re.IGNORECASE,
+)
+_IW_VHT_WIDTH_RE = re.compile(r"Supported Channel Width:\s*(.+)$", re.IGNORECASE)
+_IW_HE_80_RE = re.compile(r"HE40/HE80(?:/5GHz)?", re.IGNORECASE)
+_HE_IFTYPES_RE = re.compile(r"^\s*HE Iftypes:\s*(.+)$", re.IGNORECASE)
+
+
+def _subprocess_text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Normalized result from a bounded, read-only command."""
+
+    argv: Tuple[str, ...]
+    exit_status: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+    missing: bool = False
+    permission_denied: bool = False
+    error: Optional[str] = None
+    exception: Optional[BaseException] = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    @property
+    def returncode(self) -> int:
+        """Compatibility spelling used by ``subprocess.CompletedProcess``."""
+        return self.exit_status
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.exit_status == 0
+            and not self.timed_out
+            and not self.missing
+            and not self.permission_denied
+        )
+
+    def combined_output(self, *, include_error: bool = True) -> str:
+        text = self.stdout or ""
+        if self.stderr:
+            text += ("\n" if text else "") + self.stderr
+        if include_error and self.error and not text:
+            text = self.error
+        return text.strip()
+
+
+def run_command(
+    argv: Sequence[str],
+    *,
+    timeout_s: Optional[float],
+    merge_stderr: bool = False,
+    env: Optional[Mapping[str, str]] = None,
+    runner: Optional[Runner] = None,
+) -> CommandResult:
+    """Run one read-only command and normalize all completion states.
+
+    ``runner`` is injectable so characterization tests never need to invoke
+    real host commands.  The default is resolved at call time so pytest's
+    subprocess safety guard remains effective.
+    """
+
+    normalized_argv = tuple(os.fspath(item) for item in argv)
+    execute = runner or subprocess.run
+    kwargs: Dict[str, Any] = {"text": True}
+    if merge_stderr:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.STDOUT
+    else:
+        kwargs["capture_output"] = True
+    if timeout_s is not None:
+        kwargs["timeout"] = timeout_s
+    if env is not None:
+        kwargs["env"] = dict(env)
+
+    try:
+        completed = execute(list(normalized_argv), **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult(
+            argv=normalized_argv,
+            exit_status=124,
+            stdout=exc.stdout if isinstance(exc.stdout, str) else "",
+            stderr=exc.stderr if isinstance(exc.stderr, str) else "",
+            timed_out=True,
+        )
+    except OSError as exc:
+        missing = isinstance(exc, FileNotFoundError) or exc.errno == errno.ENOENT
+        permission_denied = isinstance(exc, PermissionError) or exc.errno in (
+            errno.EACCES,
+            errno.EPERM,
+        )
+        return CommandResult(
+            argv=normalized_argv,
+            exit_status=127,
+            missing=missing,
+            permission_denied=permission_denied,
+            error=f"{type(exc).__name__}: {exc}",
+            exception=exc,
+        )
+    except Exception as exc:
+        return CommandResult(
+            argv=normalized_argv,
+            exit_status=127,
+            error=f"{type(exc).__name__}: {exc}",
+            exception=exc,
+        )
+
+    return CommandResult(
+        argv=normalized_argv,
+        exit_status=int(completed.returncode),
+        stdout=_subprocess_text(getattr(completed, "stdout", "")),
+        stderr=_subprocess_text(getattr(completed, "stderr", "")),
+    )
+
+
+def split_tokens(value: object) -> List[str]:
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        tokens: List[str] = []
+        for item in value:
+            tokens.extend(split_tokens(item))
+        return tokens
+    return [
+        item.strip().lower()
+        for item in str(value).replace(",", " ").split()
+        if item.strip()
+    ]
+
+
+def classify_os_flavor(info: Mapping[str, object]) -> Dict[str, Any]:
+    """Preserve the runtime OS-family classification used by Wi-Fi probing."""
+
+    tokens: List[str] = []
+    for key in ("id", "id_like", "variant_id", "variant", "name"):
+        tokens.extend(split_tokens(info.get(key)))
+
+    flavor = "unknown"
+    family: Optional[str] = None
+    if "steamos" in tokens:
+        flavor = "steamos"
+        family = "arch"
+    elif "bazzite" in tokens:
+        flavor = "bazzite"
+        family = "fedora"
+    elif "fedora" in tokens and any(
+        token in tokens
+        for token in ("silverblue", "kinoite", "sericea", "onyx", "atomic", "ostree")
+    ):
+        flavor = "fedora_atomic"
+        family = "fedora"
+    elif "fedora" in tokens:
+        flavor = "fedora"
+        family = "fedora"
+    elif any(token in tokens for token in ("ubuntu", "debian", "pop", "linuxmint")):
+        flavor = "ubuntu_debian"
+        family = "debian"
+    elif any(token in tokens for token in ("arch", "cachyos")):
+        flavor = "arch"
+        family = "arch"
+
+    return {
+        "id": info.get("id"),
+        "id_like": info.get("id_like"),
+        "variant_id": info.get("variant_id"),
+        "version_id": info.get("version_id"),
+        "name": info.get("name"),
+        "flavor": flavor,
+        "family": family,
+    }
+
+
+def parse_iw_dev_interfaces(text: str) -> List[Dict[str, str]]:
+    """Parse ``iw dev`` into interface/phy pairs."""
+
+    interfaces: List[Dict[str, str]] = []
+    current_phy: Optional[str] = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("phy#"):
+            number = line.split("#", 1)[1].strip()
+            current_phy = f"phy{number}"
+        elif line.startswith("Interface") and current_phy:
+            parts = line.split()
+            interfaces.append({"ifname": parts[1].strip(), "phy": current_phy})
+    return interfaces
+
+
+def split_wiphy_sections(text: str) -> Dict[str, str]:
+    sections: Dict[str, List[str]] = {}
+    current: Optional[str] = None
+    for raw in text.splitlines():
+        line = raw.rstrip("\n")
+        match = _IW_WIPHY_RE.match(line.strip())
+        if match:
+            current = match.group(1)
+            sections.setdefault(current, []).append(line)
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {phy: "\n".join(lines) for phy, lines in sections.items()}
+
+
+def parse_supported_interface_modes(text: str) -> Optional[List[str]]:
+    """Return modes in the ``Supported interface modes`` section."""
+
+    if not text or "Supported interface modes" not in text:
+        return None
+    modes: List[str] = []
+    in_modes = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("Supported interface modes"):
+            in_modes = True
+            continue
+        if not in_modes:
+            continue
+        if line.startswith("*"):
+            modes.append(line.lstrip("*").strip())
+        elif line:
+            break
+    return modes
+
+
+def supports_ap_mode(text: str, *, extended_variants: bool = False) -> Optional[bool]:
+    modes = parse_supported_interface_modes(text)
+    if modes is None:
+        return None
+    if extended_variants:
+        for mode in modes:
+            normalized = mode.upper()
+            if (
+                normalized == "AP"
+                or normalized.startswith("AP/")
+                or normalized.startswith("AP-")
+            ):
+                return True
+        return False
+    return any(mode in ("AP", "AP/VLAN") for mode in modes)
+
+
+def parse_regulatory_domains(text: str) -> Dict[str, Any]:
+    """Parse ``iw reg get`` without applying regulatory policy."""
+
+    global_country: Optional[str] = None
+    global_header: Optional[str] = None
+    phys: Dict[str, Dict[str, Any]] = {}
+    current_section = "global"
+    current_phy: Optional[str] = None
+    current_phy_source = "unknown"
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("phy#"):
+            current_section = "phy"
+            phy_number = line.split()[0].split("#", 1)[1]
+            current_phy = f"phy{phy_number}"
+            current_phy_source = (
+                "self-managed" if "self-managed" in line else "kernel-managed"
+            )
+            phys.setdefault(
+                current_phy,
+                {
+                    "country": None,
+                    "source": current_phy_source,
+                    "raw_header": None,
+                },
+            )
+            phys[current_phy]["source"] = current_phy_source
+            continue
+
+        if line.startswith("country "):
+            parts = line.split()
+            country = parts[1].rstrip(":") if len(parts) >= 2 else None
+            if current_section == "global":
+                global_country = country
+                global_header = line
+            elif current_section == "phy" and current_phy:
+                phys.setdefault(current_phy, {})
+                phys[current_phy]["country"] = country
+                phys[current_phy]["raw_header"] = line
+                phys[current_phy].setdefault("source", current_phy_source)
+
+    return {
+        "global": {
+            "country": global_country or "unknown",
+            "raw_header": global_header,
+        },
+        "phys": phys,
+    }
+
+
+def he_iftypes_has_ap(text: str) -> Optional[bool]:
+    seen = False
+    for raw in text.splitlines():
+        match = _HE_IFTYPES_RE.search(raw)
+        if not match:
+            continue
+        seen = True
+        for token in match.group(1).split(","):
+            if token.strip().upper() in ("AP", "AP/VLAN", "AP-VLAN"):
+                return True
+    return False if seen else None
+
+
+def supports_wifi6(text: str) -> bool:
+    he_ap = he_iftypes_has_ap(text)
+    if he_ap is True:
+        return True
+    if he_ap is False:
+        return False
+    lowered = text.lower()
+    return "802.11ax" in lowered or "he capabilities" in lowered
+
+
+def supports_80mhz(text: str) -> bool:
+    """Preserve inventory's VHT80/HE80 capability heuristic."""
+
+    if re.search(r"HE40/HE80/5GHz", text, re.IGNORECASE):
+        return True
+
+    vht_section = re.search(
+        r"VHT Capabilities \(.*?\):(.*?)(?:\n\s*[A-Za-z]|\Z)",
+        text,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if not vht_section:
+        return False
+    width_line = re.search(
+        r"Supported Channel Width:(.*)",
+        vht_section.group(1),
+        re.IGNORECASE,
+    )
+    if width_line:
+        value = width_line.group(1).strip().lower()
+        if "160" in value or "neither 160 nor 80+80" in value:
+            return True
+        if "20/40" in value:
+            return False
+    return True
+
+
+def parse_band_support(text: str) -> Dict[str, bool]:
+    supports = {
+        "supports_2ghz": False,
+        "supports_5ghz": False,
+        "supports_6ghz": False,
+    }
+    in_frequencies = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("Frequencies:"):
+            in_frequencies = True
+            continue
+        if in_frequencies and line and not line.startswith("*"):
+            in_frequencies = False
+        if not in_frequencies:
+            continue
+
+        match = _IW_FREQ_LINE_RE.match(line)
+        if not match:
+            continue
+        try:
+            mhz = int(float(match.group(1)))
+        except Exception:
+            continue
+        lowered = line.lower()
+        if "disabled" in lowered or "no ir" in lowered or "no-ir" in lowered:
+            continue
+        if 2400 <= mhz <= 2500:
+            supports["supports_2ghz"] = True
+        elif 4900 <= mhz <= 5900:
+            supports["supports_5ghz"] = True
+        elif 5925 <= mhz <= 7125:
+            supports["supports_6ghz"] = True
+    return supports
+
+
+def parse_5ghz_channels(text: str) -> List[Dict[str, Any]]:
+    channels: List[Dict[str, Any]] = []
+    in_frequencies = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("Frequencies:"):
+            in_frequencies = True
+            continue
+        if in_frequencies and line and not line.startswith("*"):
+            in_frequencies = False
+        if not in_frequencies:
+            continue
+
+        match = _IW_FREQ_LINE_RE.match(raw)
+        if not match:
+            continue
+        try:
+            mhz = int(float(match.group(1)))
+            channel = int(match.group(2))
+        except Exception:
+            continue
+        if not 4900 <= mhz <= 5900:
+            continue
+        flags = (match.group(3) or "").lower()
+        channels.append(
+            {
+                "channel": channel,
+                "freq_mhz": mhz,
+                "disabled": "disabled" in flags,
+                "no_ir": (
+                    "no ir" in flags
+                    or "no-ir" in flags
+                    or "no_ir" in flags
+                ),
+                "dfs": "radar detection" in flags or "dfs" in flags,
+                "flags": flags.strip(),
+            }
+        )
+    return channels
+
+
+def parse_vht_supports_80(text: str) -> Optional[bool]:
+    if "VHT Capabilities" not in text:
+        return None
+    for line in text.splitlines():
+        match = _IW_VHT_WIDTH_RE.search(line)
+        if not match:
+            continue
+        value = match.group(1).strip().lower()
+        if "20/40" in value and "80" not in value and "160" not in value:
+            return False
+        return True
+    return True
+
+
+def parse_he_supports_80(text: str) -> Optional[bool]:
+    if _IW_HE_80_RE.search(text):
+        return True
+    return None
+
+
+def parse_ap_managed_concurrency(text: str) -> Optional[bool]:
+    """Preserve the existing, currently informational concurrency parser."""
+
+    if not text or "valid interface combinations" not in text:
+        return None
+
+    found_managed = False
+    found_ap = False
+    found_total = False
+    in_section = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "valid interface combinations" in line:
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if line.startswith("*"):
+            found_managed = False
+            found_ap = False
+            found_total = False
+        if "#{ managed }" in line:
+            found_managed = True
+        if "AP" in line:
+            found_ap = True
+        if "total <=" in line:
+            found_total = True
+        if found_managed and found_ap and found_total:
+            return True
+    return False
+
+
+def parse_default_uplink(text: str) -> Optional[str]:
+    """Return the first interface following ``dev`` in default-route output."""
+
+    for raw in text.splitlines():
+        parts = raw.strip().split()
+        if "dev" not in parts:
+            continue
+        index = parts.index("dev")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    return None
+
+
+def probe_default_uplink(
+    *,
+    which: Optional[Which] = None,
+    runner: Optional[Runner] = None,
+    raise_on_execution_error: bool = False,
+) -> Optional[str]:
+    """Read and parse the active default-route interface.
+
+    The compatibility flag reflects the two legacy policies: network tuning
+    treated execution errors as no uplink, while engine helpers propagated
+    them.
+    """
+
+    resolve = which or shutil.which
+    ip = resolve("ip") or "/usr/sbin/ip"
+    result = run_command(
+        [ip, "route", "show", "default"],
+        timeout_s=None,
+        runner=runner,
+    )
+    if result.exception is not None and raise_on_execution_error:
+        raise result.exception
+    if result.exception is not None:
+        return None
+    return parse_default_uplink(result.stdout)
+
+
+def probe_network_manager(
+    *,
+    which: Optional[Which] = None,
+    runner: Optional[Runner] = None,
+) -> Dict[str, bool]:
+    resolve = which or shutil.which
+    nmcli = resolve("nmcli")
+    running = False
+    if nmcli:
+        result = run_command(
+            [nmcli, "-t", "-f", "RUNNING", "g"],
+            timeout_s=1.0,
+            runner=runner,
+        )
+        running = result.exit_status == 0 and result.combined_output() == "running"
+    return {"nmcli": bool(nmcli), "running": running}
+
+
+def probe_firewall_backends(
+    *,
+    which: Optional[Which] = None,
+    runner: Optional[Runner] = None,
+) -> Dict[str, Any]:
+    """Preserve Wi-Fi probe firewall priority and result shape."""
+
+    resolve = which or shutil.which
+    firewall_cmd = resolve("firewall-cmd")
+    firewalld_active = False
+    if firewall_cmd:
+        result = run_command(
+            ["firewall-cmd", "--state"],
+            timeout_s=1.0,
+            runner=runner,
+        )
+        firewalld_active = (
+            result.exit_status == 0 and result.combined_output() == "running"
+        )
+
+    ufw = resolve("ufw")
+    ufw_active = False
+    if ufw:
+        result = run_command(["ufw", "status"], timeout_s=1.5, runner=runner)
+        if result.exit_status == 0:
+            for line in result.combined_output().splitlines():
+                if "Status:" in line:
+                    # Compatibility: the legacy probe used this substring
+                    # check, so "inactive" also evaluates as active.
+                    ufw_active = "active" in line.lower()
+                    break
+
+    nft_present = bool(resolve("nft"))
+    iptables = resolve("iptables")
+    iptables_variant: Optional[str] = None
+    if iptables:
+        result = run_command(
+            [iptables, "--version"],
+            timeout_s=1.0,
+            runner=runner,
+        )
+        if result.exit_status != 0:
+            iptables_variant = "iptables-unknown"
+        else:
+            lowered = result.combined_output().lower()
+            if "nf_tables" in lowered or "nft" in lowered:
+                iptables_variant = "iptables-nft"
+            elif "legacy" in lowered:
+                iptables_variant = "iptables-legacy"
+            else:
+                iptables_variant = "iptables-unknown"
+
+    selected = "unknown"
+    rationale = "no_firewall_detected"
+    if firewalld_active:
+        selected = "firewalld"
+        rationale = "firewalld_running"
+    elif ufw_active:
+        selected = "ufw"
+        rationale = "ufw_active"
+    elif nft_present:
+        selected = "nftables"
+        rationale = "nft_present"
+    elif iptables_variant:
+        selected = "iptables"
+        rationale = "iptables_present"
+
+    return {
+        "firewalld": {
+            "available": bool(firewall_cmd),
+            "active": firewalld_active,
+        },
+        "ufw": {"available": bool(ufw), "active": ufw_active},
+        "nftables": {"available": nft_present},
+        "iptables": {
+            "available": iptables_variant is not None,
+            "variant": iptables_variant,
+        },
+        "selected_backend": selected,
+        "rationale": rationale,
+    }

--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -26,7 +26,14 @@ from vr_hotspotd.engine.hostapd_bridge_cmd import build_cmd_bridge
 from vr_hotspotd.engine.supervisor import start_engine, stop_engine, is_running, get_tails
 from vr_hotspotd.engine.channel_scan import select_best_channel
 from vr_hotspotd.engine.tx_power import auto_adjust_tx_power, set_tx_power, get_tx_power
-from vr_hotspotd import system_tuning, preflight, network_tuning, os_release, wifi_probe
+from vr_hotspotd import (
+    host_probes,
+    network_tuning,
+    os_release,
+    preflight,
+    system_tuning,
+    wifi_probe,
+)
 from vr_hotspotd.policy import (
     BASIC_MODE_REQUIRED_BAND,
     ERROR_BASIC_MODE_REQUIRES_5GHZ,
@@ -1305,70 +1312,11 @@ def _parse_iw_dev_ap_ifaces(iw_text: str) -> Set[str]:
     return {ap.ifname for ap in _parse_iw_dev_ap_info(iw_text) if ap.ifname}
 
 def _parse_supported_interface_modes(text: str) -> Optional[bool]:
-    if not text or "Supported interface modes" not in text:
-        return None
-    
-    in_modes = False
-    for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("Supported interface modes"):
-            in_modes = True
-            continue
-        if in_modes:
-            if line.startswith("*"):
-                mode = line.lstrip("*").strip()
-                if mode in ("AP", "AP/VLAN"):
-                    return True
-            elif line and not line.startswith("*"):
-                # End of section
-                break
-    return False
+    return host_probes.supports_ap_mode(text)
 
 
 def _parse_ap_managed_concurrency(text: str) -> Optional[bool]:
-    if not text or "valid interface combinations" not in text:
-        return None
-    
-    # Simple multi-line check: flatten the text or check presence in the relevant section.
-    # We look for a combination that supports AP and Managed handling.
-    # Example snippet:
-    #  * #{ managed } <= 1, #{ AP, P2P-client, P2P-GO } <= 1,
-    #    total <= 2, #channels <= 1
-    
-    found_managed = False
-    found_ap = False
-    found_total = False
-    
-    in_section = False
-    for line in text.splitlines():
-        line = line.strip()
-        if "valid interface combinations" in line:
-            in_section = True
-            continue
-        if not in_section:
-            continue
-            
-        # Stop at next section if any (usually starting with non-indented text or Specific Keywords)
-        # But 'iw phy' output indentation varies. We assume valid combinations block continues until
-        # another header or end of file.
-        
-        if line.startswith("*"):
-            # New combination
-            found_managed = False
-            found_ap = False
-            found_total = False
-        
-        if "#{ managed }" in line:
-            found_managed = True
-        if "AP" in line:
-            found_ap = True
-        if "total <=" in line:
-            found_total = True
-            
-        if found_managed and found_ap and found_total:
-            return True
-            
-    return False
+    return host_probes.parse_ap_managed_concurrency(text)
 
 
 def _band_from_freq_mhz(freq_mhz: Optional[int]) -> Optional[str]:

--- a/backend/vr_hotspotd/network_tuning.py
+++ b/backend/vr_hotspotd/network_tuning.py
@@ -4,23 +4,12 @@ import shutil
 import subprocess
 from typing import Dict, List, Optional, Tuple
 
-from vr_hotspotd import qos, nat_accel
+from vr_hotspotd import host_probes, nat_accel, qos
 from vr_hotspotd.engine import ufw
 
 
 def _default_uplink_iface() -> Optional[str]:
-    ip = shutil.which("ip") or "/usr/sbin/ip"
-    try:
-        p = subprocess.run([ip, "route", "show", "default"], capture_output=True, text=True)
-    except Exception:
-        return None
-    for raw in (p.stdout or "").splitlines():
-        parts = raw.strip().split()
-        if "dev" in parts:
-            idx = parts.index("dev")
-            if idx + 1 < len(parts):
-                return parts[idx + 1]
-    return None
+    return host_probes.probe_default_uplink()
 
 
 def _ethtool_path() -> Optional[str]:

--- a/backend/vr_hotspotd/os_release.py
+++ b/backend/vr_hotspotd/os_release.py
@@ -14,7 +14,7 @@ def _strip_quotes(value: str) -> str:
     return value
 
 
-def _parse_os_release(text: str) -> Dict[str, str]:
+def parse_os_release(text: str) -> Dict[str, str]:
     data: Dict[str, str] = {}
     for raw in text.splitlines():
         line = raw.strip()
@@ -28,13 +28,17 @@ def _parse_os_release(text: str) -> Dict[str, str]:
     return data
 
 
+# Retain the private name for compatibility with any existing internal callers.
+_parse_os_release = parse_os_release
+
+
 def read_os_release(paths: Optional[Tuple[str, ...]] = None) -> Dict[str, str]:
     for path in paths or _OS_RELEASE_PATHS:
         try:
             text = Path(path).read_text(encoding="utf-8")
         except Exception:
             continue
-        data = _parse_os_release(text)
+        data = parse_os_release(text)
         if data:
             return data
     return {}

--- a/backend/vr_hotspotd/preflight.py
+++ b/backend/vr_hotspotd/preflight.py
@@ -4,9 +4,9 @@ import ipaddress
 import os
 import re
 import shutil
-import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
+from vr_hotspotd import host_probes
 from vr_hotspotd.engine import supervisor
 
 
@@ -16,16 +16,8 @@ _HOSTAPD_HE_RE = re.compile(r"\b(802\.11ax|ieee80211ax|he)\b", re.IGNORECASE)
 
 
 def _run(cmd: List[str], timeout_s: float = 1.2) -> Tuple[int, str]:
-    try:
-        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
-        out = (p.stdout or "") + ("\n" + p.stderr if p.stderr else "")
-        return p.returncode, out.strip()
-    except subprocess.TimeoutExpired as exc:
-        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
-        err = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
-        return 124, (out + "\n" + err).strip()
-    except Exception as exc:
-        return 127, f"{type(exc).__name__}: {exc}"
+    result = host_probes.run_command(cmd, timeout_s=timeout_s)
+    return result.exit_status, result.combined_output()
 
 
 def _parse_rfkill(text: str) -> List[Dict[str, Optional[str]]]:

--- a/backend/vr_hotspotd/wifi_probe.py
+++ b/backend/vr_hotspotd/wifi_probe.py
@@ -2,18 +2,11 @@ from __future__ import annotations
 
 import re
 import shutil
-import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
-from vr_hotspotd import os_release
+from vr_hotspotd import host_probes, os_release
 from vr_hotspotd.adapters.inventory import get_adapters
 
-_IW_WIPHY_RE = re.compile(r"^Wiphy\s+(phy\d+)")
-_IW_FREQ_LINE_RE = re.compile(
-    r"^\s*\*\s+(\d+(?:\.\d+)?)\s+MHz\s+\[(\d+)\](.*)$", re.IGNORECASE
-)
-_IW_VHT_WIDTH_RE = re.compile(r"Supported Channel Width:\s*(.+)$", re.IGNORECASE)
-_IW_HE_80_RE = re.compile(r"HE40/HE80(?:/5GHz)?", re.IGNORECASE)
 _COUNTRY_RE = re.compile(r"^[A-Z]{2}$")
 
 ERROR_REMEDIATIONS: Dict[str, str] = {
@@ -76,17 +69,8 @@ def build_error_detail(code: str, context: Optional[Dict[str, Any]] = None) -> D
 
 
 def _run(cmd: List[str], timeout_s: float = 2.0) -> Tuple[int, str]:
-    try:
-        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
-    except subprocess.TimeoutExpired as exc:
-        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
-        err = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
-        return 124, (out + "\n" + err).strip()
-    except Exception as exc:
-        return 127, f"{type(exc).__name__}: {exc}"
-
-    out = (p.stdout or "") + ("\n" + p.stderr if p.stderr else "")
-    return p.returncode, out.strip()
+    result = host_probes.run_command(cmd, timeout_s=timeout_s)
+    return result.exit_status, result.combined_output()
 
 
 def _iw_bin() -> str:
@@ -107,258 +91,41 @@ def _run_iw_reg_get() -> Tuple[int, str]:
     return _run([_iw_bin(), "reg", "get"], timeout_s=2.0)
 
 
-def _split_tokens(value: Optional[str]) -> List[str]:
-    if not value:
-        return []
-    return [item.strip().lower() for item in value.replace(",", " ").split() if item.strip()]
-
-
 def detect_os_flavor(info: Optional[Dict[str, str]] = None) -> Dict[str, Optional[str]]:
     info = info or os_release.read_os_release()
-    tokens: List[str] = []
-    for key in ("id", "id_like", "variant_id", "variant", "name"):
-        tokens.extend(_split_tokens(info.get(key)))
-
-    flavor = "unknown"
-    family = None
-    if "steamos" in tokens:
-        flavor = "steamos"
-        family = "arch"
-    elif "bazzite" in tokens:
-        flavor = "bazzite"
-        family = "fedora"
-    elif "fedora" in tokens and any(
-        t in tokens for t in ("silverblue", "kinoite", "sericea", "onyx", "atomic", "ostree")
-    ):
-        flavor = "fedora_atomic"
-        family = "fedora"
-    elif "fedora" in tokens:
-        flavor = "fedora"
-        family = "fedora"
-    elif any(t in tokens for t in ("ubuntu", "debian", "pop", "linuxmint")):
-        flavor = "ubuntu_debian"
-        family = "debian"
-    elif any(t in tokens for t in ("arch", "cachyos")):
-        flavor = "arch"
-        family = "arch"
-
-    return {
-        "id": info.get("id"),
-        "id_like": info.get("id_like"),
-        "variant_id": info.get("variant_id"),
-        "version_id": info.get("version_id"),
-        "name": info.get("name"),
-        "flavor": flavor,
-        "family": family,
-    }
-
-
-def _firewalld_active() -> bool:
-    if not shutil.which("firewall-cmd"):
-        return False
-    rc, out = _run(["firewall-cmd", "--state"], timeout_s=1.0)
-    return rc == 0 and out.strip() == "running"
-
-
-def _ufw_active() -> bool:
-    if not shutil.which("ufw"):
-        return False
-    rc, out = _run(["ufw", "status"], timeout_s=1.5)
-    if rc != 0:
-        return False
-    for line in out.splitlines():
-        if "Status:" in line:
-            return "active" in line.lower()
-    return False
-
-
-def _iptables_variant() -> Optional[str]:
-    ipt = shutil.which("iptables")
-    if not ipt:
-        return None
-    rc, out = _run([ipt, "--version"], timeout_s=1.0)
-    if rc != 0:
-        return "iptables-unknown"
-    low = out.lower()
-    if "nf_tables" in low or "nft" in low:
-        return "iptables-nft"
-    if "legacy" in low:
-        return "iptables-legacy"
-    return "iptables-unknown"
+    return host_probes.classify_os_flavor(info)
 
 
 def detect_firewall_backends() -> Dict[str, Any]:
-    firewalld_active = _firewalld_active()
-    ufw_active = _ufw_active()
-    nft_present = bool(shutil.which("nft"))
-    ipt_variant = _iptables_variant()
-
-    selected = "unknown"
-    rationale = "no_firewall_detected"
-    if firewalld_active:
-        selected = "firewalld"
-        rationale = "firewalld_running"
-    elif ufw_active:
-        selected = "ufw"
-        rationale = "ufw_active"
-    elif nft_present:
-        selected = "nftables"
-        rationale = "nft_present"
-    elif ipt_variant:
-        selected = "iptables"
-        rationale = "iptables_present"
-
-    return {
-        "firewalld": {"available": bool(shutil.which("firewall-cmd")), "active": firewalld_active},
-        "ufw": {"available": bool(shutil.which("ufw")), "active": ufw_active},
-        "nftables": {"available": nft_present},
-        "iptables": {"available": ipt_variant is not None, "variant": ipt_variant},
-        "selected_backend": selected,
-        "rationale": rationale,
-    }
+    return host_probes.probe_firewall_backends()
 
 
 def detect_network_manager() -> Dict[str, Any]:
-    nmcli = shutil.which("nmcli")
-    running = False
-    if nmcli:
-        rc, out = _run([nmcli, "-t", "-f", "RUNNING", "g"], timeout_s=1.0)
-        running = rc == 0 and out.strip() == "running"
-    return {"nmcli": bool(nmcli), "running": running}
+    return host_probes.probe_network_manager()
 
 
 def _split_wiphy_sections(text: str) -> Dict[str, str]:
-    sections: Dict[str, List[str]] = {}
-    current: Optional[str] = None
-    for raw in text.splitlines():
-        line = raw.rstrip("\n")
-        m = _IW_WIPHY_RE.match(line.strip())
-        if m:
-            current = m.group(1)
-            sections.setdefault(current, []).append(line)
-            continue
-        if current is not None:
-            sections[current].append(line)
-    return {phy: "\n".join(lines) for phy, lines in sections.items()}
+    return host_probes.split_wiphy_sections(text)
 
 
 def _parse_supported_interface_modes(text: str) -> Optional[bool]:
-    if not text or "Supported interface modes" not in text:
-        return None
-    in_modes = False
-    for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("Supported interface modes"):
-            in_modes = True
-            continue
-        if in_modes:
-            if line.startswith("*"):
-                mode = line.lstrip("*").strip()
-                if mode in ("AP", "AP/VLAN"):
-                    return True
-            elif line and not line.startswith("*"):
-                break
-    return False
+    return host_probes.supports_ap_mode(text)
 
 
 def _parse_5ghz_channels(text: str) -> List[Dict[str, Any]]:
-    channels: List[Dict[str, Any]] = []
-    in_freqs = False
-    for raw in text.splitlines():
-        line = raw.strip()
-        if line.startswith("Frequencies:"):
-            in_freqs = True
-            continue
-        if in_freqs and line and not line.startswith("*"):
-            in_freqs = False
-        if not in_freqs:
-            continue
-
-        m = _IW_FREQ_LINE_RE.match(raw)
-        if not m:
-            continue
-        try:
-            mhz = int(float(m.group(1)))
-            channel = int(m.group(2))
-        except Exception:
-            continue
-        if not (4900 <= mhz <= 5900):
-            continue
-        flags = (m.group(3) or "").lower()
-        disabled = "disabled" in flags
-        no_ir = "no ir" in flags or "no-ir" in flags or "no_ir" in flags
-        dfs = "radar detection" in flags or "dfs" in flags
-        channels.append(
-            {
-                "channel": channel,
-                "freq_mhz": mhz,
-                "disabled": disabled,
-                "no_ir": no_ir,
-                "dfs": dfs,
-                "flags": flags.strip(),
-            }
-        )
-    return channels
+    return host_probes.parse_5ghz_channels(text)
 
 
 def _parse_vht_supports_80(text: str) -> Optional[bool]:
-    if "VHT Capabilities" not in text:
-        return None
-    for line in text.splitlines():
-        m = _IW_VHT_WIDTH_RE.search(line)
-        if not m:
-            continue
-        value = m.group(1).strip().lower()
-        if "20/40" in value and "80" not in value and "160" not in value:
-            return False
-        return True
-    return True
+    return host_probes.parse_vht_supports_80(text)
 
 
 def _parse_he_supports_80(text: str) -> Optional[bool]:
-    if _IW_HE_80_RE.search(text):
-        return True
-    if "HE Capabilities" in text or "HE Iftypes" in text:
-        return None
-    return None
+    return host_probes.parse_he_supports_80(text)
 
 
 def _parse_iw_reg_get(text: str) -> Dict[str, Any]:
-    global_country: Optional[str] = None
-    global_header: Optional[str] = None
-    phys: Dict[str, Dict[str, Any]] = {}
-
-    current_section = "global"
-    current_phy: Optional[str] = None
-    current_phy_source = "unknown"
-
-    for raw in text.splitlines():
-        s = raw.strip()
-        if s.startswith("phy#"):
-            current_section = "phy"
-            phy_num = s.split()[0].split("#", 1)[1]
-            current_phy = f"phy{phy_num}"
-            current_phy_source = "self-managed" if "self-managed" in s else "kernel-managed"
-            phys.setdefault(current_phy, {"country": None, "source": current_phy_source, "raw_header": None})
-            phys[current_phy]["source"] = current_phy_source
-            continue
-
-        if s.startswith("country "):
-            parts = s.split()
-            cc = parts[1].rstrip(":") if len(parts) >= 2 else None
-            if current_section == "global":
-                global_country = cc
-                global_header = s
-            elif current_section == "phy" and current_phy:
-                phys.setdefault(current_phy, {})
-                phys[current_phy]["country"] = cc
-                phys[current_phy]["raw_header"] = s
-                phys[current_phy].setdefault("source", current_phy_source)
-
-    return {
-        "global": {"country": global_country or "unknown", "raw_header": global_header},
-        "phys": phys,
-    }
+    return host_probes.parse_regulatory_domains(text)
 
 
 def _effective_country(config_country: Optional[str], reg_country: Optional[str]) -> Optional[str]:

--- a/tests/test_host_probes.py
+++ b/tests/test_host_probes.py
@@ -1,0 +1,486 @@
+from types import SimpleNamespace
+import subprocess
+
+import pytest
+
+from vr_hotspotd import host_probes
+from vr_hotspotd import lifecycle
+from vr_hotspotd import network_tuning
+from vr_hotspotd import preflight
+from vr_hotspotd import wifi_probe
+from vr_hotspotd.adapters import inventory
+from vr_hotspotd.diagnostics import platform
+from vr_hotspotd.engine import hostapd6_engine
+from vr_hotspotd.engine import hostapd_bridge_engine
+from vr_hotspotd.engine import hostapd_nat_engine
+
+
+def test_run_command_normalizes_success_and_keeps_streams_separate():
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=3, stdout="standard\n", stderr="diagnostic\n")
+
+    result = host_probes.run_command(
+        ["/usr/bin/probe", "--status"],
+        timeout_s=1.25,
+        env={"LC_ALL": "C"},
+        runner=runner,
+    )
+
+    assert result.argv == ("/usr/bin/probe", "--status")
+    assert result.exit_status == 3
+    assert result.returncode == 3
+    assert result.stdout == "standard\n"
+    assert result.stderr == "diagnostic\n"
+    assert result.combined_output() == "standard\n\ndiagnostic"
+    assert result.ok is False
+    assert calls == [
+        (
+            ["/usr/bin/probe", "--status"],
+            {
+                "capture_output": True,
+                "text": True,
+                "timeout": 1.25,
+                "env": {"LC_ALL": "C"},
+            },
+        )
+    ]
+
+
+def test_run_command_discards_byte_timeout_output_for_legacy_callers():
+    def runner(argv, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=argv,
+            timeout=kwargs["timeout"],
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    result = host_probes.run_command(
+        ["read-only-probe"],
+        timeout_s=0.1,
+        runner=runner,
+    )
+
+    assert result.exit_status == 124
+    assert result.timed_out is True
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert result.combined_output() == ""
+
+
+def test_run_command_keeps_text_timeout_output_for_legacy_callers():
+    def runner(argv, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=argv,
+            timeout=kwargs["timeout"],
+            output="partial stdout",
+            stderr="partial stderr",
+        )
+
+    result = host_probes.run_command(
+        ["read-only-probe"],
+        timeout_s=0.1,
+        runner=runner,
+    )
+
+    assert result.exit_status == 124
+    assert result.timed_out is True
+    assert result.stdout == "partial stdout"
+    assert result.stderr == "partial stderr"
+    assert result.combined_output() == "partial stdout\npartial stderr"
+
+
+@pytest.mark.parametrize(
+    ("raised", "missing", "permission_denied"),
+    [
+        (FileNotFoundError("not installed"), True, False),
+        (PermissionError("not executable"), False, True),
+    ],
+)
+def test_run_command_normalizes_os_errors(raised, missing, permission_denied):
+    def runner(_argv, **_kwargs):
+        raise raised
+
+    result = host_probes.run_command(
+        ["read-only-probe"],
+        timeout_s=0.1,
+        runner=runner,
+    )
+
+    assert result.exit_status == 127
+    assert result.missing is missing
+    assert result.permission_denied is permission_denied
+    assert type(raised).__name__ in (result.error or "")
+
+
+def test_legacy_runner_wrappers_keep_their_timeout_contracts(monkeypatch):
+    def runner(argv, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=argv,
+            timeout=kwargs["timeout"],
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(host_probes.subprocess, "run", runner)
+
+    assert wifi_probe._run(["probe"]) == (124, "")
+    assert preflight._run(["probe"]) == (124, "")
+    assert platform._run_cmd(["probe"]) == (127, "")
+
+
+def test_preflight_hostapd_timeout_uses_version_fallback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(preflight, "_resolve_hostapd_path", lambda: "/usr/sbin/hostapd")
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        if argv[-1] == "-vv":
+            raise subprocess.TimeoutExpired(
+                cmd=argv,
+                timeout=kwargs["timeout"],
+                output=b"SAE\nIEEE 802.11ax",
+                stderr=b"",
+            )
+        return SimpleNamespace(returncode=0, stdout="hostapd v2.9", stderr="")
+
+    monkeypatch.setattr(host_probes.subprocess, "run", runner)
+
+    assert preflight._hostapd_caps() == {
+        "sae": False,
+        "he": False,
+        "raw": "hostapd v2.9",
+    }
+    assert [argv[-1] for argv, _kwargs in calls] == ["-vv", "-v"]
+
+
+def test_inventory_runner_keeps_merged_output_order_on_failure(monkeypatch):
+    merged_output = "stdout-before\nstderr-middle\nstdout-after\n"
+
+    def runner(argv, **kwargs):
+        assert argv == ["probe"]
+        assert kwargs == {
+            "text": True,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+        }
+        return SimpleNamespace(
+            returncode=5,
+            stdout=merged_output,
+            stderr=None,
+        )
+
+    monkeypatch.setattr(host_probes.subprocess, "run", runner)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        inventory._run(["probe"])
+
+    assert exc.value.returncode == 5
+    assert exc.value.output == merged_output
+
+
+def test_inventory_ap_mode_scan_resumes_at_later_modes_block(monkeypatch):
+    iw_text = """
+Supported interface modes:
+  * managed
+Band 1:
+Supported interface modes:
+  * AP
+"""
+    monkeypatch.setattr(inventory, "_run_iw", lambda _args: iw_text)
+
+    assert inventory._phy_supports_ap("phy0") is True
+
+
+@pytest.mark.parametrize(
+    ("info", "flavor", "family"),
+    [
+        ({"id": "steamos", "id_like": "arch"}, "steamos", "arch"),
+        ({"id": "bazzite", "id_like": "fedora"}, "bazzite", "fedora"),
+        (
+            {"id": "fedora", "variant_id": "silverblue"},
+            "fedora_atomic",
+            "fedora",
+        ),
+        ({"id": "pop", "id_like": "ubuntu debian"}, "ubuntu_debian", "debian"),
+        ({"id": "cachyos", "id_like": "arch"}, "arch", "arch"),
+        ({"id": "unsupported"}, "unknown", None),
+    ],
+)
+def test_os_flavor_characterization(info, flavor, family):
+    expected = host_probes.classify_os_flavor(info)
+
+    assert expected["flavor"] == flavor
+    assert expected["family"] == family
+    assert wifi_probe.detect_os_flavor(info) == expected
+
+
+def _firewall_probe(*, firewalld, ufw, nft, iptables_output):
+    paths = {
+        "firewall-cmd": "/usr/bin/firewall-cmd",
+        "ufw": "/usr/sbin/ufw",
+        "nft": "/usr/sbin/nft",
+        "iptables": "/usr/sbin/iptables",
+    }
+    if firewalld is None:
+        paths.pop("firewall-cmd")
+    if ufw is None:
+        paths.pop("ufw")
+    if not nft:
+        paths.pop("nft")
+    if iptables_output is None:
+        paths.pop("iptables")
+
+    def which(name):
+        return paths.get(name)
+
+    def runner(argv, **_kwargs):
+        command = tuple(argv)
+        if command == ("firewall-cmd", "--state"):
+            return SimpleNamespace(
+                returncode=0 if firewalld else 1,
+                stdout="running\n" if firewalld else "not running\n",
+                stderr="",
+            )
+        if command == ("ufw", "status"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f"Status: {'active' if ufw else 'inactive'}\n",
+                stderr="",
+            )
+        if command == ("/usr/sbin/iptables", "--version"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=iptables_output,
+                stderr="",
+            )
+        raise AssertionError(f"unexpected read-only command: {argv}")
+
+    return host_probes.probe_firewall_backends(which=which, runner=runner)
+
+
+def test_firewall_priority_prefers_running_firewalld():
+    result = _firewall_probe(
+        firewalld=True,
+        ufw=True,
+        nft=True,
+        iptables_output="iptables v1.8.10 (nf_tables)",
+    )
+
+    assert result["selected_backend"] == "firewalld"
+    assert result["rationale"] == "firewalld_running"
+    assert result["iptables"]["variant"] == "iptables-nft"
+
+
+def test_firewall_priority_falls_through_ufw_nft_and_iptables():
+    ufw_result = _firewall_probe(
+        firewalld=False,
+        ufw=True,
+        nft=True,
+        iptables_output="iptables v1.8.10 (legacy)",
+    )
+    inactive_ufw_result = _firewall_probe(
+        firewalld=False,
+        ufw=False,
+        nft=True,
+        iptables_output="iptables v1.8.10 (legacy)",
+    )
+    nft_result = _firewall_probe(
+        firewalld=False,
+        ufw=None,
+        nft=True,
+        iptables_output="iptables v1.8.10 (legacy)",
+    )
+    iptables_result = _firewall_probe(
+        firewalld=None,
+        ufw=None,
+        nft=False,
+        iptables_output="iptables v1.8.10 (legacy)",
+    )
+
+    assert ufw_result["selected_backend"] == "ufw"
+    # Preserve the existing substring behavior: "inactive" contains "active".
+    assert inactive_ufw_result["selected_backend"] == "ufw"
+    assert nft_result["selected_backend"] == "nftables"
+    assert iptables_result["selected_backend"] == "iptables"
+    assert iptables_result["iptables"]["variant"] == "iptables-legacy"
+
+
+def test_network_manager_probe_preserves_result_shape():
+    def runner(argv, **_kwargs):
+        assert argv == ["/usr/bin/nmcli", "-t", "-f", "RUNNING", "g"]
+        return SimpleNamespace(returncode=0, stdout="running\n", stderr="")
+
+    result = host_probes.probe_network_manager(
+        which=lambda name: "/usr/bin/nmcli" if name == "nmcli" else None,
+        runner=runner,
+    )
+
+    assert result == {"nmcli": True, "running": True}
+
+
+def test_lifecycle_iwd_detection_keeps_service_then_iwctl_fallback(monkeypatch):
+    monkeypatch.setattr(lifecycle, "_systemctl_is_active", lambda _unit: False)
+    monkeypatch.setattr(
+        lifecycle.shutil,
+        "which",
+        lambda name: "/usr/bin/iwctl" if name == "iwctl" else None,
+    )
+
+    assert lifecycle._iwd_is_active() is True
+
+
+def test_engine_iwd_detection_keeps_service_then_iwctl_fallback(monkeypatch):
+    def which(name):
+        return {
+            "systemctl": "/usr/bin/systemctl",
+            "iwctl": "/usr/bin/iwctl",
+        }.get(name)
+
+    def runner(argv, **kwargs):
+        assert argv == [
+            "/usr/bin/systemctl",
+            "is-active",
+            "--quiet",
+            "iwd",
+        ]
+        assert kwargs == {"capture_output": True, "text": True}
+        return SimpleNamespace(returncode=3, stdout="inactive\n", stderr="")
+
+    monkeypatch.setattr(hostapd_nat_engine.shutil, "which", which)
+    monkeypatch.setattr(hostapd_nat_engine.subprocess, "run", runner)
+
+    assert hostapd_nat_engine._iwd_is_active() is True
+
+
+IW_PHY_SAMPLE = """
+Wiphy phy0
+  Supported interface modes:
+     * managed
+     * AP/VLAN
+  valid interface combinations:
+     * #{ managed } <= 1, #{ AP, P2P-client } <= 1,
+       total <= 2, #channels <= 1
+  Band 1:
+    Frequencies:
+      * 2412.0 MHz [1] (22.0 dBm)
+  Band 2:
+    HE Iftypes: AP, managed
+    HE40/HE80/5GHz
+    Frequencies:
+      * 5180.0 MHz [36] (23.0 dBm)
+      * 5200.0 MHz [40] (no IR)
+"""
+
+IW_REG_SAMPLE = """
+global
+country US: DFS-FCC
+phy#0 (self-managed)
+country CA: DFS-FCC
+"""
+
+
+def test_shared_iw_capability_parsers_preserve_legacy_wrappers(monkeypatch):
+    assert host_probes.supports_ap_mode(IW_PHY_SAMPLE) is True
+    assert wifi_probe._parse_supported_interface_modes(IW_PHY_SAMPLE) is True
+    assert lifecycle._parse_supported_interface_modes(IW_PHY_SAMPLE) is True
+    assert inventory._supports_wifi6_from_iw(IW_PHY_SAMPLE) is True
+    assert host_probes.supports_80mhz(IW_PHY_SAMPLE) is True
+    assert host_probes.parse_band_support(IW_PHY_SAMPLE) == {
+        "supports_2ghz": True,
+        "supports_5ghz": True,
+        "supports_6ghz": False,
+    }
+    assert lifecycle._parse_ap_managed_concurrency(IW_PHY_SAMPLE) is True
+
+    monkeypatch.setattr(inventory, "_run_iw", lambda _args: IW_PHY_SAMPLE)
+    inventory._phy_supports_80mhz.cache_clear()
+    try:
+        assert inventory._phy_supports_ap("phy0") is True
+        assert inventory._phy_supports_80mhz("phy0") is True
+        assert inventory._phy_band_support("phy0") == {
+            "supports_2ghz": True,
+            "supports_5ghz": True,
+            "supports_6ghz": False,
+        }
+    finally:
+        inventory._phy_supports_80mhz.cache_clear()
+
+
+def test_shared_regulatory_parser_preserves_inventory_and_wifi_shapes(monkeypatch):
+    expected = {
+        "global": {
+            "country": "US",
+            "raw_header": "country US: DFS-FCC",
+        },
+        "phys": {
+            "phy0": {
+                "country": "CA",
+                "source": "self-managed",
+                "raw_header": "country CA: DFS-FCC",
+            }
+        },
+    }
+
+    monkeypatch.setattr(inventory, "_run_iw", lambda _args: IW_REG_SAMPLE)
+
+    assert host_probes.parse_regulatory_domains(IW_REG_SAMPLE) == expected
+    assert wifi_probe._parse_iw_reg_get(IW_REG_SAMPLE) == expected
+    assert inventory._parse_iw_reg_get() == expected
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        network_tuning,
+        hostapd_nat_engine,
+        hostapd_bridge_engine,
+        hostapd6_engine,
+    ],
+)
+def test_default_uplink_wrappers_keep_first_default_route(module, monkeypatch):
+    route_output = "\n".join(
+        [
+            "default via 192.0.2.1 dev enp4s0 proto dhcp metric 100",
+            "default via 198.51.100.1 dev wlan0 proto dhcp metric 600",
+        ]
+    )
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0, stdout=route_output, stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/sbin/ip" if name == "ip" else None)
+    monkeypatch.setattr(module.subprocess, "run", runner)
+
+    assert module._default_uplink_iface() == "enp4s0"
+    assert calls == [
+        (
+            ["/usr/sbin/ip", "route", "show", "default"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+
+
+def test_default_uplink_parser_keeps_missing_route_behavior():
+    assert host_probes.parse_default_uplink("default via 192.0.2.1") is None
+    assert host_probes.parse_default_uplink("") is None
+
+
+def test_default_uplink_execution_error_policies_are_unchanged(monkeypatch):
+    failure = FileNotFoundError("ip unavailable")
+
+    def runner(_argv, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(host_probes.subprocess, "run", runner)
+    monkeypatch.setattr(host_probes.shutil, "which", lambda _name: None)
+
+    assert network_tuning._default_uplink_iface() is None
+    with pytest.raises(FileNotFoundError) as exc:
+        hostapd_nat_engine._default_uplink_iface()
+    assert exc.value is failure

--- a/tests/test_installer_endeavouros.py
+++ b/tests/test_installer_endeavouros.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import stat
 import subprocess
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "install.sh"
@@ -62,6 +64,43 @@ def test_endeavouros_selects_pacman():
 
     assert result.returncode == 0
     assert "package_manager=pacman" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("os_id", "package_manager"),
+    [
+        ("steamos", "pacman"),
+        ("cachyos", "pacman"),
+        ("arch", "pacman"),
+        ("endeavouros", "pacman"),
+        ("ubuntu", "apt"),
+        ("debian", "apt"),
+        ("pop", "apt"),
+        ("fedora", "dnf"),
+        ("bazzite", "rpm-ostree"),
+    ],
+)
+def test_package_manager_detection_matrix_is_unchanged(os_id, package_manager):
+    env = os.environ.copy()
+    env.update(
+        {
+            "VR_HOTSPOT_OS_ID": os_id,
+            "VR_HOTSPOT_OS_NAME": os_id,
+            "VR_HOTSPOT_OS_ID_LIKE": "",
+        }
+    )
+
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        detect_os
+        printf 'package_manager=%s\n' "$PKG_MANAGER"
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert f"package_manager={package_manager}" in result.stdout
 
 
 def test_endeavouros_dependency_plan_keeps_vendor_hostapd_and_system_dnsmasq():

--- a/tests/test_platform_probes.py
+++ b/tests/test_platform_probes.py
@@ -1,0 +1,86 @@
+from vr_hotspotd.diagnostics import platform
+
+
+def test_platform_os_probe_preserves_public_matrix_shape(monkeypatch):
+    monkeypatch.setattr(
+        platform,
+        "_read_os_release",
+        lambda: {
+            "pretty_name": "Fedora Linux 42 (Kinoite)",
+            "name": "Fedora Linux",
+            "id": "fedora",
+            "version_id": "42",
+            "variant_id": "kinoite",
+            "id_like": "rhel centos",
+        },
+    )
+
+    assert platform._probe_os() == {
+        "pretty_name": "Fedora Linux 42 (Kinoite)",
+        "id": "fedora",
+        "version_id": "42",
+        "variant_id": "kinoite",
+        "id_like": ["rhel", "centos"],
+    }
+
+
+def test_platform_integration_probe_preserves_presence_and_service_semantics(
+    monkeypatch,
+):
+    present = {
+        "systemctl": "/usr/bin/systemctl",
+        "nmcli": "/usr/bin/nmcli",
+        "firewall-cmd": "/usr/bin/firewall-cmd",
+        "ufw": "/usr/sbin/ufw",
+        "nft": "/usr/sbin/nft",
+    }
+    active = {
+        "systemd-journald": True,
+        "NetworkManager": True,
+        "firewalld": False,
+        "ufw": True,
+    }
+    monkeypatch.setattr(platform.shutil, "which", lambda name: present.get(name))
+    monkeypatch.setattr(
+        platform,
+        "_systemctl_is_active",
+        lambda service: active[service],
+    )
+
+    assert platform._probe_integration() == {
+        "systemd": {"present": True, "active": True},
+        "network_manager": {
+            "present": True,
+            "active": True,
+            "nmcli": True,
+        },
+        "firewall": {
+            "firewalld": {"present": True, "active": False},
+            "ufw": {"present": True, "active": True},
+            "nft": {"present": True},
+            "iptables": {"present": False},
+        },
+    }
+
+
+def test_platform_immutability_keeps_rpm_ostree_priority(monkeypatch):
+    monkeypatch.setattr(
+        platform.shutil,
+        "which",
+        lambda name: "/usr/bin/rpm-ostree" if name == "rpm-ostree" else None,
+    )
+    monkeypatch.setattr(
+        platform,
+        "_path_is_writable",
+        lambda path: path != "/var/lib/vr-hotspot",
+    )
+
+    assert platform._probe_immutability() == {
+        "is_immutable": True,
+        "signal": "rpm-ostree",
+        "writable_paths": {
+            "/var": True,
+            "/var/lib": True,
+            "/var/lib/vr-hotspot": False,
+        },
+    }

--- a/tests/test_preflight_probes.py
+++ b/tests/test_preflight_probes.py
@@ -1,0 +1,181 @@
+from vr_hotspotd import preflight
+
+
+def test_preflight_run_preserves_aggregation_order_and_shape(monkeypatch):
+    monkeypatch.setattr(
+        preflight,
+        "_check_rfkill",
+        lambda: (
+            ["rfkill_blocked"],
+            ["rfkill_warning"],
+            {"checked": True},
+        ),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_check_regdom",
+        lambda country, adapter, band: (
+            [f"regdom_error:{country}:{band}"],
+            ["regdom_warning"],
+            {"adapter": adapter["ifname"]},
+        ),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_check_hostapd_features",
+        lambda band, security: (
+            [f"hostapd_error:{band}:{security}"],
+            ["hostapd_warning"],
+            {"sae": False, "he": False},
+        ),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_check_subnet_conflicts",
+        lambda gateway: (
+            [f"subnet_error:{gateway}"],
+            ["subnet_warning"],
+            {"conflicts": ["route:eth0:10.42.0.0/24"]},
+        ),
+    )
+
+    result = preflight.run(
+        {
+            "country": "US",
+            "bridge_mode": False,
+            "lan_gateway_ip": "10.42.0.1",
+        },
+        adapter={"ifname": "wlan1"},
+        band="6ghz",
+        ap_security="wpa3_sae",
+        enable_internet=False,
+    )
+
+    assert result == {
+        "errors": [
+            "rfkill_blocked",
+            "regdom_error:US:6ghz",
+            "hostapd_error:6ghz:wpa3_sae",
+            "subnet_error:10.42.0.1",
+        ],
+        "warnings": [
+            "rfkill_warning",
+            "regdom_warning",
+            "hostapd_warning",
+            "subnet_warning",
+            "internet_disabled_no_nat",
+        ],
+        "details": {
+            "rfkill": {"checked": True},
+            "regdom": {"adapter": "wlan1"},
+            "hostapd": {"sae": False, "he": False},
+            "subnet": {"conflicts": ["route:eth0:10.42.0.0/24"]},
+        },
+    }
+
+
+def test_hostapd_version_probe_preserves_capability_inference(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        preflight,
+        "_resolve_hostapd_path",
+        lambda: "/opt/vr-hotspot/vendor/hostapd",
+    )
+
+    def run(argv, timeout_s=1.2):
+        calls.append((argv, timeout_s))
+        return 0, "hostapd v2.11-devel\nSAE\nIEEE 802.11ax"
+
+    monkeypatch.setattr(preflight, "_run", run)
+
+    result = preflight._hostapd_caps()
+
+    assert result == {
+        "sae": True,
+        "he": True,
+        "raw": "hostapd v2.11-devel\nSAE\nIEEE 802.11ax",
+    }
+    assert calls == [
+        (
+            ["/opt/vr-hotspot/vendor/hostapd", "-vv"],
+            1.2,
+        )
+    ]
+
+
+def test_hostapd_version_probe_keeps_v_fallback_and_negative_caps(monkeypatch):
+    calls = []
+    monkeypatch.setattr(preflight, "_resolve_hostapd_path", lambda: "/usr/sbin/hostapd")
+
+    def run(argv, timeout_s=1.2):
+        calls.append((argv, timeout_s))
+        if argv[-1] == "-vv":
+            return 1, ""
+        return 0, "hostapd v2.9"
+
+    monkeypatch.setattr(preflight, "_run", run)
+
+    result = preflight._hostapd_caps()
+
+    assert result == {
+        "sae": False,
+        "he": False,
+        "raw": "hostapd v2.9",
+    }
+    assert [argv[-1] for argv, _timeout in calls] == ["-vv", "-v"]
+
+
+def test_hostapd_feature_policy_keeps_unknown_as_warning(monkeypatch):
+    monkeypatch.setattr(
+        preflight,
+        "_hostapd_caps",
+        lambda: {
+            "sae": None,
+            "he": None,
+            "error": "hostapd_not_found",
+        },
+    )
+
+    errors, warnings, details = preflight._check_hostapd_features(
+        "6ghz",
+        "wpa3_sae",
+    )
+
+    assert errors == []
+    assert warnings == ["hostapd_sae_unknown", "hostapd_11ax_unknown"]
+    assert details["error"] == "hostapd_not_found"
+
+
+def test_subnet_probe_preserves_address_and_route_conflict_shapes(monkeypatch):
+    responses = {
+        ("/usr/sbin/ip", "-4", "-o", "addr", "show"): (
+            0,
+            "2: eth0    inet 10.42.0.23/24 brd 10.42.0.255 scope global eth0",
+        ),
+        ("/usr/sbin/ip", "-4", "route", "show"): (
+            0,
+            "\n".join(
+                [
+                    "default via 192.0.2.1 dev eth0",
+                    "10.42.0.0/24 dev eth0 proto kernel",
+                ]
+            ),
+        ),
+    }
+    monkeypatch.setattr(preflight.shutil, "which", lambda name: "/usr/sbin/ip" if name == "ip" else None)
+    monkeypatch.setattr(
+        preflight,
+        "_run",
+        lambda argv: responses[tuple(argv)],
+    )
+
+    errors, warnings, details = preflight._check_subnet_conflicts("10.42.0.1")
+
+    assert errors == ["subnet_conflict"]
+    assert warnings == []
+    assert details == {
+        "conflicts": [
+            "addr:eth0:10.42.0.23",
+            "route:eth0:10.42.0.0/24",
+        ]
+    }


### PR DESCRIPTION
Consolidates existing read-only host/system probing into a reusable boundary without adding Flatpak support, internal Wi-Fi support, daemon rewrites, or new privileged behavior.

What changed:
- Adds `backend/vr_hotspotd/host_probes.py` as a normalized read-only probe boundary.
- Centralizes OS-family, firewall, NetworkManager, iw, AP mode, regulatory, band, 5 GHz, 80 MHz, Wi-Fi 6, concurrency, and default-uplink parsing.
- Reuses the existing OS-release parser.
- Removes duplicated subprocess/default-route/probe parsing logic across inventory, preflight, Wi-Fi probing, platform diagnostics, lifecycle, network tuning, and hostapd engines.
- Adds regression coverage for compatibility behavior.

Behavior intentionally preserved:
- Timeout byte partials are discarded while legacy string partials remain.
- Inventory still uses OS-level `stderr=STDOUT` merging.
- Inventory keeps its legacy multi-section AP-mode parser behavior.
- API payloads, lifecycle behavior, adapter scoring, wlan0 heuristics, installer mapping, hostapd/dnsmasq fallback policies, and NetworkManager/iwd mutation behavior are unchanged.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `307 passed, 4 subtests passed`