### PR TITLE
feat: add preflight diagnostics CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Enter the **API token** shown during installation to access the interface.
 **Diagnostics:**
 - `GET /v1/diagnostics/clients` - Connected clients
 - `GET /v1/diagnostics/preflight` - Canonical read-only host readiness report
+- `vr-hotspot preflight` - Print or export that same canonical report through the authenticated API
 - `POST /v1/diagnostics/ping` - Ping test
 - `POST /v1/diagnostics/ping_under_load` - Performance under load
 - `GET /v1/diagnostics/support_bundle` - Download a sanitized support bundle
@@ -317,6 +318,44 @@ TOKEN=$(sudo awk -F= '/VR_HOTSPOTD_API_TOKEN/{print $2}' /etc/vr-hotspot/env)
 # Check status
 curl -s "http://127.0.0.1:8732/v1/status?include_logs=1" -H "X-Api-Token: $TOKEN" | python3 -m json.tool
 ```
+
+### Preflight Diagnostics
+
+Installed systems provide a read-only CLI that calls the existing authenticated
+preflight endpoint. Running it with `sudo` lets it read the protected daemon
+token from `/etc/vr-hotspot/env` without putting the token in shell history or
+process arguments:
+
+```bash
+# Print the canonical report as formatted JSON
+sudo /var/lib/vr-hotspot/bin/vr-hotspot preflight
+
+# Export through stdout into a new private, user-owned directory and file
+report_dir="$(mktemp -d "${TMPDIR:-/tmp}/vr-hotspot-preflight.XXXXXX")"
+(umask 077; sudo /var/lib/vr-hotspot/bin/vr-hotspot preflight \
+  > "$report_dir/preflight.json")
+```
+
+`--output PATH` is also available when the CLI should create the file directly.
+It creates a new file with mode `0600` and refuses existing paths and symlinks;
+choose a private destination rather than a predictable shared `/tmp` filename.
+
+For development or custom API locations, use `--api-url` and provide the token
+through `VR_HOTSPOTD_API_TOKEN` or stdin. For a one-off prompt that does not echo
+the token or store it in shell history:
+
+```bash
+read -rsp 'VR Hotspot API token: ' API_TOKEN && echo
+printf '%s\n' "$API_TOKEN" | vr-hotspot preflight \
+  --api-url http://127.0.0.1:8732 --token-stdin
+unset API_TOKEN
+```
+
+The `--token` option is available for automation compatibility, but its value is
+visible in process arguments and may be retained in shell history; prefer the
+protected env file, environment variable, or `--token-stdin`. The CLI rejects
+redirects and only performs `GET /v1/diagnostics/preflight`; it does not probe
+the host directly or mutate hotspot state.
 
 ### Common Issues
 

--- a/backend/scripts/install.sh
+++ b/backend/scripts/install.sh
@@ -119,6 +119,16 @@ install_autostart_helper() {
   install -m 755 "$wait_src" "$BIN_DIR/wait-healthy.sh"
 }
 
+install_cli_launcher() {
+  local cli_src="$VENV_DIR/bin/vr-hotspot"
+  local cli_dst="$BIN_DIR/vr-hotspot"
+
+  [[ -x "$cli_src" ]] || die "Installed CLI not found: $cli_src"
+  log "Installing read-only CLI launcher -> $cli_dst"
+  install -d -m 755 "$BIN_DIR"
+  ln -sfn "$cli_src" "$cli_dst"
+}
+
 install_systemd_units() {
   local template_dir="$BACKEND_SRC/systemd"
   local unit template tmp
@@ -216,6 +226,7 @@ log "Installing Python dependencies..."
 "$VENV_DIR/bin/pip" install --no-cache-dir -U pip &>/dev/null
 "$VENV_DIR/bin/pip" install --no-cache-dir "$INSTALL_DIR" &>/dev/null
 
+install_cli_launcher
 install_autostart_helper
 install_systemd_units
 cleanup_legacy_systemd_units

--- a/backend/vr_hotspotd/cli.py
+++ b/backend/vr_hotspotd/cli.py
@@ -1,0 +1,444 @@
+"""Read-only command-line client for the VR Hotspot daemon API."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import getpass
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any, Dict, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import build_opener, HTTPRedirectHandler, Request
+import uuid
+
+
+DEFAULT_API_URL = "http://127.0.0.1:8732"
+DEFAULT_ENV_FILE = "/etc/vr-hotspot/env"
+PREFLIGHT_PATH = "/v1/diagnostics/preflight"
+
+_ENV_KEYS = {
+    "VR_HOTSPOTD_API_TOKEN",
+    "VR_HOTSPOTD_API_URL",
+    "VR_HOTSPOTD_HOST",
+    "VR_HOTSPOTD_PORT",
+}
+
+
+class CLIError(RuntimeError):
+    """Expected client-side or API error suitable for concise terminal output."""
+
+
+def _redirect_error(status: int) -> CLIError:
+    return CLIError(
+        f"API request was redirected (HTTP {status}); redirects are not allowed for "
+        "vr-hotspot preflight."
+    )
+
+
+class _RejectRedirectHandler(HTTPRedirectHandler):
+    """Reject every redirect before urllib can forward authentication headers."""
+
+    def _reject(self, _request, response, status, _message, _headers):
+        try:
+            response.close()
+        except OSError:
+            pass
+        raise _redirect_error(status)
+
+    http_error_301 = _reject
+    http_error_302 = _reject
+    http_error_303 = _reject
+    http_error_307 = _reject
+    http_error_308 = _reject
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    """Read the daemon's simple KEY=VALUE file without executing shell code."""
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (FileNotFoundError, PermissionError):
+        return {}
+    except OSError as exc:
+        raise CLIError(f"Unable to read environment file {path}: {exc}") from exc
+
+    values: Dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        key, separator, raw_value = line.partition("=")
+        key = key.strip()
+        if not separator or key not in _ENV_KEYS:
+            continue
+        value = raw_value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _load_client_settings(env_file: Path) -> Dict[str, str]:
+    settings = _read_env_file(env_file)
+    for key in _ENV_KEYS:
+        if key in os.environ:
+            settings[key] = os.environ[key]
+    return settings
+
+
+def _validated_api_url(value: str) -> str:
+    candidate = (value or "").strip().rstrip("/")
+    parsed = urlsplit(candidate)
+    try:
+        hostname = parsed.hostname
+        parsed.port
+    except ValueError as exc:
+        raise CLIError("API URL contains an invalid host or port.") from exc
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not hostname:
+        raise CLIError("API URL must be an absolute http:// or https:// URL.")
+    if parsed.username is not None or parsed.password is not None:
+        raise CLIError("API URL must not include user credentials.")
+    if parsed.path not in {"", "/"}:
+        raise CLIError("API URL must contain only the origin, without a path.")
+    if parsed.query or parsed.fragment:
+        raise CLIError("API URL must not include a query string or fragment.")
+    return candidate
+
+
+def _api_url_from_settings(settings: Mapping[str, str]) -> str:
+    configured_url = settings.get("VR_HOTSPOTD_API_URL")
+    if configured_url:
+        return _validated_api_url(configured_url)
+
+    host = (settings.get("VR_HOTSPOTD_HOST") or "127.0.0.1").strip()
+    port_text = (settings.get("VR_HOTSPOTD_PORT") or "8732").strip()
+    try:
+        port = int(port_text)
+    except ValueError as exc:
+        raise CLIError(f"Invalid VR_HOTSPOTD_PORT value: {port_text}") from exc
+    if not 1 <= port <= 65535:
+        raise CLIError(f"Invalid VR_HOTSPOTD_PORT value: {port_text}")
+
+    if host in {"", "0.0.0.0", "*"}:
+        host = "127.0.0.1"
+    elif host in {"::", "[::]"}:
+        host = "::1"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return _validated_api_url(f"http://{host}:{port}")
+
+
+def _api_error_detail(raw: bytes, *, secret: str = "") -> Optional[str]:
+    try:
+        payload = json.loads(raw.decode("utf-8", "replace"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    result_code = payload.get("result_code")
+    detail = str(result_code) if result_code else None
+    if detail and secret and secret in detail:
+        return None
+    return detail
+
+
+def _contains_secret(value: Any, secret: str) -> bool:
+    if not secret:
+        return False
+    if isinstance(value, str):
+        return secret in value
+    if isinstance(value, Mapping):
+        return any(
+            _contains_secret(key, secret) or _contains_secret(item, secret)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret(item, secret) for item in value)
+    return False
+
+
+def _redacted_error_text(value: object, secret: str) -> str:
+    try:
+        text = str(value)
+    except Exception:
+        text = "unexpected error"
+    return text.replace(secret, "[redacted]") if secret else text
+
+
+def _validated_token(value: str) -> str:
+    if not isinstance(value, str):
+        raise CLIError("API token must be text.")
+    if any(ord(character) < 0x20 or ord(character) > 0x7E for character in value):
+        raise CLIError("API token contains characters that are unsafe for an HTTP header.")
+    return value
+
+
+def _open_preflight_request(request: Request, *, timeout: float):
+    opener = build_opener(_RejectRedirectHandler())
+    return opener.open(request, timeout=timeout)
+
+
+def _transport_cli_error(
+    exc: Exception,
+    *,
+    endpoint: str,
+    token: str,
+) -> CLIError:
+    if isinstance(exc, HTTPError):
+        try:
+            raw = exc.read()
+        except Exception as read_exc:
+            safe_error = _redacted_error_text(read_exc, token)
+            return CLIError(f"Unable to read the VR Hotspot API response: {safe_error}")
+        if 300 <= exc.code < 400:
+            return _redirect_error(exc.code)
+        detail = _api_error_detail(raw, secret=token)
+        suffix = f": {detail}" if detail else ""
+        auth_hint = (
+            " Use VR_HOTSPOTD_API_TOKEN or --token-stdin, or run with permission "
+            f"to read {DEFAULT_ENV_FILE}."
+            if exc.code in {401, 403}
+            else ""
+        )
+        return CLIError(f"API request failed (HTTP {exc.code}{suffix}).{auth_hint}")
+    if isinstance(exc, URLError):
+        reason = getattr(exc, "reason", exc)
+        safe_reason = _redacted_error_text(reason, token)
+        return CLIError(f"Unable to reach the VR Hotspot API at {endpoint}: {safe_reason}")
+    if isinstance(exc, TimeoutError):
+        return CLIError(f"Timed out waiting for the VR Hotspot API at {endpoint}.")
+    if isinstance(exc, OSError):
+        safe_error = _redacted_error_text(exc, token)
+        return CLIError(f"Unable to read the VR Hotspot API response: {safe_error}")
+    return CLIError(
+        "Unable to complete the VR Hotspot API request due to an unexpected "
+        f"transport error ({type(exc).__name__})."
+    )
+
+
+def fetch_preflight_report(
+    api_url: str,
+    *,
+    token: str = "",
+    timeout: float = 15.0,
+) -> Dict[str, Any]:
+    """Fetch and return only the canonical report from the API envelope."""
+
+    endpoint = _validated_api_url(api_url) + PREFLIGHT_PATH
+    token = _validated_token(token)
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "vr-hotspot-cli",
+        "X-Correlation-Id": f"cli-preflight-{uuid.uuid4()}",
+    }
+    if token:
+        headers["X-Api-Token"] = token
+    transport_exc: Optional[Exception] = None
+    try:
+        request = Request(endpoint, headers=headers, method="GET")
+        with _open_preflight_request(request, timeout=timeout) as response:
+            status = int(getattr(response, "status", 200))
+            raw = response.read()
+    except CLIError:
+        raise
+    except Exception as exc:
+        transport_exc = exc
+    if transport_exc is not None:
+        transport_error = _transport_cli_error(
+            transport_exc,
+            endpoint=endpoint,
+            token=token,
+        )
+        transport_exc = None
+        raise transport_error
+
+    if 300 <= status < 400:
+        raise _redirect_error(status)
+    if status != 200:
+        detail = _api_error_detail(raw, secret=token)
+        suffix = f": {detail}" if detail else ""
+        raise CLIError(f"API request failed (HTTP {status}{suffix}).")
+
+    invalid_json = False
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        invalid_json = True
+    if invalid_json:
+        raise CLIError("The VR Hotspot API returned invalid JSON.")
+    if not isinstance(payload, Mapping):
+        raise CLIError("The VR Hotspot API returned an invalid response envelope.")
+    result_code = payload.get("result_code")
+    if result_code not in (None, "ok"):
+        safe_result_code = _redacted_error_text(result_code, token)
+        raise CLIError(f"The VR Hotspot API returned {safe_result_code}.")
+    report = payload.get("data")
+    if not isinstance(report, Mapping):
+        raise CLIError("The VR Hotspot API response did not contain a preflight report.")
+    if _contains_secret(report, token):
+        raise CLIError(
+            "The VR Hotspot API returned a report containing the authentication token; "
+            "refusing to print or export it."
+        )
+    return dict(report)
+
+
+def _positive_timeout(value: str) -> float:
+    try:
+        timeout = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be a number") from exc
+    if timeout <= 0:
+        raise argparse.ArgumentTypeError("timeout must be greater than zero")
+    return timeout
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vr-hotspot",
+        description="Read-only client for the VR Hotspot daemon API.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    preflight_parser = commands.add_parser(
+        "preflight",
+        help="Print or export the daemon's canonical preflight diagnostics report.",
+    )
+    preflight_parser.add_argument(
+        "--api-url",
+        help=f"Daemon API base URL (default: {DEFAULT_API_URL}).",
+    )
+    token_group = preflight_parser.add_mutually_exclusive_group()
+    token_group.add_argument(
+        "--token",
+        metavar="TOKEN",
+        help=(
+            "API token (warning: visible in process arguments and shell history; prefer "
+            "the daemon env file, VR_HOTSPOTD_API_TOKEN, or --token-stdin)."
+        ),
+    )
+    token_group.add_argument(
+        "--token-stdin",
+        action="store_true",
+        help="Read the API token from stdin without echoing it on an interactive terminal.",
+    )
+    preflight_parser.add_argument(
+        "--env-file",
+        default=os.environ.get("VR_HOTSPOTD_ENV_FILE", DEFAULT_ENV_FILE),
+        help=f"Daemon environment file (default: {DEFAULT_ENV_FILE}).",
+    )
+    preflight_parser.add_argument(
+        "--output",
+        default="-",
+        metavar="PATH",
+        help=(
+            "Write canonical report JSON to a new mode-0600 PATH; existing paths and "
+            "symlinks are refused. Use - for stdout."
+        ),
+    )
+    preflight_parser.add_argument(
+        "--timeout",
+        type=_positive_timeout,
+        default=15.0,
+        metavar="SECONDS",
+        help="HTTP request timeout (default: 15).",
+    )
+    return parser
+
+
+def _read_token_from_stdin() -> str:
+    read_failed = False
+    try:
+        if sys.stdin.isatty():
+            token = getpass.getpass("VR Hotspot API token: ", stream=sys.stderr)
+        else:
+            token = sys.stdin.readline().rstrip("\r\n")
+    except (EOFError, OSError, UnicodeError):
+        read_failed = True
+    if read_failed:
+        raise CLIError("Unable to read the API token from stdin.")
+    if not token:
+        raise CLIError("No API token was provided on stdin.")
+    return token
+
+
+def _write_new_private_file(path: Path, rendered: str, *, token: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    safe_path = _redacted_error_text(path, token)
+    descriptor: Optional[int] = None
+    write_error: Optional[CLIError] = None
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        os.fchmod(descriptor, 0o600)
+        output_file = os.fdopen(descriptor, "w", encoding="utf-8")
+        descriptor = None
+        with output_file:
+            output_file.write(rendered)
+    except FileExistsError:
+        write_error = CLIError(
+            "Output path already exists or is a symlink; refusing to overwrite it: "
+            f"{safe_path}"
+        )
+    except OSError as exc:
+        if exc.errno in {errno.EEXIST, errno.ELOOP}:
+            write_error = CLIError(
+                "Output path already exists or is a symlink; refusing to overwrite it: "
+                f"{safe_path}"
+            )
+        else:
+            safe_error = _redacted_error_text(exc, token)
+            write_error = CLIError(
+                f"Unable to write preflight report to {safe_path}: {safe_error}"
+            )
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    if write_error is not None:
+        raise write_error
+
+
+def _run_preflight(args: argparse.Namespace) -> int:
+    settings = _load_client_settings(Path(args.env_file))
+    api_url = _validated_api_url(args.api_url) if args.api_url else _api_url_from_settings(settings)
+    if args.token_stdin:
+        token = _read_token_from_stdin()
+    elif args.token is not None:
+        token = args.token
+    else:
+        token = settings.get("VR_HOTSPOTD_API_TOKEN", "")
+    report = fetch_preflight_report(api_url, token=token, timeout=args.timeout)
+    rendered = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+
+    if args.output == "-":
+        sys.stdout.write(rendered)
+        return 0
+
+    output_path = Path(args.output)
+    _write_new_private_file(output_path, rendered, token=token)
+    safe_output_path = _redacted_error_text(output_path, token)
+    sys.stderr.write(f"Wrote canonical preflight report to {safe_output_path}\n")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "preflight":
+            return _run_preflight(args)
+    except CLIError as exc:
+        parser.exit(1, f"vr-hotspot: error: {exc}\n")
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.sh
+++ b/install.sh
@@ -727,6 +727,7 @@ show_completion() {
     echo -e "${CYAN}🔧 ${BOLD}Useful Commands:${NC}"
     echo -e "   - Status:      ${BOLD}sudo systemctl status $DAEMON_UNIT${NC}"
     echo -e "   - Logs:        ${BOLD}sudo journalctl -u $DAEMON_UNIT -f${NC}"
+    echo -e "   - Preflight:   ${BOLD}sudo $INSTALL_ROOT/bin/vr-hotspot preflight${NC}"
     echo -e "   - Uninstall:   ${BOLD}sudo bash $APP_DIR/uninstall.sh${NC}"
     echo
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "VR-grade Wi-Fi hotspot daemon for SteamOS/Linux"
 requires-python = ">=3.9"
 
 [project.scripts]
+vr-hotspot = "vr_hotspotd.cli:main"
 vr-hotspotd = "vr_hotspotd.main:main"
 
 [tool.setuptools]

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -1,0 +1,714 @@
+import io
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import shlex
+import stat
+import subprocess
+import threading
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from vr_hotspotd import cli
+
+
+class _FakeResponse:
+    def __init__(self, payload=None, *, status=200, raw=None):
+        self.status = status
+        self._raw = raw if raw is not None else json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+@pytest.fixture(autouse=True)
+def clear_cli_environment(monkeypatch):
+    for key in (*cli._ENV_KEYS, "VR_HOTSPOTD_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _mocked_open(monkeypatch, payload, seen, *, status=200, raw=None):
+    def open_request(request, *, timeout):
+        seen["method"] = request.get_method()
+        seen["url"] = request.full_url
+        seen["headers"] = {key.lower(): value for key, value in request.header_items()}
+        seen["timeout"] = timeout
+        return _FakeResponse(payload, status=status, raw=raw)
+
+    monkeypatch.setattr(cli, "_open_preflight_request", open_request)
+
+
+def _mocked_http_error(monkeypatch, status, result_code):
+    raw = json.dumps({"result_code": result_code}).encode("utf-8")
+
+    def reject(request, *, timeout):
+        assert timeout == 15.0
+        raise HTTPError(
+            request.full_url,
+            status,
+            "mocked error",
+            {},
+            io.BytesIO(raw),
+        )
+
+    monkeypatch.setattr(cli, "_open_preflight_request", reject)
+
+
+def _missing_env_args(tmp_path):
+    return ["--env-file", str(tmp_path / "missing-env")]
+
+
+def test_preflight_command_performs_authenticated_get_only_to_canonical_endpoint(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "authenticated-test-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    report = {
+        "schema_version": 1,
+        "overall_readiness": "warning",
+        "issues": [{"code": "default_uplink_not_detected", "severity": "warning"}],
+    }
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {
+            "correlation_id": "test-cid",
+            "result_code": "ok",
+            "warnings": [],
+            "data": report,
+        },
+        seen,
+    )
+
+    result = cli.main(
+        [
+            "preflight",
+            "--api-url",
+            "http://127.0.0.1:9900",
+            *_missing_env_args(tmp_path),
+            "--timeout",
+            "3.5",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == report
+    assert "correlation_id" not in json.loads(captured.out)
+    assert captured.err == ""
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/diagnostics/preflight"
+    assert seen["headers"]["x-api-token"] == secret
+    assert seen["timeout"] == 3.5
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_uses_explicit_argument_token_without_disclosing_it(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "explicit-argument-token"
+    report = {"schema_version": 1, "overall_readiness": "ready", "issues": []}
+    seen = {}
+    _mocked_open(monkeypatch, {"result_code": "ok", "data": report}, seen)
+
+    result = cli.main(
+        [
+            "preflight",
+            "--token",
+            secret,
+            *_missing_env_args(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == report
+    assert captured.err == ""
+    assert seen["headers"]["x-api-token"] == secret
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+@pytest.mark.parametrize(
+    "secret",
+    (
+        pytest.param("unsafe\rheader", id="carriage-return"),
+        pytest.param("unsafe\nheader", id="line-feed"),
+        pytest.param("unsafe\x00header", id="nul"),
+        pytest.param("unsafe\x1fheader", id="control-character"),
+        pytest.param("unsafe\x7fheader", id="delete-character"),
+        pytest.param("unsafe-\N{SNOWMAN}-header", id="non-ascii"),
+    ),
+)
+def test_preflight_command_rejects_unsafe_header_tokens_without_disclosure(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    secret,
+):
+    called = False
+
+    def must_not_open(_request, *, timeout):
+        nonlocal called
+        called = True
+        raise AssertionError(f"unexpected request with timeout {timeout}")
+
+    monkeypatch.setattr(cli, "_open_preflight_request", must_not_open)
+    output = tmp_path / "must-not-exist.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                "--token",
+                secret,
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "unsafe for an HTTP header" in captured.err
+    assert called is False
+    assert not output.exists()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_unexpected_transport_error_is_sanitized_without_exception_chain(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "unexpected-transport-token"
+
+    def unexpected_failure(_request, *, timeout):
+        assert timeout == 15.0
+        raise ValueError(f"invalid header value containing {secret}")
+
+    monkeypatch.setattr(cli, "_open_preflight_request", unexpected_failure)
+    output = tmp_path / "must-not-exist.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                "--token",
+                secret,
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    cli_error = exc_info.value.__context__
+    assert exc_info.value.code == 1
+    assert "unexpected transport error (ValueError)" in captured.err
+    assert isinstance(cli_error, cli.CLIError)
+    assert cli_error.__cause__ is None
+    assert cli_error.__context__ is None
+    assert not output.exists()
+    assert secret not in str(cli_error)
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_url_error_reason_is_redacted_without_retaining_exception_chain(monkeypatch):
+    secret = "url-error-reason-token"
+
+    def unavailable(_request, *, timeout):
+        assert timeout == 15.0
+        raise URLError(RuntimeError(f"transport failure containing {secret}"))
+
+    monkeypatch.setattr(cli, "_open_preflight_request", unavailable)
+
+    with pytest.raises(cli.CLIError) as exc_info:
+        cli.fetch_preflight_report(cli.DEFAULT_API_URL, token=secret)
+
+    error = exc_info.value
+    assert "transport failure containing [redacted]" in str(error)
+    assert secret not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+def test_preflight_command_exports_report_using_protected_service_env_file(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "protected-file-token"
+    env_file = tmp_path / "vr-hotspot.env"
+    env_file.write_text(
+        "\n".join(
+            (
+                f'VR_HOTSPOTD_API_TOKEN="{secret}"',
+                "VR_HOTSPOTD_HOST=0.0.0.0",
+                "VR_HOTSPOTD_PORT=9876",
+            )
+        ),
+        encoding="utf-8",
+    )
+    report = {"schema_version": 1, "overall_readiness": "ready", "issues": []}
+    seen = {}
+    _mocked_open(monkeypatch, {"result_code": "ok", "data": report}, seen)
+    output = tmp_path / "preflight.json"
+
+    result = cli.main(
+        [
+            "preflight",
+            "--env-file",
+            str(env_file),
+            "--output",
+            str(output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    exported = output.read_text(encoding="utf-8")
+    assert result == 0
+    assert captured.out == ""
+    assert "Wrote canonical preflight report" in captured.err
+    assert json.loads(exported) == report
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    assert seen["url"] == "http://127.0.0.1:9876/v1/diagnostics/preflight"
+    assert seen["headers"]["x-api-token"] == secret
+    assert secret not in captured.out
+    assert secret not in captured.err
+    assert secret not in exported
+
+
+def test_preflight_command_reads_token_from_stdin_without_echoing_it(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "stdin-only-token"
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(f"{secret}\n"))
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"result_code": "ok", "data": {"schema_version": 1, "issues": []}},
+        seen,
+    )
+
+    result = cli.main(
+        [
+            "preflight",
+            "--token-stdin",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert seen["headers"]["x-api-token"] == secret
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_hides_interactive_stdin_token(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "hidden-interactive-token"
+
+    class InteractiveInput:
+        @staticmethod
+        def isatty():
+            return True
+
+    monkeypatch.setattr(cli.sys, "stdin", InteractiveInput())
+    monkeypatch.setattr(cli.getpass, "getpass", lambda _prompt, *, stream: secret)
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"result_code": "ok", "data": {"schema_version": 1, "issues": []}},
+        seen,
+    )
+
+    result = cli.main(
+        [
+            "preflight",
+            "--token-stdin",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert seen["headers"]["x-api-token"] == secret
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_rejects_redirect_without_forwarding_token(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "redirect-guard-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    requests = []
+
+    class RedirectHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests.append(
+                {
+                    "path": self.path,
+                    "token": self.headers.get("X-Api-Token"),
+                }
+            )
+            if self.path == cli.PREFLIGHT_PATH:
+                self.send_response(302)
+                self.send_header("Location", "/redirect-target")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"result_code":"ok","data":{}}')
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(
+                [
+                    "preflight",
+                    "--api-url",
+                    f"http://127.0.0.1:{server.server_port}",
+                    *_missing_env_args(tmp_path),
+                ]
+            )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "redirected (HTTP 302)" in captured.err
+    assert "redirects are not allowed" in captured.err
+    assert requests == [{"path": cli.PREFLIGHT_PATH, "token": secret}]
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_reports_service_unavailable(monkeypatch, tmp_path, capsys):
+    secret = "unavailable-service-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+
+    def unavailable(_request, *, timeout):
+        assert timeout == 15.0
+        raise URLError(ConnectionRefusedError("mocked service unavailable"))
+
+    monkeypatch.setattr(cli, "_open_preflight_request", unavailable)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", *_missing_env_args(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "Unable to reach the VR Hotspot API" in captured.err
+    assert "mocked service unavailable" in captured.err
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_reports_auth_failure_without_token_leak(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "auth-failure-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    _mocked_http_error(monkeypatch, 401, "unauthorized")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", *_missing_env_args(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "HTTP 401: unauthorized" in captured.err
+    assert "VR_HOTSPOTD_API_TOKEN or --token-stdin" in captured.err
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_reports_generic_non_200(monkeypatch, tmp_path, capsys):
+    _mocked_http_error(monkeypatch, 500, "internal_error")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", *_missing_env_args(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "API request failed (HTTP 500: internal_error)" in captured.err
+    assert captured.out == ""
+
+
+def test_preflight_command_rejects_malformed_json(monkeypatch, tmp_path, capsys):
+    seen = {}
+    _mocked_open(monkeypatch, None, seen, raw=b"{not-json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", *_missing_env_args(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "returned invalid JSON" in captured.err
+    assert captured.out == ""
+
+
+def test_preflight_command_reports_unwritable_output_path(monkeypatch, tmp_path, capsys):
+    secret = "output-error-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"result_code": "ok", "data": {"schema_version": 1, "issues": []}},
+        seen,
+    )
+    output = tmp_path / "missing-parent" / "preflight.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "Unable to write preflight report" in captured.err
+    assert not output.exists()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_does_not_overwrite_existing_output(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "existing-output-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"result_code": "ok", "data": {"schema_version": 1, "issues": []}},
+        seen,
+    )
+    output = tmp_path / f"{secret}.json"
+    output.write_text("keep-existing-content\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "already exists or is a symlink" in captured.err
+    assert "refusing to overwrite" in captured.err
+    assert output.read_text(encoding="utf-8") == "keep-existing-content\n"
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_rejects_symlink_output_without_touching_target(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "symlink-output-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"result_code": "ok", "data": {"schema_version": 1, "issues": []}},
+        seen,
+    )
+    target = tmp_path / "target.json"
+    target.write_text("keep-target-content\n", encoding="utf-8")
+    output = tmp_path / "preflight.json"
+    output.symlink_to(target)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "already exists or is a symlink" in captured.err
+    assert output.is_symlink()
+    assert target.read_text(encoding="utf-8") == "keep-target-content\n"
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_refuses_report_that_contains_authentication_token(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    secret = "reflected-authentication-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {
+            "result_code": "ok",
+            "data": {"schema_version": 1, "unexpected_secret": secret},
+        },
+        seen,
+    )
+    output = tmp_path / "must-not-exist.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                *_missing_env_args(tmp_path),
+                "--output",
+                str(output),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "report containing the authentication token" in captured.err
+    assert not output.exists()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_preflight_command_rejects_api_base_paths_before_request(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    called = False
+
+    def must_not_open(_request, *, timeout):
+        nonlocal called
+        called = True
+        raise AssertionError(f"unexpected request with timeout {timeout}")
+
+    monkeypatch.setattr(cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(
+            [
+                "preflight",
+                "--api-url",
+                "http://127.0.0.1:8732/not-the-preflight-endpoint",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "without a path" in captured.err
+    assert called is False
+
+
+def test_preflight_help_warns_about_argument_token_and_offers_stdin(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", "--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "--token-stdin" in captured.out
+    normalized_help = " ".join(captured.out.split())
+    assert "visible in process arguments and shell history" in normalized_help
+    assert "existing paths and symlinks are refused" in normalized_help
+
+
+def test_cli_entry_points_and_installed_launcher_behavior_are_preserved(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    installer = (root / "backend" / "scripts" / "install.sh").read_text(encoding="utf-8")
+
+    assert 'vr-hotspot = "vr_hotspotd.cli:main"' in pyproject
+    assert 'vr-hotspotd = "vr_hotspotd.main:main"' in pyproject
+    start = installer.index("install_cli_launcher() {")
+    end = installer.index("\n}\n", start) + 2
+    launcher_function = installer[start:end]
+    assert 'local cli_src="$VENV_DIR/bin/vr-hotspot"' in launcher_function
+    assert 'local cli_dst="$BIN_DIR/vr-hotspot"' in launcher_function
+    assert 'ln -sfn "$cli_src" "$cli_dst"' in launcher_function
+    pip_install = installer.index('"$VENV_DIR/bin/pip" install --no-cache-dir "$INSTALL_DIR"')
+    launcher_call = installer.index("\ninstall_cli_launcher\n", pip_install)
+    daemon_setup = installer.index("\ninstall_systemd_units\n", launcher_call)
+    assert pip_install < launcher_call < daemon_setup
+
+    venv_cli = tmp_path / "venv" / "bin" / "vr-hotspot"
+    venv_cli.parent.mkdir(parents=True)
+    venv_cli.write_text(
+        "#!/usr/bin/env bash\nprintf 'cli-args=%s\\n' \"$*\"\n",
+        encoding="utf-8",
+    )
+    venv_cli.chmod(0o755)
+    bin_dir = tmp_path / "bin"
+    command = "\n".join(
+        (
+            "set -euo pipefail",
+            f"VENV_DIR={shlex.quote(str(tmp_path / 'venv'))}",
+            f"BIN_DIR={shlex.quote(str(bin_dir))}",
+            "log() { :; }",
+            'die() { printf "%s\\n" "$*" >&2; exit 1; }',
+            launcher_function,
+            "install_cli_launcher",
+            '"$BIN_DIR/vr-hotspot" preflight --help',
+        )
+    )
+
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    installed_cli = bin_dir / "vr-hotspot"
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "cli-args=preflight --help\n"
+    assert installed_cli.is_symlink()
+    assert installed_cli.resolve() == venv_cli


### PR DESCRIPTION
Adds `vr-hotspot preflight` CLI support for the existing authenticated `GET /v1/diagnostics/preflight` endpoint.

What changed:
- Adds a `vr-hotspot preflight` command.
- Supports printing the canonical preflight report to stdout.
- Supports secure JSON export with `--output`.
- Adds `--token-stdin` for safer token input.
- Keeps `--token` available with explicit shell-history/process-argument warnings.
- Installs a `vr-hotspot` launcher at `/var/lib/vr-hotspot/bin/vr-hotspot`.
- Preserves the existing `vr-hotspotd` daemon entry point.

Security behavior:
- Rejects redirects so `X-Api-Token` is never forwarded to another origin/path.
- Calls exactly `/v1/diagnostics/preflight`.
- Validates token header safety before request construction.
- Redacts tokens from errors.
- Refuses reflected-token reports.
- Creates `--output` files with exclusive creation and mode `0600`.
- Refuses existing output files and symlinks.

Intentionally deferred:
- Web UI diagnostics tab.
- Flatpak packaging.
- Internal Wi-Fi support.
- Lifecycle/start gating.
- New probes.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `345 passed, 4 subtests passed`