### PR TITLE
feat: add preflight diagnostics Web UI

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -200,6 +200,9 @@
           <li class="nav-item" data-tab="telemetry">
             <span class="icon">📈</span> Telemetry
           </li>
+          <li class="nav-item" data-tab="diagnostics">
+            <span class="icon">🩺</span> Diagnostics
+          </li>
           <li class="nav-item" data-tab="logs">
             <span class="icon">📜</span> Logs
           </li>
@@ -717,6 +720,96 @@
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+
+        <!-- Tab: Diagnostics -->
+        <div id="tab-diagnostics" class="tab-pane">
+          <div class="preflight-page">
+            <div class="preflight-header">
+              <div>
+                <h2>Preflight Diagnostics</h2>
+                <div class="small faded mt-6">Read-only readiness report collected on demand.</div>
+              </div>
+              <div class="action-group">
+                <button class="btn secondary" id="btnRefreshPreflight" type="button">Refresh</button>
+                <button class="btn secondary" id="btnExportPreflight" type="button" disabled>Export JSON</button>
+              </div>
+            </div>
+
+            <div id="preflightStatus" class="preflight-status" data-state="idle" role="status" aria-live="polite">
+              Open this view or select Refresh to collect the canonical preflight report.
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h2>Readiness &amp; Host Summary</h2>
+                <div id="preflightReadiness" class="preflight-readiness" data-readiness="unknown">Not collected</div>
+              </div>
+              <div class="card-body">
+                <div class="kv-grid preflight-summary-grid">
+                  <div class="kv-item">
+                    <div class="kv-label">Selected adapter</div>
+                    <div class="kv-value" id="preflightSelectedAdapter">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">Default route / uplink</div>
+                    <div class="kv-value" id="preflightUplink">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">Platform</div>
+                    <div class="kv-value" id="preflightPlatform">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">Firewall</div>
+                    <div class="kv-value" id="preflightFirewall">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">NetworkManager</div>
+                    <div class="kv-value" id="preflightNetworkManager">--</div>
+                  </div>
+                  <div class="kv-item">
+                    <div class="kv-label">iwd</div>
+                    <div class="kv-value" id="preflightIwd">--</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="preflight-issue-grid">
+              <div class="card">
+                <div class="card-header">
+                  <h2>Blocking Issues</h2>
+                </div>
+                <div class="card-body">
+                  <ul id="preflightBlockingIssues" class="preflight-list"></ul>
+                </div>
+              </div>
+              <div class="card">
+                <div class="card-header">
+                  <h2>Warnings</h2>
+                </div>
+                <div class="card-body">
+                  <ul id="preflightWarningIssues" class="preflight-list"></ul>
+                </div>
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="card-header">
+                <h2>Recommended Actions</h2>
+              </div>
+              <div class="card-body">
+                <ol id="preflightActions" class="preflight-list preflight-actions"></ol>
+              </div>
+            </div>
+
+            <details class="debug-accordion preflight-raw">
+              <summary>Raw canonical report JSON</summary>
+              <div class="accordion-body">
+                <pre id="preflightRawJson" class="mono-box code-block preflight-raw-json"></pre>
+              </div>
+            </details>
           </div>
         </div>
 

--- a/assets/ui.css
+++ b/assets/ui.css
@@ -1236,6 +1236,143 @@ canvas {
   min-height: 18px;
 }
 
+/* On-demand preflight diagnostics */
+.preflight-page {
+  width: min(100%, 1000px);
+  margin: 0 auto;
+  display: grid;
+  gap: 18px;
+}
+
+.preflight-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.preflight-header h2 {
+  color: var(--text-main);
+  font-size: 22px;
+}
+
+.preflight-status {
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.preflight-status[data-state="loading"] {
+  border-color: rgba(0, 243, 255, 0.35);
+  color: var(--accent-primary);
+}
+
+.preflight-status[data-state="success"] {
+  border-color: rgba(0, 255, 157, 0.35);
+  color: var(--success);
+}
+
+.preflight-status[data-state="error"] {
+  border-color: rgba(255, 0, 85, 0.45);
+  color: var(--danger);
+}
+
+.preflight-readiness {
+  padding: 4px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.preflight-readiness[data-readiness="ready"] {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.preflight-readiness[data-readiness="warning"] {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.preflight-readiness[data-readiness="blocked"] {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.preflight-summary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.preflight-issue-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.preflight-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.preflight-list-item {
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+}
+
+.preflight-list-message {
+  color: var(--text-main);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.preflight-list-code {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.preflight-list-empty {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.preflight-raw {
+  margin-top: 0;
+}
+
+.preflight-raw-json {
+  max-height: 520px;
+  margin: 0;
+  overflow: auto;
+}
+
+@media (max-width: 700px) {
+  .preflight-issue-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .preflight-header .action-group,
+  .preflight-header .btn {
+    width: 100%;
+  }
+}
+
 .mini-select {
   width: auto;
   min-width: 68px;

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -1,4 +1,5 @@
 const BASE = '';
+const PREFLIGHT_REPORT_PATH = '/v1/diagnostics/preflight';
 const STORE = (function () {
   try { localStorage.setItem('__t', '1'); localStorage.removeItem('__t'); return localStorage; } catch { return sessionStorage; }
 })();
@@ -356,6 +357,8 @@ let passphraseDirty = false;
 let lastCfg = null;
 let lastAdapters = null;
 let lastStatus = null;
+let lastPreflightReport = null;
+let preflightRequestInFlight = false;
 
 const CFG_IDS = [
   "ssid", "wpa2_passphrase", "band_preference", "ap_security", "channel_6g", "country", "country_sel",
@@ -1988,6 +1991,228 @@ async function downloadSupportBundle() {
   }
 }
 
+// --- Canonical preflight diagnostics view
+function isRecord(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function canonicalPreflightReportFromPayload(payload) {
+  if (!isRecord(payload) || !isRecord(payload.data)) return null;
+  const report = payload.data;
+  const readiness = report.overall_readiness;
+  if (report.schema_version !== 1) return null;
+  if (!['ready', 'warning', 'blocked'].includes(readiness)) return null;
+  if (!Array.isArray(report.issues) || !Array.isArray(report.recommended_actions)) return null;
+  return report;
+}
+
+function preflightDisplayValue(value, fallback = 'Not reported') {
+  if (value === null || value === undefined) return fallback;
+  const text = String(value).trim();
+  return text || fallback;
+}
+
+function preflightSummary(parts, fallback = 'Not reported') {
+  const values = parts
+    .filter((value) => value !== null && value !== undefined && String(value).trim() !== '')
+    .map((value) => labelizeKey(String(value).trim()));
+  return values.length ? values.join(' · ') : fallback;
+}
+
+function preflightServiceSummary(service) {
+  const data = isRecord(service) ? service : {};
+  if (data.status !== null && data.status !== undefined && String(data.status).trim()) {
+    return labelizeKey(data.status);
+  }
+  if (data.active === true) return 'Active';
+  if (data.present === true) return 'Present, inactive';
+  if (data.present === false) return 'Not installed';
+  return 'Not reported';
+}
+
+function setPreflightStatus(message, state = 'idle') {
+  const el = document.getElementById('preflightStatus');
+  if (!el) return;
+  el.textContent = message;
+  el.dataset.state = state;
+}
+
+function renderPreflightList(containerId, entries, emptyText) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const fragment = document.createDocumentFragment();
+
+  if (!entries.length) {
+    const empty = document.createElement('li');
+    empty.className = 'preflight-list-empty';
+    empty.textContent = emptyText;
+    fragment.appendChild(empty);
+  } else {
+    for (const entry of entries) {
+      const item = isRecord(entry) ? entry : {};
+      const li = document.createElement('li');
+      li.className = 'preflight-list-item';
+
+      const message = document.createElement('div');
+      message.className = 'preflight-list-message';
+      message.textContent = preflightDisplayValue(item.message, 'No description provided.');
+      li.appendChild(message);
+
+      if (item.code !== null && item.code !== undefined && String(item.code).trim()) {
+        const code = document.createElement('div');
+        code.className = 'preflight-list-code';
+        code.textContent = String(item.code);
+        li.appendChild(code);
+      }
+      fragment.appendChild(li);
+    }
+  }
+
+  container.replaceChildren(fragment);
+}
+
+function clearPreflightReportView() {
+  setTextById('preflightSelectedAdapter', null);
+  setTextById('preflightUplink', null);
+  setTextById('preflightPlatform', null);
+  setTextById('preflightFirewall', null);
+  setTextById('preflightNetworkManager', null);
+  setTextById('preflightIwd', null);
+
+  const readiness = document.getElementById('preflightReadiness');
+  if (readiness) {
+    readiness.textContent = 'Not collected';
+    readiness.dataset.readiness = 'unknown';
+  }
+  renderPreflightList('preflightBlockingIssues', [], 'No report collected.');
+  renderPreflightList('preflightWarningIssues', [], 'No report collected.');
+  renderPreflightList('preflightActions', [], 'No report collected.');
+  const raw = document.getElementById('preflightRawJson');
+  if (raw) raw.textContent = '';
+  const exportButton = document.getElementById('btnExportPreflight');
+  if (exportButton) exportButton.disabled = true;
+}
+
+function renderPreflightReport(report) {
+  const platform = isRecord(report.platform) ? report.platform : {};
+  const firewall = isRecord(report.firewall) ? report.firewall : {};
+  const services = isRecord(report.services) ? report.services : {};
+  const network = isRecord(report.network) ? report.network : {};
+  const wifi = isRecord(report.wifi) ? report.wifi : {};
+  const issues = report.issues;
+  const blockingIssues = issues.filter((issue) => isRecord(issue) && issue.severity === 'blocked');
+  const warningIssues = issues.filter((issue) => !isRecord(issue) || issue.severity !== 'blocked');
+
+  const readinessValue = String(report.overall_readiness).toLowerCase();
+  const readiness = document.getElementById('preflightReadiness');
+  if (readiness) {
+    readiness.textContent = labelizeKey(readinessValue);
+    readiness.dataset.readiness = readinessValue;
+  }
+
+  setTextById('preflightSelectedAdapter', preflightDisplayValue(wifi.selected_adapter));
+  setTextById('preflightUplink', preflightDisplayValue(network.active_uplink_interface));
+  setTextById(
+    'preflightPlatform',
+    preflightSummary([
+      platform.os_name,
+      platform.os_version,
+      platform.host_kind || platform.os_family,
+    ]),
+  );
+  setTextById('preflightFirewall', preflightSummary([firewall.backend, firewall.status]));
+  setTextById('preflightNetworkManager', preflightServiceSummary(services.network_manager));
+  setTextById('preflightIwd', preflightServiceSummary(services.iwd));
+
+  renderPreflightList('preflightBlockingIssues', blockingIssues, 'No blocking issues.');
+  renderPreflightList('preflightWarningIssues', warningIssues, 'No warnings.');
+  renderPreflightList('preflightActions', report.recommended_actions, 'No actions recommended.');
+
+  const raw = document.getElementById('preflightRawJson');
+  if (raw) raw.textContent = JSON.stringify(report, null, 2);
+  const exportButton = document.getElementById('btnExportPreflight');
+  if (exportButton) exportButton.disabled = false;
+  setPreflightStatus('Canonical preflight report collected.', 'success');
+}
+
+function renderPreflightError(message) {
+  lastPreflightReport = null;
+  clearPreflightReportView();
+  setPreflightStatus(message, 'error');
+}
+
+async function loadPreflightReport() {
+  if (preflightRequestInFlight) return;
+  if (!isAuthenticated) {
+    renderPreflightError('Sign in to collect the preflight diagnostics report.');
+    return;
+  }
+
+  const refreshButton = document.getElementById('btnRefreshPreflight');
+  preflightRequestInFlight = true;
+  if (refreshButton) refreshButton.disabled = true;
+  lastPreflightReport = null;
+  clearPreflightReportView();
+  setPreflightStatus('Collecting the preflight diagnostics report...', 'loading');
+
+  try {
+    const response = await api(PREFLIGHT_REPORT_PATH, {
+      method: 'GET',
+      skipAuthHandling: true,
+    });
+    if (isUnauthorizedStatus(response.status)) {
+      const message = 'Your session expired. Sign in again to view diagnostics.';
+      renderPreflightError(message);
+      logoutToSplash(message);
+      return;
+    }
+    if (!isAuthenticated) return;
+    if (!response.ok) {
+      const resultCode = isRecord(response.json) && typeof response.json.result_code === 'string'
+        ? `: ${response.json.result_code}`
+        : '';
+      renderPreflightError(`Preflight report request failed (HTTP ${response.status}${resultCode}).`);
+      return;
+    }
+
+    const report = canonicalPreflightReportFromPayload(response.json);
+    if (!report) {
+      renderPreflightError('The service returned a malformed preflight report. Refresh to try again.');
+      return;
+    }
+
+    lastPreflightReport = report;
+    renderPreflightReport(report);
+  } catch {
+    if (isAuthenticated) {
+      renderPreflightError('Unable to reach the service. Check the connection and try again.');
+    }
+  } finally {
+    preflightRequestInFlight = false;
+    if (refreshButton) refreshButton.disabled = false;
+  }
+}
+
+function exportPreflightReport() {
+  if (!lastPreflightReport) {
+    setPreflightStatus('Collect a valid preflight report before exporting JSON.', 'error');
+    return;
+  }
+
+  const json = `${JSON.stringify(lastPreflightReport, null, 2)}\n`;
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'vr-hotspot-preflight-report.json';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  setPreflightStatus('Exported the canonical preflight report JSON.', 'success');
+}
+// --- End canonical preflight diagnostics view
+
 function setMsg(text, kind = '') {
   const els = [document.getElementById('msg'), document.getElementById('msgBasic')];
   for (const el of els) {
@@ -3225,6 +3450,9 @@ function wireTabs() {
     if (targetPane) {
       targetPane.classList.add('active');
     }
+    if (targetName === 'diagnostics') {
+      void loadPreflightReport();
+    }
   }
 
   tabs.forEach(tab => {
@@ -3298,6 +3526,14 @@ function bootstrapAuthenticatedUi() {
   const btnDownloadSupportBundle = document.getElementById('btnDownloadSupportBundle');
   if (btnDownloadSupportBundle) {
     btnDownloadSupportBundle.addEventListener('click', downloadSupportBundle);
+  }
+  const btnRefreshPreflight = document.getElementById('btnRefreshPreflight');
+  if (btnRefreshPreflight) {
+    btnRefreshPreflight.addEventListener('click', loadPreflightReport);
+  }
+  const btnExportPreflight = document.getElementById('btnExportPreflight');
+  if (btnExportPreflight) {
+    btnExportPreflight.addEventListener('click', exportPreflightReport);
   }
   const btnStartBasic = document.getElementById('btnStartBasic');
   if (btnStartBasic) btnStartBasic.addEventListener('click', async () => {

--- a/tests/test_ui_preflight_contract.py
+++ b/tests/test_ui_preflight_contract.py
@@ -1,0 +1,884 @@
+from pathlib import Path
+import json
+import shutil
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = (ROOT / "assets" / "index.html").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+# The project does not carry a browser test dependency.  This harness executes the
+# real assets/ui.js in Node's VM with the smallest DOM surface the preflight view
+# needs.  Its textContent and innerHTML implementations deliberately behave
+# differently so hostile-value tests fail if rendering switches to HTML parsing.
+NODE_HARNESS = r"""
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { webcrypto } = require('crypto');
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  values() {
+    return new Set(String(this.owner.className || '').split(/\s+/).filter(Boolean));
+  }
+
+  write(values) {
+    this.owner.className = Array.from(values).join(' ');
+  }
+
+  add(...names) {
+    const values = this.values();
+    names.forEach((name) => values.add(name));
+    this.write(values);
+  }
+
+  remove(...names) {
+    const values = this.values();
+    names.forEach((name) => values.delete(name));
+    this.write(values);
+  }
+
+  contains(name) {
+    return this.values().has(name);
+  }
+
+  toggle(name, force) {
+    const values = this.values();
+    const enabled = force === undefined ? !values.has(name) : Boolean(force);
+    if (enabled) values.add(name);
+    else values.delete(name);
+    this.write(values);
+    return enabled;
+  }
+}
+
+function dataKey(attribute) {
+  return attribute
+    .slice(5)
+    .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+class FakeElement {
+  constructor(tagName, ownerDocument, state) {
+    this.tagName = String(tagName || 'div').toUpperCase();
+    this.ownerDocument = ownerDocument;
+    this.state = state;
+    this.parentNode = null;
+    this.children = [];
+    this.dataset = {};
+    this.style = {};
+    this.attributes = {};
+    this.listeners = new Map();
+    this.className = '';
+    this.classList = new FakeClassList(this);
+    this.disabled = false;
+    this.checked = false;
+    this.value = '';
+    this.placeholder = '';
+    this.readOnly = false;
+    this.type = '';
+    this.href = '';
+    this.download = '';
+    this.clicked = 0;
+    this._textContent = '';
+    this._innerHTML = null;
+  }
+
+  get id() {
+    return this.attributes.id || '';
+  }
+
+  set id(value) {
+    this.setAttribute('id', value);
+  }
+
+  get textContent() {
+    const childText = this.children.map((child) => child.textContent).join('');
+    return this._textContent + childText;
+  }
+
+  set textContent(value) {
+    for (const child of this.children) child.parentNode = null;
+    this.children = [];
+    this._innerHTML = null;
+    this._textContent = value === null || value === undefined ? '' : String(value);
+  }
+
+  get innerHTML() {
+    return this._innerHTML === null ? this.textContent : this._innerHTML;
+  }
+
+  set innerHTML(value) {
+    const html = value === null || value === undefined ? '' : String(value);
+    this.state.htmlWrites += 1;
+    this._innerHTML = html;
+    this._textContent = '';
+    this.children = [];
+    for (const tag of ['script', 'img', 'iframe']) {
+      if (new RegExp(`<${tag}\\b`, 'i').test(html)) {
+        this.state.interpretedDangerousTags.push(tag);
+        this.appendChild(this.ownerDocument.createElement(tag));
+      }
+    }
+  }
+
+  get options() {
+    return this.children.filter((child) => child.tagName === 'OPTION');
+  }
+
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const index = this.parentNode.children.indexOf(this);
+    return index >= 0 ? this.parentNode.children[index + 1] || null : null;
+  }
+
+  setAttribute(name, value) {
+    const text = String(value);
+    this.attributes[name] = text;
+    if (name === 'class') this.className = text;
+    if (name.startsWith('data-')) this.dataset[dataKey(name)] = text;
+    if (name === 'id') this.ownerDocument.elementsById.set(text, this);
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+  }
+
+  appendChild(child) {
+    if (child.tagName === '#DOCUMENT-FRAGMENT') {
+      for (const grandchild of [...child.children]) this.appendChild(grandchild);
+      return child;
+    }
+    if (child.parentNode) {
+      const oldIndex = child.parentNode.children.indexOf(child);
+      if (oldIndex >= 0) child.parentNode.children.splice(oldIndex, 1);
+    }
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  insertBefore(child, reference) {
+    if (!reference || reference.parentNode !== this) return this.appendChild(child);
+    if (child.parentNode) child.remove();
+    const index = this.children.indexOf(reference);
+    child.parentNode = this;
+    this.children.splice(index, 0, child);
+    return child;
+  }
+
+  replaceChildren(...children) {
+    for (const child of this.children) child.parentNode = null;
+    this.children = [];
+    this._textContent = '';
+    this._innerHTML = null;
+    for (const child of children) this.appendChild(child);
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+    const index = this.parentNode.children.indexOf(this);
+    if (index >= 0) this.parentNode.children.splice(index, 1);
+    this.parentNode = null;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  async dispatch(type, extra = {}) {
+    const event = {
+      target: this,
+      currentTarget: this,
+      preventDefault() {},
+      stopPropagation() {},
+      ...extra,
+    };
+    for (const listener of this.listeners.get(type) || []) {
+      await listener(event);
+    }
+  }
+
+  click() {
+    this.clicked += 1;
+    return this.dispatch('click');
+  }
+
+  focus() {
+    this.state.focusedElement = this;
+  }
+
+  select() {}
+
+  querySelectorAll(selector) {
+    const matches = [];
+    const visit = (element) => {
+      for (const child of element.children) {
+        if (matchesSelector(child, selector)) matches.push(child);
+        visit(child);
+      }
+    };
+    visit(this);
+    return matches;
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+}
+
+function matchesSelector(element, selector) {
+  if (selector.startsWith('.')) return element.classList.contains(selector.slice(1));
+  if (selector.startsWith('#')) return element.id === selector.slice(1);
+  const attribute = selector.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+  if (attribute) {
+    const name = attribute[1];
+    const expected = attribute[2];
+    const actual = name.startsWith('data-')
+      ? element.dataset[dataKey(name)]
+      : element.getAttribute(name);
+    return expected === undefined ? actual !== undefined && actual !== null : actual === expected;
+  }
+  const tagAttribute = selector.match(/^([a-z0-9-]+)\[([^=]+)="([^"]*)"\]$/i);
+  if (tagAttribute) {
+    return element.tagName === tagAttribute[1].toUpperCase()
+      && element.getAttribute(tagAttribute[2]) === tagAttribute[3];
+  }
+  return element.tagName === selector.toUpperCase();
+}
+
+class FakeDocument {
+  constructor(state) {
+    this.state = state;
+    this.readyState = 'loading';
+    this.elements = new Set();
+    this.elementsById = new Map();
+    this.listeners = new Map();
+    this.body = this.createElement('body');
+  }
+
+  createElement(tagName) {
+    const element = new FakeElement(tagName, this, this.state);
+    this.elements.add(element);
+    return element;
+  }
+
+  createDocumentFragment() {
+    return this.createElement('#document-fragment');
+  }
+
+  getElementById(id) {
+    if (!this.elementsById.has(id)) {
+      const element = this.createElement('div');
+      element.id = id;
+    }
+    return this.elementsById.get(id);
+  }
+
+  querySelectorAll(selector) {
+    return Array.from(this.elements).filter((element) => matchesSelector(element, selector));
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+}
+
+class FakeStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.values.delete(key);
+  }
+}
+
+function responseBody(body, status = 200) {
+  return { body, status };
+}
+
+function createEnvironment() {
+  const state = {
+    blobs: [],
+    focusedElement: null,
+    htmlWrites: 0,
+    interpretedDangerousTags: [],
+    intervals: [],
+    objectUrls: [],
+    requests: [],
+    responses: [],
+    revokedUrls: [],
+  };
+  const document = new FakeDocument(state);
+  const localStorage = new FakeStorage();
+  const sessionStorage = new FakeStorage();
+
+  class FakeBlob {
+    constructor(parts, options = {}) {
+      this.parts = parts.map((part) => String(part));
+      this.type = options.type || '';
+      state.blobs.push(this);
+    }
+
+    async text() {
+      return this.parts.join('');
+    }
+  }
+
+  async function fetch(url, options = {}) {
+    const method = String(options.method || 'GET').toUpperCase();
+    state.requests.push({ url: String(url), method, options });
+    if (!state.responses.length) throw new Error(`No mock response for ${method} ${url}`);
+    const next = state.responses.shift();
+    if (next.throw) throw next.throw;
+    const status = next.status === undefined ? 200 : next.status;
+    const raw = next.raw === undefined ? JSON.stringify(next.body) : String(next.raw);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(next.headers || {}),
+      async text() { return raw; },
+      async blob() { return new FakeBlob([raw]); },
+    };
+  }
+
+  const sandbox = {
+    Blob: FakeBlob,
+    Headers,
+    URL: {
+      createObjectURL(blob) {
+        const url = `blob:test-${state.objectUrls.length + 1}`;
+        state.objectUrls.push({ blob, url });
+        return url;
+      },
+      revokeObjectURL(url) {
+        state.revokedUrls.push(url);
+      },
+    },
+    clearInterval() {},
+    clearTimeout() {},
+    console: { error() {}, log() {}, warn() {} },
+    crypto: webcrypto,
+    document,
+    fetch,
+    localStorage,
+    navigator: { clipboard: { async writeText() {} } },
+    sessionStorage,
+    setInterval(callback, delay) {
+      const timer = { callback, delay };
+      state.intervals.push(timer);
+      return timer;
+    },
+    setTimeout(callback) {
+      return { callback };
+    },
+  };
+  sandbox.window = sandbox;
+  sandbox.window.addEventListener = () => {};
+  sandbox.window.history = { replaceState() {} };
+  sandbox.window.location = { hash: '', pathname: '/', search: '' };
+  sandbox.window.isSecureContext = true;
+  sandbox.globalThis = sandbox;
+
+  const context = vm.createContext(sandbox);
+  const source = fs.readFileSync('assets/ui.js', 'utf8');
+  vm.runInContext(source, context, { filename: 'assets/ui.js' });
+
+  return {
+    context,
+    document,
+    localStorage,
+    run(sourceText) {
+      return vm.runInContext(sourceText, context);
+    },
+    state,
+  };
+}
+
+function canonicalReport(overrides = {}) {
+  return {
+    schema_version: 1,
+    overall_readiness: 'blocked',
+    platform: { os_name: 'Bazzite', os_version: '42', host_kind: 'immutable' },
+    firewall: { backend: 'firewalld', status: 'active' },
+    services: {
+      network_manager: { status: 'active' },
+      iwd: { present: false, active: false },
+    },
+    network: { active_uplink_interface: 'enp4s0' },
+    wifi: { selected_adapter: 'wlan1' },
+    issues: [
+      { severity: 'blocked', code: 'no_ap_capable_adapter', message: 'No AP-capable adapter.' },
+      { severity: 'warning', code: 'regdom_unknown', message: 'Regulatory domain is unknown.' },
+    ],
+    recommended_actions: [
+      { code: 'choose_adapter', message: 'Choose an AP-capable adapter.' },
+    ],
+    ...overrides,
+  };
+}
+
+function envelope(report, extras = {}) {
+  return { result_code: 'preflight_report', data: report, ...extras };
+}
+
+function authenticate(environment, token = 'test-auth-token') {
+  environment.run(`isAuthenticated = true; authFlowLocked = false; setToken(${JSON.stringify(token)});`);
+}
+
+function addNavigation(environment) {
+  const { document } = environment;
+  const statusTab = document.createElement('button');
+  statusTab.className = 'nav-item active';
+  statusTab.dataset.tab = 'status';
+  document.body.appendChild(statusTab);
+
+  const diagnosticsTab = document.createElement('button');
+  diagnosticsTab.className = 'nav-item';
+  diagnosticsTab.dataset.tab = 'diagnostics';
+  document.body.appendChild(diagnosticsTab);
+
+  const statusPane = document.getElementById('tab-status');
+  statusPane.className = 'tab-pane active';
+  const diagnosticsPane = document.getElementById('tab-diagnostics');
+  diagnosticsPane.className = 'tab-pane';
+  return { diagnosticsTab, statusTab };
+}
+
+async function wireAuthenticatedUi(environment) {
+  const navigation = addNavigation(environment);
+  environment.run(`
+    applyUiMode = () => {};
+    initCharts = () => {};
+    wireDirtyTracking = () => {};
+    wireQosBasic = () => {};
+    enforceBandRules = () => {};
+    wireQr = () => {};
+    loadAdapters = async () => {};
+    loadAdapterReadiness = async () => {};
+    refresh = async () => {};
+    applyAutoRefresh = () => {};
+    refreshInfo = async () => {};
+    bootstrapAuthenticatedUi();
+  `);
+  await settle();
+  return navigation;
+}
+
+async function settle() {
+  for (let index = 0; index < 8; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+async function waitForPreflightIdle(environment) {
+  for (let index = 0; index < 30; index += 1) {
+    if (!environment.run('preflightRequestInFlight')) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('preflight request did not settle');
+}
+
+function elementText(environment, id) {
+  return environment.document.getElementById(id).textContent;
+}
+
+function listMessages(environment, id) {
+  return environment.document.getElementById(id).children.map((item) => ({
+    message: item.children[0] ? item.children[0].textContent : item.textContent,
+    code: item.children[1] ? item.children[1].textContent : '',
+  }));
+}
+
+async function loadReport(environment, report, extras = {}) {
+  environment.state.responses.push(responseBody(envelope(report, extras)));
+  await environment.run('loadPreflightReport()');
+}
+
+async function scenarioOnDemand() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  const navigation = await wireAuthenticatedUi(environment);
+
+  assert.deepStrictEqual(environment.state.requests, []);
+  await navigation.statusTab.dispatch('click');
+  await settle();
+  assert.deepStrictEqual(environment.state.requests, []);
+
+  environment.state.responses.push(responseBody(envelope(canonicalReport())));
+  await navigation.diagnosticsTab.dispatch('click');
+  await waitForPreflightIdle(environment);
+  assert.strictEqual(environment.state.requests.length, 1);
+
+  environment.state.responses.push(responseBody(envelope(canonicalReport({ overall_readiness: 'ready' }))));
+  await environment.document.getElementById('btnRefreshPreflight').dispatch('click');
+  assert.strictEqual(environment.state.requests.length, 2);
+
+  for (const request of environment.state.requests) {
+    assert.strictEqual(request.url, '/v1/diagnostics/preflight');
+    assert.strictEqual(request.method, 'GET');
+  }
+}
+
+async function scenarioPolling() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  environment.context.__apiCalls = [];
+  environment.run(`
+    api = async (path, options = {}) => {
+      __apiCalls.push({ path, method: String(options.method || 'GET').toUpperCase() });
+      return { ok: false, status: 503, json: null, raw: '' };
+    };
+  `);
+
+  environment.document.getElementById('privacyMode').checked = true;
+  await environment.run('refreshVisibleUi()');
+  const auto = environment.document.getElementById('autoRefresh');
+  auto.checked = true;
+  environment.document.getElementById('refreshEvery').value = '2500';
+  environment.run('applyAutoRefresh()');
+  assert.strictEqual(environment.state.intervals.length, 1);
+  await environment.state.intervals[0].callback();
+
+  const paths = Array.from(environment.context.__apiCalls, (entry) => entry.path);
+  assert(paths.includes('/v1/status'));
+  assert(paths.includes('/v1/config'));
+  assert(paths.includes('/v1/adapters/readiness'));
+  assert(!paths.includes('/v1/diagnostics/preflight'));
+}
+
+async function scenarioSuccess() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  const report = canonicalReport();
+  await loadReport(environment, report);
+
+  const readiness = environment.document.getElementById('preflightReadiness');
+  assert.strictEqual(readiness.textContent, 'Blocked');
+  assert.strictEqual(readiness.dataset.readiness, 'blocked');
+  assert.deepStrictEqual(listMessages(environment, 'preflightBlockingIssues'), [
+    { message: 'No AP-capable adapter.', code: 'no_ap_capable_adapter' },
+  ]);
+  assert.deepStrictEqual(listMessages(environment, 'preflightWarningIssues'), [
+    { message: 'Regulatory domain is unknown.', code: 'regdom_unknown' },
+  ]);
+  assert.deepStrictEqual(listMessages(environment, 'preflightActions'), [
+    { message: 'Choose an AP-capable adapter.', code: 'choose_adapter' },
+  ]);
+  assert.strictEqual(elementText(environment, 'preflightSelectedAdapter'), 'wlan1');
+  assert.strictEqual(elementText(environment, 'preflightUplink'), 'enp4s0');
+  assert.strictEqual(elementText(environment, 'preflightPlatform'), 'Bazzite · 42 · Immutable');
+  assert.strictEqual(elementText(environment, 'preflightFirewall'), 'Firewalld · Active');
+  assert.strictEqual(elementText(environment, 'preflightNetworkManager'), 'Active');
+  assert.strictEqual(elementText(environment, 'preflightIwd'), 'Not installed');
+  assert.strictEqual(elementText(environment, 'preflightStatus'), 'Canonical preflight report collected.');
+  assert.deepStrictEqual(JSON.parse(elementText(environment, 'preflightRawJson')), report);
+}
+
+async function scenarioAuthErrors() {
+  for (const status of [401, 403]) {
+    const environment = createEnvironment();
+    authenticate(environment, `secret-${status}`);
+    environment.state.responses.push(responseBody({ result_code: 'invalid_token' }, status));
+    await environment.run('loadPreflightReport()');
+
+    assert.strictEqual(environment.run('isAuthenticated'), false);
+    assert.strictEqual(environment.run('lastPreflightReport'), null);
+    assert.strictEqual(environment.localStorage.getItem('vr_hotspot_token'), null);
+    assert.strictEqual(environment.document.body.getAttribute('data-auth-state'), 'unauthenticated');
+    assert.strictEqual(
+      environment.document.getElementById('login-splash').getAttribute('aria-hidden'),
+      'false',
+    );
+    assert.strictEqual(
+      elementText(environment, 'loginError'),
+      'Your session expired. Sign in again to view diagnostics.',
+    );
+    assert.strictEqual(environment.document.getElementById('btnExportPreflight').disabled, true);
+  }
+}
+
+async function scenarioRequestErrors() {
+  {
+    const environment = createEnvironment();
+    authenticate(environment);
+    environment.state.responses.push({ throw: new Error('connection refused') });
+    await environment.run('loadPreflightReport()');
+    assert.strictEqual(
+      elementText(environment, 'preflightStatus'),
+      'Unable to reach the service. Check the connection and try again.',
+    );
+    assert.strictEqual(environment.document.getElementById('preflightStatus').dataset.state, 'error');
+  }
+
+  {
+    const environment = createEnvironment();
+    authenticate(environment);
+    environment.state.responses.push(responseBody({ result_code: 'preflight_failed' }, 503));
+    await environment.run('loadPreflightReport()');
+    assert.strictEqual(
+      elementText(environment, 'preflightStatus'),
+      'Preflight report request failed (HTTP 503: preflight_failed).',
+    );
+    assert.strictEqual(environment.document.getElementById('preflightStatus').dataset.state, 'error');
+  }
+
+  {
+    const environment = createEnvironment();
+    authenticate(environment);
+    environment.state.responses.push(responseBody({ result_code: 'preflight_report', data: { schema_version: 1 } }));
+    await environment.run('loadPreflightReport()');
+    assert.strictEqual(
+      elementText(environment, 'preflightStatus'),
+      'The service returned a malformed preflight report. Refresh to try again.',
+    );
+    assert.strictEqual(environment.document.getElementById('preflightStatus').dataset.state, 'error');
+  }
+}
+
+async function scenarioStaleRefresh() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  await wireAuthenticatedUi(environment);
+  await loadReport(environment, canonicalReport());
+  assert.strictEqual(environment.document.getElementById('btnExportPreflight').disabled, false);
+  assert.notStrictEqual(elementText(environment, 'preflightRawJson'), '');
+
+  environment.state.responses.push(responseBody({ result_code: 'service_unavailable' }, 503));
+  await environment.document.getElementById('btnRefreshPreflight').dispatch('click');
+
+  assert.strictEqual(environment.run('lastPreflightReport'), null);
+  assert.strictEqual(environment.document.getElementById('btnExportPreflight').disabled, true);
+  assert.strictEqual(elementText(environment, 'preflightRawJson'), '');
+  assert.strictEqual(elementText(environment, 'preflightSelectedAdapter'), '--');
+  assert.strictEqual(environment.document.getElementById('preflightReadiness').textContent, 'Not collected');
+  assert.strictEqual(environment.document.getElementById('preflightStatus').dataset.state, 'error');
+  assert.match(elementText(environment, 'preflightStatus'), /HTTP 503/);
+}
+
+async function scenarioHostileValues() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  environment.state.htmlWrites = 0;
+  environment.state.interpretedDangerousTags = [];
+  const hostile = '<img src=x onerror="globalThis.pwned=true"><script>globalThis.pwned=true</script>';
+  const report = canonicalReport({
+    platform: { os_name: hostile, os_version: '1', host_kind: 'mutable' },
+    wifi: { selected_adapter: hostile },
+    issues: [{ severity: 'blocked', code: hostile, message: hostile }],
+    recommended_actions: [{ code: 'hostile_action', message: hostile }],
+  });
+  await loadReport(environment, report);
+
+  assert.strictEqual(elementText(environment, 'preflightSelectedAdapter'), hostile);
+  assert.match(elementText(environment, 'preflightPlatform'), /<Img\b.*<Script>/);
+  assert.strictEqual(listMessages(environment, 'preflightBlockingIssues')[0].message, hostile);
+  assert.strictEqual(listMessages(environment, 'preflightBlockingIssues')[0].code, hostile);
+  assert.strictEqual(listMessages(environment, 'preflightActions')[0].message, hostile);
+  assert.strictEqual(
+    JSON.parse(elementText(environment, 'preflightRawJson')).wifi.selected_adapter,
+    hostile,
+  );
+  assert.strictEqual(environment.state.htmlWrites, 0);
+  assert.deepStrictEqual(environment.state.interpretedDangerousTags, []);
+  assert.strictEqual(environment.run('globalThis.pwned'), undefined);
+  for (const id of [
+    'preflightSelectedAdapter',
+    'preflightPlatform',
+    'preflightBlockingIssues',
+    'preflightActions',
+    'preflightRawJson',
+  ]) {
+    const element = environment.document.getElementById(id);
+    assert.strictEqual(element.querySelectorAll('script').length, 0);
+    assert.strictEqual(element.querySelectorAll('img').length, 0);
+  }
+}
+
+async function scenarioOptionalFields() {
+  const environment = createEnvironment();
+  authenticate(environment);
+  const report = {
+    schema_version: 1,
+    overall_readiness: 'ready',
+    issues: [],
+    recommended_actions: [],
+  };
+  await loadReport(environment, report);
+
+  assert.strictEqual(elementText(environment, 'preflightStatus'), 'Canonical preflight report collected.');
+  for (const id of [
+    'preflightSelectedAdapter',
+    'preflightUplink',
+    'preflightPlatform',
+    'preflightFirewall',
+    'preflightNetworkManager',
+    'preflightIwd',
+  ]) {
+    assert.strictEqual(elementText(environment, id), 'Not reported');
+  }
+  assert.strictEqual(listMessages(environment, 'preflightBlockingIssues')[0].message, 'No blocking issues.');
+  assert.strictEqual(listMessages(environment, 'preflightWarningIssues')[0].message, 'No warnings.');
+  assert.strictEqual(listMessages(environment, 'preflightActions')[0].message, 'No actions recommended.');
+}
+
+async function scenarioExport() {
+  const environment = createEnvironment();
+  const token = 'token-that-must-not-be-exported';
+  authenticate(environment, token);
+  const report = canonicalReport({ report_id: 'canonical-only' });
+  await loadReport(environment, report, {
+    auth_token: 'envelope-secret',
+    ui_state: { selected_tab: 'diagnostics' },
+  });
+  environment.run('exportPreflightReport()');
+
+  assert.strictEqual(environment.state.blobs.length, 1);
+  const blob = environment.state.blobs[0];
+  const text = await blob.text();
+  const exported = JSON.parse(text);
+  assert.deepStrictEqual(exported, report);
+  assert.strictEqual(blob.type, 'application/json');
+  assert(!text.includes(token));
+  assert(!text.includes('envelope-secret'));
+  assert(!Object.prototype.hasOwnProperty.call(exported, 'result_code'));
+  assert(!Object.prototype.hasOwnProperty.call(exported, 'auth_token'));
+  assert(!Object.prototype.hasOwnProperty.call(exported, 'ui_state'));
+  assert.strictEqual(environment.state.objectUrls.length, 1);
+  assert.deepStrictEqual(environment.state.revokedUrls, ['blob:test-1']);
+}
+
+const scenarios = {
+  auth_errors: scenarioAuthErrors,
+  export: scenarioExport,
+  hostile: scenarioHostileValues,
+  on_demand: scenarioOnDemand,
+  optional: scenarioOptionalFields,
+  polling: scenarioPolling,
+  request_errors: scenarioRequestErrors,
+  stale: scenarioStaleRefresh,
+  success: scenarioSuccess,
+};
+
+const scenario = process.argv[1];
+if (!Object.prototype.hasOwnProperty.call(scenarios, scenario)) {
+  throw new Error(`Unknown scenario: ${scenario}`);
+}
+
+scenarios[scenario]()
+  .then(() => process.stdout.write(JSON.stringify({ scenario, ok: true })))
+  .catch((error) => {
+    console.error(error && error.stack ? error.stack : error);
+    process.exitCode = 1;
+  });
+"""
+
+
+def _run_node_scenario(name: str) -> None:
+    if NODE is None:
+        raise AssertionError("Node.js is required for executable Web UI behavior tests")
+    result = subprocess.run(
+        [NODE, "-e", NODE_HARNESS, name],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"Node UI scenario {name!r} failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    payload = json.loads(result.stdout)
+    if payload != {"scenario": name, "ok": True}:
+        raise AssertionError(f"Unexpected Node UI scenario result: {payload!r}")
+
+
+class TestUiPreflightContract(unittest.TestCase):
+    def test_diagnostics_view_remains_in_pro_mode(self):
+        """Keep one source check for placement; behavior is covered below."""
+        advanced_start = HTML.index("<!-- ADVANCED UI SECTION -->")
+        basic_html = HTML[:advanced_start]
+        advanced_html = HTML[advanced_start:]
+
+        self.assertNotIn('data-tab="diagnostics"', basic_html)
+        self.assertNotIn('id="tab-diagnostics"', basic_html)
+        self.assertEqual(advanced_html.count('data-tab="diagnostics"'), 1)
+        for element_id in (
+            "tab-diagnostics",
+            "btnRefreshPreflight",
+            "btnExportPreflight",
+            "preflightStatus",
+            "preflightReadiness",
+            "preflightSelectedAdapter",
+            "preflightUplink",
+            "preflightPlatform",
+            "preflightFirewall",
+            "preflightNetworkManager",
+            "preflightIwd",
+            "preflightBlockingIssues",
+            "preflightWarningIssues",
+            "preflightActions",
+            "preflightRawJson",
+        ):
+            self.assertEqual(advanced_html.count(f'id="{element_id}"'), 1)
+
+    def test_tab_open_and_refresh_fetch_exact_canonical_endpoint(self):
+        _run_node_scenario("on_demand")
+
+    def test_normal_status_refresh_and_polling_do_not_fetch_diagnostics(self):
+        _run_node_scenario("polling")
+
+    def test_successful_report_renders_required_diagnostics(self):
+        _run_node_scenario("success")
+
+    def test_unauthorized_responses_follow_logout_behavior(self):
+        _run_node_scenario("auth_errors")
+
+    def test_network_http_and_malformed_response_errors_are_clear(self):
+        _run_node_scenario("request_errors")
+
+    def test_failed_refresh_clears_stale_report_and_disables_export(self):
+        _run_node_scenario("stale")
+
+    def test_hostile_report_values_remain_text_not_html(self):
+        _run_node_scenario("hostile")
+
+    def test_missing_optional_fields_render_without_crashing(self):
+        _run_node_scenario("optional")
+
+    def test_export_is_exactly_the_canonical_report(self):
+        _run_node_scenario("export")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Pro-mode Web UI Diagnostics tab for the existing canonical preflight diagnostics endpoint.

What changed:
- Adds a Pro-mode Diagnostics tab.
- Fetches diagnostics on demand from `GET /v1/diagnostics/preflight`.
- Shows readiness, blocking issues, warnings, recommended actions, selected adapter, uplink, platform, firewall, NetworkManager, and iwd summaries.
- Adds raw JSON viewing.
- Adds canonical-report JSON export.
- Handles expired auth, service/network failures, non-200 API responses, malformed payloads, missing optional fields, and stale-data clearing.
- Keeps diagnostics collection out of normal status polling.

Safety:
- Web UI only.
- No backend changes.
- No CLI changes.
- No new probes.
- No lifecycle/start/stop changes.
- No adapter scoring/selection changes.
- No Flatpak/internal-Wi-Fi behavior.
- Report-controlled values are rendered through safe DOM/text APIs.
- Export includes only the canonical report, not auth tokens, response envelopes, or UI state.

Tests:
- Executes the real `assets/ui.js` in a Node VM harness.
- Covers on-demand fetching, polling exclusion, auth failure, network/API/malformed-payload errors, stale clearing, XSS-safe rendering, optional-field fallbacks, and export contents.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `355 passed, 4 subtests passed`