### PR TITLE
fix: block hotspot start on active uplink adapter

### DIFF
--- a/backend/vr_hotspotd/diagnostics/preflight_report.py
+++ b/backend/vr_hotspotd/diagnostics/preflight_report.py
@@ -19,6 +19,7 @@ from vr_hotspotd.adapters.readiness import build_readiness_model
 from vr_hotspotd.config import DEFAULT_CONFIG
 from vr_hotspotd.diagnostics.platform import collect_platform_matrix
 from vr_hotspotd.engine import supervisor
+from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
 from vr_hotspotd.vendor_paths import vendor_bin_dirs
 
 
@@ -44,7 +45,7 @@ _ISSUE_MESSAGES = {
     "binary_selection_failed": "The configured binary selection constraints could not be satisfied by read-only inspection.",
     "firewall_backend_not_detected": "No supported firewall backend was detected for internet sharing.",
     "default_uplink_not_detected": "No active default-route interface was detected for internet sharing.",
-    "ap_adapter_is_active_uplink": "The selected AP adapter is also the active uplink; VRhotspot does not yet support using one radio for both roles safely.",
+    ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK: "The selected AP adapter is also the active uplink; VRhotspot does not yet support using one radio for both roles safely.",
     "platform_family_unknown": "The Linux distribution family could not be classified.",
     "rfkill_blocked": "A Wi-Fi radio is blocked by rfkill.",
     "rfkill_not_found": "rfkill is unavailable, so radio block state could not be checked.",
@@ -81,7 +82,7 @@ _ACTION_MESSAGES = {
     "binary_selection_failed": "Review VR_HOTSPOT_FORCE_SYSTEM_BIN, VR_HOTSPOT_FORCE_VENDOR_BIN, and the installed binaries.",
     "firewall_backend_not_detected": "Install or enable a supported firewall backend before sharing the uplink.",
     "default_uplink_not_detected": "Connect the host to an upstream network or disable internet sharing.",
-    "ap_adapter_is_active_uplink": "Use a separate Wi-Fi adapter for the AP, preferably with Ethernet or another interface as the uplink.",
+    ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK: "Use a separate Wi-Fi adapter for the AP, or use Ethernet or another interface as the uplink.",
     "platform_family_unknown": "Confirm that this distribution is supported and that /etc/os-release is readable.",
     "rfkill_blocked": "Unblock the Wi-Fi radio with the host's normal radio or rfkill controls.",
     "rfkill_not_found": "Install rfkill if radio-block diagnostics are needed.",
@@ -519,7 +520,7 @@ def build_preflight_report(
     if internet_required and not active_uplink_interface:
         add_issue("default_uplink_not_detected", "warning")
     if report_adapter and report_adapter == active_uplink_interface:
-        add_issue("ap_adapter_is_active_uplink", "warning")
+        add_issue(ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK, "blocked")
     if not os_family:
         add_issue("platform_family_unknown", "warning")
 

--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -36,6 +36,7 @@ from vr_hotspotd import (
 )
 from vr_hotspotd.policy import (
     BASIC_MODE_REQUIRED_BAND,
+    ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
     ERROR_BASIC_MODE_REQUIRES_5GHZ,
     ERROR_BASIC_MODE_REQUIRES_80MHZ_ADAPTER,
     ERROR_NM_INTERFACE_MANAGED,
@@ -1823,8 +1824,36 @@ def _start_hotspot_5ghz_strict(
     iface_up_grace_s: float = 0.0,
     ap_ready_nohint_retry_s: float = 0.0,
     pop_timeout_retry_no_virt: bool = False,
+    active_uplink_interface: Optional[str] = None,
 ) -> LifecycleResult:
     attempts: List[Dict[str, Any]] = []
+
+    def _active_uplink_reselection_failure() -> LifecycleResult:
+        last_error = ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+        warnings = list(start_warnings)
+        warnings.extend(_safe_revert_tuning(tuning_state))
+        state = update_state(
+            phase="error",
+            running=False,
+            adapter=ap_ifname,
+            ap_interface=None,
+            last_error=last_error,
+            last_error_detail=wifi_probe.build_error_detail(
+                last_error,
+                {
+                    "ap_adapter": ap_ifname,
+                    "active_uplink_interface": active_uplink_interface,
+                },
+            ),
+            last_correlation_id=correlation_id,
+            fallback_reason=None,
+            warnings=warnings,
+            attempts=attempts,
+            tuning={},
+            network_tuning={},
+        )
+        return LifecycleResult(last_error, state)
+
     preferred_primary_channel: Optional[int] = None
     if enforced_channel_5g is not None:
         preferred_primary_channel = enforced_channel_5g
@@ -2097,6 +2126,8 @@ def _start_hotspot_5ghz_strict(
                 platform_is_pop=True,
                 prep_warnings=["ap_iface_not_up_prestart"],
             )
+            if active_uplink_interface and ap_ifname == active_uplink_interface:
+                return _active_uplink_reselection_failure()
             if reselect_warnings:
                 start_warnings.extend(reselect_warnings)
             if ap_ifname != old_ifname:
@@ -2225,6 +2256,8 @@ def _start_hotspot_5ghz_strict(
                         platform_is_pop=True,
                         prep_warnings=["ap_iface_not_up_post_driver_reload"],
                     )
+                    if active_uplink_interface and ap_ifname == active_uplink_interface:
+                        return _active_uplink_reselection_failure()
                     if reselect_warnings:
                         start_warnings.extend(reselect_warnings)
                     # Retry once more after parent-iface recovery even when the
@@ -3557,8 +3590,6 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
     if state.get("phase") in ("starting", "running") and is_running():
         return LifecycleResult("already_running", state)
 
-    _repair_impl(correlation_id=correlation_id)
-
     state = update_state(
         phase="starting",
         last_op="start",
@@ -3672,6 +3703,7 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
             return LifecycleResult("start_failed", state)
 
     ap_ifname = None
+    active_uplink_interface: Optional[str] = None
     nm_remediation_attempted = False
     nm_remediation_error: Optional[str] = None
     prestart_warnings: List[str] = []
@@ -3711,6 +3743,33 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
         a = _get_adapter(inv, ap_ifname)
         if not a or not a.get("supports_ap"):
             raise RuntimeError("no_ap_capable_adapter_found")
+
+        active_uplink_interface = host_probes.probe_default_uplink()
+        if active_uplink_interface and ap_ifname == active_uplink_interface:
+            raise RuntimeError(ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK)
+
+        # All host mutation stays behind the active-uplink role guard. Repair
+        # can stop engines, revert tuning/firewall state, and remove virtual
+        # interfaces, so it must not run until the selected AP role is safe.
+        _repair_impl(correlation_id=correlation_id)
+        state = update_state(
+            phase="starting",
+            last_op="start",
+            last_correlation_id=correlation_id,
+            last_error=None,
+            mode=None,
+            fallback_reason=None,
+            warnings=[],
+            ap_interface=None,
+            engine={"ap_logs_tail": []},
+            attempts=[],
+            selected_band=None,
+            selected_width_mhz=None,
+            selected_channel=None,
+            selected_country=None,
+            pro_mode_allow_fallback_40mhz=allow_fallback_40mhz,
+            last_error_detail=None,
+        )
 
         iwd_warnings = _reserve_iwd_ap_adapter(
             ap_ifname,
@@ -3801,6 +3860,8 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
                 platform_is_pop=platform_is_pop,
                 prep_warnings=prep_warnings,
             )
+            if active_uplink_interface and ap_ifname == active_uplink_interface:
+                raise RuntimeError(ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK)
             if reselect_warnings:
                 prestart_warnings.extend(reselect_warnings)
             if ap_ifname != old_ifname:
@@ -3849,8 +3910,20 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
             ERROR_BASIC_MODE_REQUIRES_80MHZ_ADAPTER,
             ERROR_NM_INTERFACE_MANAGED,
             _IWD_ASSOCIATION_ERROR,
+            ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
         ):
-            context = {"interface": ap_ifname} if err in (ERROR_NM_INTERFACE_MANAGED, _IWD_ASSOCIATION_ERROR) and ap_ifname else {}
+            if err == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK:
+                context = {
+                    "ap_adapter": ap_ifname,
+                    "active_uplink_interface": active_uplink_interface,
+                }
+            else:
+                context = (
+                    {"interface": ap_ifname}
+                    if err in (ERROR_NM_INTERFACE_MANAGED, _IWD_ASSOCIATION_ERROR)
+                    and ap_ifname
+                    else {}
+                )
             error_detail = wifi_probe.build_error_detail(err, context)
             if err == ERROR_NM_INTERFACE_MANAGED:
                 error_detail["remediation_attempted"] = nm_remediation_attempted
@@ -3874,7 +3947,12 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
                 "ap_logs_tail": [],
             },
         )
-        return LifecycleResult("start_failed", state)
+        result_code = (
+            ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+            if err == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+            else "start_failed"
+        )
+        return LifecycleResult(result_code, state)
 
     wifi6_setting = cfg.get("wifi6", "auto")
     if isinstance(wifi6_setting, str):
@@ -3992,6 +4070,7 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
             iface_up_grace_s=iface_up_grace_s,
             ap_ready_nohint_retry_s=ap_ready_nohint_retry_s,
             pop_timeout_retry_no_virt=platform_is_pop,
+            active_uplink_interface=active_uplink_interface,
         )
 
     # Attempt 1: requested band

--- a/backend/vr_hotspotd/policy.py
+++ b/backend/vr_hotspotd/policy.py
@@ -29,11 +29,12 @@ BASIC_MODE_REQUIRED_PHY: Literal["wifi5+", "wifi6+"] = "wifi5+"
 # =============================================================================
 # Error Codes
 # =============================================================================
-# Basic Mode enforcement error codes (must match wifi_probe.ERROR_REMEDIATIONS)
+# Lifecycle enforcement error codes (must match wifi_probe.ERROR_REMEDIATIONS)
 
 ERROR_BASIC_MODE_REQUIRES_5GHZ = "basic_mode_requires_5ghz"
 ERROR_BASIC_MODE_REQUIRES_80MHZ_ADAPTER = "basic_mode_requires_80mhz_adapter"
 ERROR_NM_INTERFACE_MANAGED = "nm_interface_managed"
+ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK = "ap_adapter_is_active_uplink"
 
 
 # =============================================================================

--- a/backend/vr_hotspotd/wifi_probe.py
+++ b/backend/vr_hotspotd/wifi_probe.py
@@ -6,10 +6,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from vr_hotspotd import host_probes, os_release
 from vr_hotspotd.adapters.inventory import get_adapters
+from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
 
 _COUNTRY_RE = re.compile(r"^[A-Z]{2}$")
 
 ERROR_REMEDIATIONS: Dict[str, str] = {
+    ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK: (
+        "Use a separate Wi-Fi adapter for the AP, or use Ethernet or another interface "
+        "as the uplink."
+    ),
     "regdom_unknown_or_global_00": (
         "Set a valid 2-letter country code (config `country`) and ensure `iw reg get` "
         "no longer reports 00; replug the adapter or reboot if needed."

--- a/tests/test_active_uplink_start_guard.py
+++ b/tests/test_active_uplink_start_guard.py
@@ -1,0 +1,327 @@
+from copy import deepcopy
+
+import pytest
+
+from vr_hotspotd import lifecycle
+from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+from vr_hotspotd.state import DEFAULT_STATE
+
+
+def _config(*, ap_adapter=""):
+    return {
+        "ssid": "VR-Hotspot",
+        "wpa2_passphrase": "password123",
+        "band_preference": "5ghz",
+        "ap_adapter": ap_adapter,
+        "enable_internet": True,
+    }
+
+
+def _inventory():
+    return {
+        "recommended": "wlan1",
+        "adapters": [
+            {
+                "ifname": "wlan0",
+                "phy": "phy0",
+                "bus": "pci",
+                "supports_ap": True,
+                "supports_5ghz": True,
+                "supports_80mhz": True,
+            },
+            {
+                "ifname": "wlan1",
+                "phy": "phy1",
+                "bus": "usb",
+                "supports_ap": True,
+                "supports_5ghz": True,
+                "supports_80mhz": True,
+            },
+        ],
+    }
+
+
+def _stub_read_only_start_environment(
+    monkeypatch,
+    *,
+    config,
+    active_uplink_interface,
+):
+    state = deepcopy(DEFAULT_STATE)
+    events = []
+
+    def load_state():
+        return state
+
+    def update_state(**kwargs):
+        for key, value in kwargs.items():
+            if key == "engine" and isinstance(value, dict):
+                state["engine"].update(value)
+            elif key == "warnings" and isinstance(value, list):
+                state["warnings"] = list(value)
+            else:
+                state[key] = value
+        return state
+
+    def get_adapters():
+        events.append("inventory")
+        return _inventory()
+
+    def probe_default_uplink():
+        events.append("active_uplink")
+        return active_uplink_interface
+
+    monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
+    monkeypatch.setattr(lifecycle, "load_state", load_state)
+    monkeypatch.setattr(lifecycle, "update_state", update_state)
+    monkeypatch.setattr(lifecycle, "load_config", lambda: dict(config))
+    monkeypatch.setattr(lifecycle, "get_adapters", get_adapters)
+    monkeypatch.setattr(
+        lifecycle.host_probes,
+        "probe_default_uplink",
+        probe_default_uplink,
+    )
+    monkeypatch.setattr(
+        lifecycle.wifi_probe,
+        "detect_firewall_backends",
+        lambda: {"selected_backend": "nftables"},
+    )
+    monkeypatch.setattr(lifecycle.os_release, "read_os_release", lambda: {"id": "ubuntu"})
+    monkeypatch.setattr(
+        lifecycle.os_release,
+        "apply_platform_overrides",
+        lambda cfg, _info: (cfg, []),
+    )
+    monkeypatch.setattr(lifecycle.os_release, "is_cachyos", lambda _info=None: False)
+    monkeypatch.setattr(lifecycle.os_release, "is_pop_os", lambda _info=None: False)
+    monkeypatch.setattr(lifecycle.os_release, "is_bazzite", lambda _info=None: False)
+
+    return state, events
+
+
+def _forbid_mutations(monkeypatch):
+    calls = []
+
+    def forbidden(name):
+        def fail(*_args, **_kwargs):
+            calls.append(name)
+            raise AssertionError(f"mutation helper called before active-uplink guard: {name}")
+
+        return fail
+
+    for name in (
+        "_repair_impl",
+        "_reserve_iwd_ap_adapter",
+        "_nm_set_unmanaged",
+        "_disconnect_iwd_ap_adapter",
+        "_prepare_ap_interface",
+        "_ensure_iface_up",
+        "_maybe_set_regdom",
+        "_start_hotspot_5ghz_strict",
+        "start_engine",
+    ):
+        monkeypatch.setattr(lifecycle, name, forbidden(name))
+    monkeypatch.setattr(
+        lifecycle.system_tuning,
+        "apply_pre",
+        forbidden("system_tuning.apply_pre"),
+    )
+    monkeypatch.setattr(
+        lifecycle.network_tuning,
+        "apply",
+        forbidden("network_tuning.apply"),
+    )
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("configured_adapter", "active_uplink_interface", "selected_adapter"),
+    (
+        ("wlan0", "wlan0", "wlan0"),
+        ("", "wlan1", "wlan1"),
+    ),
+    ids=("configured_adapter", "automatically_recommended_adapter"),
+)
+def test_active_uplink_conflict_blocks_before_any_mutation(
+    monkeypatch,
+    configured_adapter,
+    active_uplink_interface,
+    selected_adapter,
+):
+    state, events = _stub_read_only_start_environment(
+        monkeypatch,
+        config=_config(ap_adapter=configured_adapter),
+        active_uplink_interface=active_uplink_interface,
+    )
+    mutation_calls = _forbid_mutations(monkeypatch)
+
+    result = lifecycle._start_hotspot_impl(correlation_id="active-uplink-test")
+
+    assert result.code == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    assert state["phase"] == "error"
+    assert state["running"] is False
+    assert state["last_error"] == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    assert state["last_error_detail"] == {
+        "code": ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+        "remediation": (
+            "Use a separate Wi-Fi adapter for the AP, or use Ethernet or another "
+            "interface as the uplink."
+        ),
+        "context": {
+            "ap_adapter": selected_adapter,
+            "active_uplink_interface": active_uplink_interface,
+        },
+    }
+    assert events == ["inventory", "active_uplink"]
+    assert mutation_calls == []
+
+
+def test_active_uplink_conflict_after_reselection_blocks_before_replacement_mutation(
+    monkeypatch,
+):
+    state, events = _stub_read_only_start_environment(
+        monkeypatch,
+        config=_config(ap_adapter="wlan0"),
+        active_uplink_interface="wlan1",
+    )
+    inventory = _inventory()
+    active_uplink_adapter = next(
+        adapter
+        for adapter in inventory["adapters"]
+        if adapter["ifname"] == "wlan1"
+    )
+    calls = []
+
+    def repair(*_args, **_kwargs):
+        calls.append(("repair", None))
+        return state
+
+    def reserve_iwd(ifname, **_kwargs):
+        calls.append(("iwd_reservation", ifname))
+        return []
+
+    def prepare(ifname, **_kwargs):
+        calls.append(("prepare", ifname))
+        if ifname == "wlan1":
+            raise AssertionError("active uplink prepared after late reselection")
+        return ["ap_iface_not_up_prestart"]
+
+    def ensure_up(ifname):
+        calls.append(("ensure_up", ifname))
+        if ifname == "wlan1":
+            raise AssertionError("active uplink mutated after late reselection")
+        return False
+
+    def reselect(**kwargs):
+        calls.append(("reselect", kwargs["ap_ifname"]))
+        return (
+            "wlan1",
+            inventory,
+            active_uplink_adapter,
+            ["ap_adapter_reselected_after_reload:wlan0->wlan1"],
+        )
+
+    def forbidden(name):
+        def fail(*_args, **_kwargs):
+            calls.append((name, None))
+            raise AssertionError(f"called after active-uplink reselection: {name}")
+
+        return fail
+
+    monkeypatch.setattr(lifecycle, "_repair_impl", repair)
+    monkeypatch.setattr(lifecycle, "_reserve_iwd_ap_adapter", reserve_iwd)
+    monkeypatch.setattr(lifecycle, "_nm_gate_check", lambda _ifname: None)
+    monkeypatch.setattr(lifecycle, "_prepare_ap_interface", prepare)
+    monkeypatch.setattr(lifecycle, "_ensure_iface_up", ensure_up)
+    monkeypatch.setattr(
+        lifecycle,
+        "_maybe_reselect_ap_after_prestart_failure",
+        reselect,
+    )
+    monkeypatch.setattr(lifecycle.os_release, "is_pop_os", lambda _info=None: True)
+    monkeypatch.setattr(lifecycle.os_release, "is_steamos", lambda _info=None: False)
+    monkeypatch.setattr(
+        lifecycle,
+        "_start_hotspot_5ghz_strict",
+        forbidden("_start_hotspot_5ghz_strict"),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_maybe_set_regdom",
+        forbidden("_maybe_set_regdom"),
+    )
+    monkeypatch.setattr(
+        lifecycle.system_tuning,
+        "apply_pre",
+        forbidden("system_tuning.apply_pre"),
+    )
+    monkeypatch.setattr(
+        lifecycle.network_tuning,
+        "apply",
+        forbidden("network_tuning.apply"),
+    )
+    monkeypatch.setattr(lifecycle, "start_engine", forbidden("start_engine"))
+
+    result = lifecycle._start_hotspot_impl(
+        correlation_id="active-uplink-reselection-test"
+    )
+
+    assert result.code == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    assert state["phase"] == "error"
+    assert state["running"] is False
+    assert state["last_error"] == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    assert state["last_error_detail"] == {
+        "code": ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+        "remediation": (
+            "Use a separate Wi-Fi adapter for the AP, or use Ethernet or another "
+            "interface as the uplink."
+        ),
+        "context": {
+            "ap_adapter": "wlan1",
+            "active_uplink_interface": "wlan1",
+        },
+    }
+    assert events == ["inventory", "active_uplink"]
+    assert calls == [
+        ("repair", None),
+        ("iwd_reservation", "wlan0"),
+        ("prepare", "wlan0"),
+        ("ensure_up", "wlan0"),
+        ("reselect", "wlan0"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "active_uplink_interface",
+    (None, "enp4s0", "wlan0"),
+    ids=("no_uplink", "separate_ethernet_uplink", "separate_wifi_uplink"),
+)
+def test_non_conflicting_uplink_is_allowed_past_guard(
+    monkeypatch,
+    active_uplink_interface,
+):
+    state, events = _stub_read_only_start_environment(
+        monkeypatch,
+        config=_config(),
+        active_uplink_interface=active_uplink_interface,
+    )
+    mutation_calls = []
+
+    def repair(*_args, **_kwargs):
+        mutation_calls.append("repair")
+        return state
+
+    def stop_after_guard(*_args, **_kwargs):
+        mutation_calls.append("iwd_reservation")
+        raise RuntimeError("stop_after_active_uplink_guard")
+
+    monkeypatch.setattr(lifecycle, "_repair_impl", repair)
+    monkeypatch.setattr(lifecycle, "_reserve_iwd_ap_adapter", stop_after_guard)
+
+    result = lifecycle._start_hotspot_impl(correlation_id="allowed-uplink-test")
+
+    assert result.code == "start_failed"
+    assert state["last_error"] == "stop_after_active_uplink_guard"
+    assert state["last_error"] != ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    assert events == ["inventory", "active_uplink"]
+    assert mutation_calls == ["repair", "iwd_reservation"]

--- a/tests/test_basic_mode_enforcement.py
+++ b/tests/test_basic_mode_enforcement.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
 
 
+@pytest.mark.usefixtures("mock_missing_system_commands")
 class TestBasicModeEnforcement(unittest.TestCase):
     """Test Basic Mode VR enforcement: requires 5GHz and 80MHz adapter."""
 
@@ -162,6 +163,7 @@ class TestBasicModeEnforcement(unittest.TestCase):
         self.assertTrue(found_error, f"Expected 80MHz requirement error. Calls: {mock_update_state.call_args_list}")
 
 
+@pytest.mark.usefixtures("mock_missing_system_commands")
 class TestNmPreStartGate(unittest.TestCase):
     """Test NetworkManager pre-start gate functionality."""
 

--- a/tests/test_iwd_ap_reservation.py
+++ b/tests/test_iwd_ap_reservation.py
@@ -110,7 +110,10 @@ def test_hostapd_nat_iwd_disconnects_parent_before_ap_start(
     ]
 
 
-def test_steamos_iwd_still_associated_fails_with_clear_error(monkeypatch):
+def test_steamos_iwd_still_associated_fails_with_clear_error(
+    monkeypatch,
+    mock_missing_system_commands,
+):
     from vr_hotspotd import lifecycle
 
     states = []

--- a/tests/test_passphrase_autoprovision.py
+++ b/tests/test_passphrase_autoprovision.py
@@ -65,7 +65,10 @@ def _common_start_mocks(monkeypatch, cfg):
     return lifecycle
 
 
-def test_start_autoprovisions_missing_passphrase(monkeypatch):
+def test_start_autoprovisions_missing_passphrase(
+    monkeypatch,
+    mock_missing_system_commands,
+):
     lifecycle = _common_start_mocks(
         monkeypatch,
         {"wpa2_passphrase": "", "band_preference": "5ghz"},
@@ -94,7 +97,10 @@ def test_start_autoprovisions_missing_passphrase(monkeypatch):
     assert strict_calls.get("passphrase") == generated
 
 
-def test_start_does_not_autoprovision_when_short_override_provided(monkeypatch):
+def test_start_does_not_autoprovision_when_short_override_provided(
+    monkeypatch,
+    mock_missing_system_commands,
+):
     lifecycle = _common_start_mocks(
         monkeypatch,
         {"wpa2_passphrase": "", "band_preference": "5ghz"},

--- a/tests/test_preflight_report.py
+++ b/tests/test_preflight_report.py
@@ -1,9 +1,12 @@
 import json
 from collections import deque
 
+import pytest
+
 from vr_hotspotd import config as config_module
 from vr_hotspotd import host_probes
 from vr_hotspotd.diagnostics import preflight_report
+from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
 
 
 PLATFORM = {
@@ -305,22 +308,69 @@ def test_report_normalizes_parameterized_issue_code_and_separates_context():
     assert all("(" not in item["code"] and ":" not in item["code"] for item in report["issues"])
 
 
-def test_same_radio_uplink_is_warning_not_internal_wifi_gating():
-    report = _build(active_uplink_interface="wlan1")
+@pytest.mark.parametrize(
+    "config",
+    (
+        {
+            "band_preference": "5ghz",
+            "channel_width": "80",
+            "allow_fallback_40mhz": False,
+            "enable_internet": True,
+        },
+        {
+            "ap_adapter": "wlan1",
+            "band_preference": "5ghz",
+            "channel_width": "80",
+            "allow_fallback_40mhz": False,
+            "enable_internet": True,
+        },
+    ),
+    ids=("recommended_adapter", "configured_adapter"),
+)
+def test_same_radio_uplink_is_blocking_even_with_concurrency_evidence(config):
+    report = _build(active_uplink_interface="wlan1", config=config)
 
-    assert report["overall_readiness"] == "warning"
+    assert report["overall_readiness"] == "blocked"
     issue = next(
         item
         for item in report["issues"]
-        if item["code"] == "ap_adapter_is_active_uplink"
+        if item["code"] == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
     )
-    assert issue["severity"] == "warning"
+    assert issue["severity"] == "blocked"
     assert "does not yet support" in issue["message"]
+    action = next(
+        item
+        for item in report["recommended_actions"]
+        if item["code"] == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    )
+    assert "separate Wi-Fi adapter" in action["message"]
+    assert "Ethernet or another interface" in action["message"]
     assert report["wifi"]["adapters"][0]["is_active_uplink"] is True
     assert (
         report["wifi"]["adapters"][0]["capabilities"]["supports_sta_ap_concurrency"]
         is True
     )
+
+
+@pytest.mark.parametrize(
+    ("active_uplink_interface", "expected_readiness"),
+    (
+        (None, "warning"),
+        ("enp4s0", "ready"),
+        ("wlan0", "ready"),
+    ),
+    ids=("no_uplink", "separate_ethernet_uplink", "separate_wifi_uplink"),
+)
+def test_non_conflicting_uplink_does_not_trigger_role_guard(
+    active_uplink_interface,
+    expected_readiness,
+):
+    report = _build(active_uplink_interface=active_uplink_interface)
+
+    assert report["overall_readiness"] == expected_readiness
+    assert ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK not in {
+        item["code"] for item in report["issues"]
+    }
 
 
 def test_collector_uses_mocked_read_only_probe_results(monkeypatch):


### PR DESCRIPTION
Implements the active-uplink fail-closed safety guard recommended by the full repository audit.

What changed:
- Promotes `ap_adapter_is_active_uplink` from warning to blocking in the canonical preflight report.
- Makes `overall_readiness` blocked when the selected AP adapter is also the active default-route uplink.
- Captures the active uplink once during hotspot start.
- Rejects start when the resolved AP adapter equals the active uplink.
- Guards both configured and automatically selected adapter paths.
- Guards late Pop!_OS/pre-start reselection paths.
- Reuses the captured uplink value instead of reprobling after mutation begins.
- Returns stable code `ap_adapter_is_active_uplink` through lifecycle/API/status patterns.

Safety:
- Rejection happens before privileged networking mutation for the selected/reselected adapter.
- Blocks before NetworkManager/iwd/firewall/tuning/engine-launch work for the conflicting adapter.
- Same-radio STA+AP/concurrency evidence does not bypass the guard.
- No same-radio/internal-Wi-Fi feature added.
- No adapter scoring/grading/recommendation feature added.
- No UI, docs, installer, Flatpak, support-bundle, or remote-access scope added.

Tests:
- Added focused lifecycle regression coverage for configured adapter conflicts.
- Added automatic/recommended adapter conflict coverage.
- Added late-reselection conflict coverage.
- Covers no-uplink, separate Ethernet uplink, separate Wi-Fi uplink, and same-interface cases.
- Confirms mutation helpers are not called before rejection.
- Confirms canonical preflight reports the conflict as blocking.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `365 passed, 4 subtests passed`