### PR TITLE
fix: fail closed when API token is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,23 @@ readiness data. Review it before attaching it to a public issue.
 
 ## Security & Privacy
 
+### Privileged API Threat Model
+
+The portal shell, static assets, favicon, and `/healthz` are public. Every
+`/v1/*` route controls or exposes privileged daemon state and requires both a
+configured `VR_HOTSPOTD_API_TOKEN` and a matching `X-Api-Token` or Bearer token.
+If the daemon token is absent or blank, privileged requests fail closed with
+HTTP 503 and `result_code: api_token_missing`; supplying a token in the browser
+cannot repair a missing daemon configuration. Configure the token in the daemon
+environment (normally `/etc/vr-hotspot/env`) and restart the service.
+
+The daemon runs as root, so the token protects network mutation, diagnostics,
+configuration, and passphrase-reveal operations from other local processes as
+well as network clients. Tokenless non-loopback binds are refused. Remote access
+still uses plain HTTP and is trusted-network-only: use it only on a network where
+traffic cannot be observed or modified. This project does not currently provide
+built-in TLS termination.
+
 ### API Token Protection
 
 - **Treat the token like a password** - don't share it publicly
@@ -422,7 +439,8 @@ readiness data. Review it before attaching it to a public issue.
 
 - By default, the web UI only listens on `127.0.0.1` (local only)
 - To allow remote access: `sudo ./install.sh --bind 0.0.0.0`
-- **Important**: Keep token enforcement enabled and use a strong token
+- **Important**: A strong token is mandatory, but remote HTTP is still suitable
+  only for a trusted network
 
 ---
 

--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -382,10 +382,26 @@ class APIHandler(BaseHTTPRequestHandler):
     def _is_authorized(self) -> bool:
         tok = self._env_token()
         if not tok:
-            return True
+            return False
         return self._get_req_token() == tok
 
     def _require_auth(self, cid: str) -> bool:
+        if not self._env_token():
+            self._respond(
+                503,
+                self._envelope(
+                    correlation_id=cid,
+                    result_code="api_token_missing",
+                    warnings=["api_token_not_configured"],
+                    data={
+                        "hint": (
+                            "Configure VR_HOTSPOTD_API_TOKEN in the daemon environment "
+                            "and restart the service"
+                        )
+                    },
+                ),
+            )
+            return False
         if self._is_authorized():
             return True
         self._respond(
@@ -1186,23 +1202,20 @@ class APIHandler(BaseHTTPRequestHandler):
             self._respond_raw(200, b"ok\n", "text/plain; charset=utf-8")
             return
 
+        if (path == "/v1" or path.startswith("/v1/")) and not self._require_auth(cid):
+            return
+
         if path == "/v1/status":
             include_logs = self._qbool(qs, "include_logs", False)
-            if not self._require_auth(cid):
-                return
             st = self._status_view(include_logs=include_logs)
             self._respond(200, self._envelope(correlation_id=cid, data=st))
             return
 
         if path == "/v1/adapters":
-            if not self._require_auth(cid):
-                return
             self._respond(200, self._envelope(correlation_id=cid, data=get_adapters()))
             return
 
         if path == "/v1/adapters/readiness":
-            if not self._require_auth(cid):
-                return
             inventory = get_adapters()
             warnings = ["adapter_inventory_error"] if isinstance(inventory, dict) and inventory.get("error") else []
             self._respond(
@@ -1216,16 +1229,12 @@ class APIHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/v1/config":
-            if not self._require_auth(cid):
-                return
             include_secrets = self._qbool(qs, "include_secrets", False)
             cfg = self._config_view(include_secrets=include_secrets)
             self._respond(200, self._envelope(correlation_id=cid, data=cfg))
             return
 
         if path == "/v1/info":
-            if not self._require_auth(cid):
-                return
             data = {
                 "version": APP_VERSION,
                 "server_version": SERVER_VERSION,
@@ -1239,8 +1248,6 @@ class APIHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/v1/diagnostics/clients":
-            if not self._require_auth(cid):
-                return
             st = load_state()
             ap_ifname = st.get("adapter")
             snapshot = get_clients_snapshot(
@@ -1251,15 +1258,11 @@ class APIHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/v1/diagnostics/preflight":
-            if not self._require_auth(cid):
-                return
             report = collect_preflight_report(config=load_config_snapshot())
             self._respond(200, self._envelope(correlation_id=cid, data=report))
             return
 
         if path == "/v1/diagnostics/support_bundle":
-            if not self._require_auth(cid):
-                return
             bundle = self._build_support_bundle()
             self._respond_attachment(
                 200,

--- a/backend/vr_hotspotd/cli.py
+++ b/backend/vr_hotspotd/cli.py
@@ -148,6 +148,24 @@ def _api_error_detail(raw: bytes, *, secret: str = "") -> Optional[str]:
     return detail
 
 
+def _api_failure_cli_error(status: int, raw: bytes, *, token: str) -> CLIError:
+    detail = _api_error_detail(raw, secret=token)
+    suffix = f": {detail}" if detail else ""
+    if detail == "api_token_missing":
+        return CLIError(
+            f"API request failed (HTTP {status}{suffix}). The daemon has no configured "
+            f"API token; configure VR_HOTSPOTD_API_TOKEN in {DEFAULT_ENV_FILE} and "
+            "restart vr-hotspotd."
+        )
+    auth_hint = (
+        " Use VR_HOTSPOTD_API_TOKEN or --token-stdin, or run with permission "
+        f"to read {DEFAULT_ENV_FILE}."
+        if status in {401, 403}
+        else ""
+    )
+    return CLIError(f"API request failed (HTTP {status}{suffix}).{auth_hint}")
+
+
 def _contains_secret(value: Any, secret: str) -> bool:
     if not secret:
         return False
@@ -198,15 +216,7 @@ def _transport_cli_error(
             return CLIError(f"Unable to read the VR Hotspot API response: {safe_error}")
         if 300 <= exc.code < 400:
             return _redirect_error(exc.code)
-        detail = _api_error_detail(raw, secret=token)
-        suffix = f": {detail}" if detail else ""
-        auth_hint = (
-            " Use VR_HOTSPOTD_API_TOKEN or --token-stdin, or run with permission "
-            f"to read {DEFAULT_ENV_FILE}."
-            if exc.code in {401, 403}
-            else ""
-        )
-        return CLIError(f"API request failed (HTTP {exc.code}{suffix}).{auth_hint}")
+        return _api_failure_cli_error(exc.code, raw, token=token)
     if isinstance(exc, URLError):
         reason = getattr(exc, "reason", exc)
         safe_reason = _redacted_error_text(reason, token)
@@ -261,9 +271,7 @@ def fetch_preflight_report(
     if 300 <= status < 400:
         raise _redirect_error(status)
     if status != 200:
-        detail = _api_error_detail(raw, secret=token)
-        suffix = f": {detail}" if detail else ""
-        raise CLIError(f"API request failed (HTTP {status}{suffix}).")
+        raise _api_failure_cli_error(status, raw, token=token)
 
     invalid_json = False
     try:

--- a/tests/test_api_adapter_readiness.py
+++ b/tests/test_api_adapter_readiness.py
@@ -37,10 +37,11 @@ def _response_json(handler):
 
 
 def test_adapter_readiness_endpoint_exists(monkeypatch):
-    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     monkeypatch.setattr(api, "get_adapters", lambda: {"adapters": [], "recommended": None})
 
     handler = _make_handler()
+    handler.headers["X-Api-Token"] = "secret"
     handler.do_GET()
 
     payload = _response_json(handler)
@@ -61,7 +62,7 @@ def test_adapter_readiness_requires_auth(monkeypatch):
 
 
 def test_adapter_readiness_calls_model_with_inventory(monkeypatch):
-    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     inventory = {
         "recommended": "wlan1",
         "global_regdom": {"country": "US"},
@@ -77,6 +78,7 @@ def test_adapter_readiness_calls_model_with_inventory(monkeypatch):
     monkeypatch.setattr(api, "build_readiness_model", fake_build_readiness_model)
 
     handler = _make_handler()
+    handler.headers["X-Api-Token"] = "secret"
     handler.do_GET()
 
     assert handler._last_code == 200
@@ -85,7 +87,7 @@ def test_adapter_readiness_calls_model_with_inventory(monkeypatch):
 
 
 def test_adapter_readiness_no_adapter_response_shape(monkeypatch):
-    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     monkeypatch.setattr(
         api,
         "get_adapters",
@@ -97,6 +99,7 @@ def test_adapter_readiness_no_adapter_response_shape(monkeypatch):
     )
 
     handler = _make_handler()
+    handler.headers["X-Api-Token"] = "secret"
     handler.do_GET()
 
     data = _response_json(handler)["data"]
@@ -112,11 +115,12 @@ def test_adapter_readiness_no_adapter_response_shape(monkeypatch):
 
 
 def test_adapters_endpoint_output_unchanged(monkeypatch):
-    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     inventory = {"recommended": "wlan1", "adapters": [{"ifname": "wlan1"}]}
     monkeypatch.setattr(api, "get_adapters", lambda: inventory)
 
     handler = _make_handler("/v1/adapters")
+    handler.headers["X-Api-Token"] = "secret"
     handler.do_GET()
 
     assert handler._last_code == 200

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,15 +1,44 @@
+import io
+import json
 from email.message import Message
 
+import pytest
+
+import vr_hotspotd.server as api_server
 from vr_hotspotd.api import APIHandler
 
 
-def _handler_with_headers(headers):
+def _handler_with_headers(headers, *, path="/v1/info", method="GET", body=b"{}"):
     handler = APIHandler.__new__(APIHandler)
+    handler.rfile = io.BytesIO(body)
+    handler.wfile = io.BytesIO()
     msg = Message()
     for key, value in headers.items():
         msg[key] = value
+    msg["Content-Length"] = str(len(body))
     handler.headers = msg
+    handler.command = method
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
     return handler
+
+
+def _perform(handler):
+    getattr(handler, f"do_{handler.command}")()
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
 
 
 def test_get_req_token_prefers_x_api_token():
@@ -25,3 +54,195 @@ def test_get_req_token_prefers_x_api_token():
 def test_get_req_token_bearer():
     handler = _handler_with_headers({"Authorization": "Bearer token-bearer"})
     assert handler._get_req_token() == "token-bearer"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_status"),
+    (
+        ("/", 302),
+        ("/ui", 200),
+        ("/assets/ui.js", 200),
+        ("/favicon.ico", 204),
+        ("/healthz", 200),
+    ),
+)
+def test_public_get_routes_remain_public_without_configured_token(
+    monkeypatch,
+    path,
+    expected_status,
+):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+
+    handler = _perform(_handler_with_headers({}, path=path))
+
+    assert handler._last_code == expected_status
+    if path == "/healthz":
+        assert handler.wfile.getvalue() == b"ok\n"
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    (
+        ("GET", "/v1"),
+        ("GET", "/v1/status"),
+        ("GET", "/v1/adapters"),
+        ("GET", "/v1/adapters/readiness"),
+        ("GET", "/v1/config"),
+        ("GET", "/v1/info"),
+        ("GET", "/v1/diagnostics/clients"),
+        ("GET", "/v1/diagnostics/preflight"),
+        ("GET", "/v1/diagnostics/support_bundle"),
+        ("GET", "/v1/future-privileged"),
+        ("POST", "/v1/start"),
+        ("POST", "/v1/stop"),
+        ("POST", "/v1/repair"),
+        ("POST", "/v1/restart"),
+        ("POST", "/v1/config"),
+        ("POST", "/v1/config/reveal_passphrase"),
+        ("POST", "/v1/diagnostics/ping"),
+        ("POST", "/v1/diagnostics/ping_under_load"),
+        ("POST", "/v1/diagnostics/udp_latency"),
+        ("POST", "/v1/future-privileged"),
+        ("PUT", "/v1/config"),
+    ),
+)
+def test_privileged_routes_fail_closed_without_configured_token(monkeypatch, method, path):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+
+    handler = _perform(_handler_with_headers({}, path=path, method=method))
+    payload = _response_json(handler)
+
+    assert handler._last_code == 503
+    assert payload["result_code"] == "api_token_missing"
+    assert payload["warnings"] == ["api_token_not_configured"]
+    assert "VR_HOTSPOTD_API_TOKEN" in payload["data"]["hint"]
+    assert "web ui" not in payload["data"]["hint"].lower()
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        pytest.param({"X-Api-Token": "attacker-x-token"}, id="x-api-token"),
+        pytest.param(
+            {"Authorization": "Bearer attacker-bearer-token"},
+            id="bearer-token",
+        ),
+        pytest.param({"X-Api-Token": ""}, id="empty-x-api-token"),
+        pytest.param({"Authorization": "Bearer "}, id="empty-bearer-token"),
+    ),
+)
+def test_client_token_cannot_bypass_missing_server_token(monkeypatch, headers):
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+
+    handler = _perform(_handler_with_headers(headers))
+    payload_text = handler.wfile.getvalue().decode("utf-8")
+
+    assert handler._last_code == 503
+    assert json.loads(payload_text)["result_code"] == "api_token_missing"
+    assert "attacker-x-token" not in payload_text
+    assert "attacker-bearer-token" not in payload_text
+
+
+@pytest.mark.parametrize("server_token", (None, "", "   "))
+def test_missing_or_blank_server_token_is_never_authorized(monkeypatch, server_token):
+    if server_token is None:
+        monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", server_token)
+    handler = _handler_with_headers({"X-Api-Token": "any-client-token"})
+
+    assert handler._is_authorized() is False
+
+    _perform(handler)
+    assert handler._last_code == 503
+    assert _response_json(handler)["result_code"] == "api_token_missing"
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        pytest.param({"X-Api-Token": "configured-secret"}, id="x-api-token"),
+        pytest.param(
+            {"Authorization": "Bearer configured-secret"},
+            id="bearer-token",
+        ),
+    ),
+)
+def test_configured_token_accepts_supported_client_headers(monkeypatch, headers):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-secret")
+
+    handler = _perform(_handler_with_headers(headers))
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert payload["result_code"] == "ok"
+    assert payload["data"]["token_configured"] is True
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        pytest.param({}, id="missing-client-token"),
+        pytest.param({"X-Api-Token": "wrong"}, id="wrong-x-api-token"),
+        pytest.param({"Authorization": "Bearer wrong"}, id="wrong-bearer-token"),
+        pytest.param({"X-Api-Token": ""}, id="empty-x-api-token"),
+        pytest.param({"Authorization": "Bearer "}, id="empty-bearer-token"),
+    ),
+)
+def test_configured_token_rejects_missing_empty_or_wrong_client_token(monkeypatch, headers):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-secret")
+
+    handler = _perform(_handler_with_headers(headers))
+    payload = _response_json(handler)
+
+    assert handler._last_code == 401
+    assert payload["result_code"] == "unauthorized"
+    assert payload["warnings"] == ["missing_or_invalid_token"]
+
+
+@pytest.mark.parametrize("configured_token", (None, "", "   "))
+def test_non_loopback_bind_without_token_remains_refused(
+    monkeypatch,
+    configured_token,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_HOST", "0.0.0.0")
+    monkeypatch.setenv("VR_HOTSPOTD_PORT", "8732")
+    if configured_token is None:
+        monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", configured_token)
+
+    def must_not_build(*_args, **_kwargs):
+        raise AssertionError("server construction must not occur")
+
+    monkeypatch.setattr(api_server, "ThreadingHTTPServer", must_not_build)
+
+    with pytest.raises(SystemExit) as exc_info:
+        api_server.build_server()
+
+    assert exc_info.value.code == 1
+
+
+def test_loopback_bind_without_token_still_starts_for_public_routes(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_HOST", "127.0.0.1")
+    monkeypatch.setenv("VR_HOTSPOTD_PORT", "9876")
+    monkeypatch.delenv("VR_HOTSPOTD_API_TOKEN", raising=False)
+    seen = {}
+
+    class FakeServer:
+        daemon_threads = False
+
+    def build(address, handler_class):
+        seen["address"] = address
+        seen["handler_class"] = handler_class
+        return FakeServer()
+
+    monkeypatch.setattr(api_server, "ThreadingHTTPServer", build)
+
+    built = api_server.build_server()
+
+    assert seen == {
+        "address": ("127.0.0.1", 9876),
+        "handler_class": APIHandler,
+    }
+    assert built.daemon_threads is True

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -457,6 +457,26 @@ def test_preflight_command_reports_auth_failure_without_token_leak(
     assert secret not in captured.err
 
 
+def test_preflight_command_reports_missing_daemon_token_as_configuration_error(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    _mocked_http_error(monkeypatch, 503, "api_token_missing")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["preflight", *_missing_env_args(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "HTTP 503: api_token_missing" in captured.err
+    assert "daemon has no configured API token" in captured.err
+    assert "VR_HOTSPOTD_API_TOKEN in /etc/vr-hotspot/env" in captured.err
+    assert "restart vr-hotspotd" in captured.err
+    assert "--token-stdin" not in captured.err
+    assert captured.out == ""
+
+
 def test_preflight_command_reports_generic_non_200(monkeypatch, tmp_path, capsys):
     _mocked_http_error(monkeypatch, 500, "internal_error")
 


### PR DESCRIPTION
Implements the missing-token fail-closed API authentication safety fix recommended by the repository audit.

What changed:
- Privileged `/v1` routes now fail closed when the daemon has no configured API token.
- Missing or blank daemon token returns HTTP 503 with `result_code: api_token_missing`.
- Wrong, empty, or missing client credentials continue to return HTTP 401 with `result_code: unauthorized`.
- Correct `X-Api-Token` and `Authorization: Bearer` credentials continue to work.
- Unknown/future `GET /v1` paths are guarded before unauthenticated route handling.
- Public routes remain accessible:
  - `/`
  - `/ui`
  - static assets
  - `/favicon.ico`
  - `/healthz`
- Non-loopback bind without a token remains refused.
- CLI preflight now reports missing daemon-token configuration clearly.
- README documents the privileged API token requirement and trusted-network-only plain HTTP boundary.

Safety:
- No TLS implementation.
- No remote-access redesign.
- No UI changes.
- No adapter changes.
- No installer behavior changes.
- No Flatpak/desktop work.
- No diagnostics expansion.
- No support-bundle work.
- Docs changes are intentionally narrow.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `410 passed, 4 subtests passed`