### PR TITLE
fix: persist watchdog 5ghz channel correctly

### DIFF
--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -73,6 +73,11 @@ _OP_LOCK = threading.Lock()
 _WATCHDOG_THREAD: Optional[threading.Thread] = None
 _WATCHDOG_STOP = threading.Event()
 _WATCHDOG_BACKOFF_MAX_S = 30.0
+_WATCHDOG_CHANNEL_CONFIG_KEY_BY_BAND = {
+    "2.4ghz": "fallback_channel_2g",
+    "5ghz": "channel_5g",
+    "6ghz": "channel_6g",
+}
 _AUTOGEN_PASSPHRASE_CACHE: Optional[str] = None
 _AUTOGEN_PASSPHRASE_TS: float = 0.0
 
@@ -3245,14 +3250,10 @@ def _restart_from_watchdog(reason: str) -> None:
             try:
                 best_channel = select_best_channel(adapter_ifname, band)
                 if best_channel:
-                    # Update config with new channel
-                    if band == "6ghz":
-                        cfg["channel_6g"] = best_channel
-                    elif band == "2.4ghz":
-                        cfg["fallback_channel_2g"] = best_channel
-                    # Note: For 5GHz, channel selection is handled by lnxrouter
-                    from vr_hotspotd.config import write_config_file
-                    write_config_file({"channel_6g" if band == "6ghz" else "fallback_channel_2g": best_channel})
+                    config_key = _WATCHDOG_CHANNEL_CONFIG_KEY_BY_BAND.get(band)
+                    if config_key:
+                        cfg[config_key] = best_channel
+                        write_config_file({config_key: best_channel})
             except Exception:
                 pass  # Best-effort
     

--- a/tests/test_watchdog_reason.py
+++ b/tests/test_watchdog_reason.py
@@ -61,3 +61,119 @@ def test_restart_from_watchdog_skips_when_not_running(monkeypatch):
 
     assert called["stop"] == 0
     assert called["start"] == 0
+
+
+def _exercise_watchdog_channel_switch(
+    monkeypatch,
+    *,
+    band,
+    selected_channel,
+    fallback_channel_2g=6,
+    persistence_error=None,
+):
+    import vr_hotspotd.lifecycle as lifecycle
+
+    state = {
+        "running": True,
+        "phase": "running",
+        "adapter": "wlan0",
+        "band": band,
+        "warnings": [],
+    }
+    cfg = {
+        "auto_channel_switch": True,
+        "fallback_channel_2g": fallback_channel_2g,
+        "channel_5g": 36,
+        "channel_6g": 5,
+    }
+    writes = []
+    restart_calls = []
+
+    def fake_write_config_file(updates):
+        writes.append(dict(updates))
+        if persistence_error is not None:
+            raise persistence_error
+        cfg.update(updates)
+        return dict(cfg)
+
+    monkeypatch.setattr(lifecycle, "load_state", lambda: state)
+    monkeypatch.setattr(lifecycle, "update_state", lambda **updates: state.update(updates))
+    monkeypatch.setattr(lifecycle, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        lifecycle,
+        "select_best_channel",
+        lambda adapter_ifname, requested_band: selected_channel,
+    )
+    monkeypatch.setattr(lifecycle, "write_config_file", fake_write_config_file)
+    monkeypatch.setattr(
+        lifecycle,
+        "_stop_hotspot_impl",
+        lambda **_kwargs: restart_calls.append("stop"),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "_start_hotspot_impl",
+        lambda **_kwargs: restart_calls.append("start"),
+    )
+
+    lifecycle._restart_from_watchdog("connection_quality_degraded:score=40.0")
+
+    return cfg, writes, restart_calls
+
+
+def test_watchdog_5ghz_channel_switch_persists_channel_5g(monkeypatch):
+    cfg, writes, restart_calls = _exercise_watchdog_channel_switch(
+        monkeypatch,
+        band="5ghz",
+        selected_channel=149,
+    )
+
+    assert writes == [{"channel_5g": 149}]
+    assert cfg["channel_5g"] == 149
+    assert restart_calls == ["stop", "start"]
+
+
+def test_watchdog_5ghz_channel_switch_preserves_2g_fallback(monkeypatch):
+    cfg, writes, _restart_calls = _exercise_watchdog_channel_switch(
+        monkeypatch,
+        band="5ghz",
+        selected_channel=149,
+        fallback_channel_2g=11,
+    )
+
+    assert writes == [{"channel_5g": 149}]
+    assert cfg["fallback_channel_2g"] == 11
+
+
+def test_watchdog_2g_channel_switch_persists_fallback_channel_2g(monkeypatch):
+    cfg, writes, _restart_calls = _exercise_watchdog_channel_switch(
+        monkeypatch,
+        band="2.4ghz",
+        selected_channel=1,
+    )
+
+    assert writes == [{"fallback_channel_2g": 1}]
+    assert cfg["fallback_channel_2g"] == 1
+
+
+def test_watchdog_6ghz_channel_switch_persists_channel_6g(monkeypatch):
+    cfg, writes, _restart_calls = _exercise_watchdog_channel_switch(
+        monkeypatch,
+        band="6ghz",
+        selected_channel=37,
+    )
+
+    assert writes == [{"channel_6g": 37}]
+    assert cfg["channel_6g"] == 37
+
+
+def test_watchdog_config_persistence_failure_remains_best_effort(monkeypatch):
+    _cfg, writes, restart_calls = _exercise_watchdog_channel_switch(
+        monkeypatch,
+        band="5ghz",
+        selected_channel=149,
+        persistence_error=OSError("config write failed"),
+    )
+
+    assert writes == [{"channel_5g": 149}]
+    assert restart_calls == ["stop", "start"]


### PR DESCRIPTION
Fixes a watchdog channel-persistence bug where a 5 GHz watchdog channel switch could incorrectly write the selected 5 GHz channel into `fallback_channel_2g`.

What changed:
- Adds explicit watchdog band-to-config-key mapping:
  - `2.4ghz` → `fallback_channel_2g`
  - `5ghz` → `channel_5g`
  - `6ghz` → `channel_6g`
- Ensures 5 GHz watchdog recovery persists selected channels to `channel_5g`.
- Ensures 5 GHz watchdog recovery does not modify or corrupt `fallback_channel_2g`.
- Preserves existing 2.4 GHz and 6 GHz persistence behavior.
- Preserves existing best-effort behavior when config persistence fails.

Safety:
- No channel scoring changes.
- No channel scanning changes.
- No adapter selection changes.
- No watchdog threshold or restart-policy changes.
- No telemetry scoring changes.
- No hostapd/lnxrouter command changes.
- No UI, API, installer, docs, Flatpak, support-bundle, auth, UFW, or firewall changes.

Tests:
- Adds focused regression coverage for 5 GHz persistence.
- Confirms 5 GHz does not modify `fallback_channel_2g`.
- Confirms 2.4 GHz still writes `fallback_channel_2g`.
- Confirms 6 GHz still writes `channel_6g`.
- Confirms config-write failure remains best-effort and restart continues.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `415 passed, 4 subtests passed`