### PR TITLE
fix: bound diagnostic input budgets

### DIFF
--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -24,8 +24,9 @@ from vr_hotspotd.lifecycle import (
 from vr_hotspotd.engine.supervisor import get_tails
 from vr_hotspotd.diagnostics.clients import get_clients_snapshot
 from vr_hotspotd.diagnostics.ping import run_ping, ping_available
-from vr_hotspotd.diagnostics.load import LoadGenerator
+from vr_hotspotd.diagnostics.load import LoadGenerator, validate_curl_url, validate_network_host
 from vr_hotspotd.diagnostics.udp_latency import run_udp_latency_test
+from vr_hotspotd.diagnostics import limits as diagnostic_limits
 from vr_hotspotd.diagnostics.platform import collect_platform_matrix
 from vr_hotspotd.diagnostics.preflight_report import collect_preflight_report
 from vr_hotspotd.diagnostics.support_bundle import (
@@ -222,7 +223,11 @@ def _clamp_int(
         parsed = int(value)
     except Exception as exc:
         raise ValueError(f"{name}_invalid") from exc
-    clamped = max(min_val, min(max_val, parsed))
+    clamped = diagnostic_limits.clamp_int(
+        parsed,
+        min_value=min_val,
+        max_value=max_val,
+    )
     if clamped != parsed:
         warnings.append(f"{name}_clamped")
     return clamped
@@ -243,7 +248,14 @@ def _clamp_float(
         parsed = float(value)
     except Exception as exc:
         raise ValueError(f"{name}_invalid") from exc
-    clamped = max(min_val, min(max_val, parsed))
+    try:
+        clamped = diagnostic_limits.clamp_float(
+            parsed,
+            min_value=min_val,
+            max_value=max_val,
+        )
+    except ValueError as exc:
+        raise ValueError(f"{name}_invalid") from exc
     if clamped != parsed:
         warnings.append(f"{name}_clamped")
     return clamped
@@ -1475,25 +1487,25 @@ class APIHandler(BaseHTTPRequestHandler):
             try:
                 duration_s = _clamp_int(
                     body.get("duration_s"),
-                    default=10,
-                    min_val=3,
-                    max_val=20,
+                    default=diagnostic_limits.PING_DEFAULT_DURATION_S,
+                    min_val=diagnostic_limits.LOAD_MIN_DURATION_S,
+                    max_val=diagnostic_limits.LOAD_MAX_DURATION_S,
                     warnings=warnings,
                     name="duration_s",
                 )
                 interval_ms = _clamp_int(
                     body.get("interval_ms"),
-                    default=20,
-                    min_val=10,
-                    max_val=200,
+                    default=diagnostic_limits.PING_DEFAULT_INTERVAL_MS,
+                    min_val=diagnostic_limits.LOAD_MIN_INTERVAL_MS,
+                    max_val=diagnostic_limits.LOAD_MAX_INTERVAL_MS,
                     warnings=warnings,
                     name="interval_ms",
                 )
             except ValueError:
                 data = {
                     "target_ip": target_ip,
-                    "duration_s": 10,
-                    "interval_ms": 20,
+                    "duration_s": diagnostic_limits.PING_DEFAULT_DURATION_S,
+                    "interval_ms": diagnostic_limits.PING_DEFAULT_INTERVAL_MS,
                     "load": {
                         "method": "none",
                         "requested_mbps": 0.0,
@@ -1552,9 +1564,9 @@ class APIHandler(BaseHTTPRequestHandler):
             try:
                 mbps = _clamp_float(
                     load_cfg.get("mbps"),
-                    default=150.0,
-                    min_val=10.0,
-                    max_val=400.0,
+                    default=diagnostic_limits.LOAD_DEFAULT_MBPS,
+                    min_val=diagnostic_limits.LOAD_MIN_MBPS,
+                    max_val=diagnostic_limits.LOAD_MAX_MBPS,
                     warnings=warnings,
                     name="mbps",
                 )
@@ -1577,11 +1589,26 @@ class APIHandler(BaseHTTPRequestHandler):
                 self._respond(400, self._envelope(correlation_id=cid, result_code="error", data=data, warnings=warnings))
                 return
 
-            url = str(load_cfg.get("url") or "").strip()
-            iperf3_host = str(load_cfg.get("iperf3_host") or "").strip()
+            url = ""
+            iperf3_host = ""
+            iperf3_port = diagnostic_limits.LOAD_DEFAULT_IPERF3_PORT
             try:
-                iperf3_port = int(load_cfg.get("iperf3_port") or 5201)
-            except Exception:
+                if method == "curl":
+                    url = validate_curl_url(load_cfg.get("url"))
+                else:
+                    iperf3_host = validate_network_host(load_cfg.get("iperf3_host"))
+                    iperf3_port = _clamp_int(
+                        load_cfg.get("iperf3_port"),
+                        default=diagnostic_limits.LOAD_DEFAULT_IPERF3_PORT,
+                        min_val=diagnostic_limits.LOAD_MIN_PORT,
+                        max_val=diagnostic_limits.LOAD_MAX_PORT,
+                        warnings=warnings,
+                        name="iperf3_port",
+                    )
+            except ValueError as exc:
+                invalid_message = str(exc)
+                if invalid_message == "iperf3_port_invalid":
+                    invalid_message = "invalid iperf3_port"
                 data = {
                     "target_ip": target_ip,
                     "duration_s": duration_s,
@@ -1593,9 +1620,9 @@ class APIHandler(BaseHTTPRequestHandler):
                         "notes": [],
                         "started": False,
                     },
-                    "ping": {"error": {"code": "invalid_params", "message": "invalid iperf3_port"}},
+                    "ping": {"error": {"code": "invalid_params", "message": invalid_message}},
                     "classification": {"grade": "unusable", "reason": "invalid_params"},
-                    "error": {"code": "invalid_params", "message": "invalid iperf3_port"},
+                    "error": {"code": "invalid_params", "message": invalid_message},
                 }
                 self._respond(400, self._envelope(correlation_id=cid, result_code="error", data=data, warnings=warnings))
                 return
@@ -1709,10 +1736,9 @@ class APIHandler(BaseHTTPRequestHandler):
             return
 
         if path == "/v1/diagnostics/ping":
-            target_ip = (body.get("target_ip") or "").strip() if isinstance(body, dict) else ""
-            duration_s = body.get("duration_s") if isinstance(body, dict) else None
-            interval_ms = body.get("interval_ms") if isinstance(body, dict) else None
-            timeout_s = body.get("timeout_s") if isinstance(body, dict) else None
+            warnings = list(body_warnings)
+            request_body = body if isinstance(body, dict) else {}
+            target_ip = str(request_body.get("target_ip") or "").strip()
 
             try:
                 ipaddress.IPv4Address(target_ip)
@@ -1727,34 +1753,80 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
                 return
 
+            raw_count = request_body.get("count")
+            if raw_count is None:
+                raw_count = request_body.get("packets")
             try:
-                duration_s = int(duration_s) if duration_s is not None else 10
-            except Exception:
-                duration_s = 10
-            try:
-                interval_ms = int(interval_ms) if interval_ms is not None else 20
-            except Exception:
-                interval_ms = 20
-            try:
-                timeout_s = int(timeout_s) if timeout_s is not None else 2
-            except Exception:
-                timeout_s = 2
+                duration_s = _clamp_int(
+                    request_body.get("duration_s"),
+                    default=diagnostic_limits.PING_DEFAULT_DURATION_S,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_DURATION_S,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_DURATION_S,
+                    warnings=warnings,
+                    name="duration_s",
+                )
+                interval_ms = _clamp_int(
+                    request_body.get("interval_ms"),
+                    default=diagnostic_limits.PING_DEFAULT_INTERVAL_MS,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_INTERVAL_MS,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_INTERVAL_MS,
+                    warnings=warnings,
+                    name="interval_ms",
+                )
+                timeout_s = _clamp_int(
+                    request_body.get("timeout_s"),
+                    default=diagnostic_limits.PING_DEFAULT_REPLY_TIMEOUT_S,
+                    min_val=diagnostic_limits.PING_MIN_REPLY_TIMEOUT_S,
+                    max_val=diagnostic_limits.PING_MAX_REPLY_TIMEOUT_S,
+                    warnings=warnings,
+                    name="timeout_s",
+                )
+                packet_size = _clamp_int(
+                    request_body.get("packet_size"),
+                    default=diagnostic_limits.PING_DEFAULT_PACKET_SIZE,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_SIZE,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_PACKET_SIZE,
+                    warnings=warnings,
+                    name="packet_size",
+                )
+                count = (
+                    diagnostic_limits.packet_count_for_budget(duration_s, interval_ms)
+                    if raw_count is None
+                    else _clamp_int(
+                        raw_count,
+                        default=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                        min_val=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                        max_val=diagnostic_limits.DIAGNOSTIC_MAX_PACKET_COUNT,
+                        warnings=warnings,
+                        name="count",
+                    )
+                )
+            except ValueError:
+                self._respond(
+                    400,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code="invalid_request",
+                        warnings=warnings + ["invalid_diagnostic_params"],
+                    ),
+                )
+                return
 
             res = run_ping(
                 target_ip=target_ip,
                 duration_s=duration_s,
                 interval_ms=interval_ms,
                 timeout_s=timeout_s,
+                count=count,
+                packet_size=packet_size,
             )
-            self._respond(200, self._envelope(correlation_id=cid, data=res))
+            self._respond(200, self._envelope(correlation_id=cid, data=res, warnings=warnings))
             return
 
         if path == "/v1/diagnostics/udp_latency":
-            target_ip = (body.get("target_ip") or "").strip() if isinstance(body, dict) else ""
-            duration_s = body.get("duration_s") if isinstance(body, dict) else None
-            interval_ms = body.get("interval_ms") if isinstance(body, dict) else None
-            target_port = body.get("target_port") if isinstance(body, dict) else None
-            packet_size = body.get("packet_size") if isinstance(body, dict) else None
+            warnings = list(body_warnings)
+            request_body = body if isinstance(body, dict) else {}
+            target_ip = str(request_body.get("target_ip") or "").strip()
 
             try:
                 ipaddress.IPv4Address(target_ip)
@@ -1769,22 +1841,64 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
                 return
 
+            raw_count = request_body.get("count")
+            if raw_count is None:
+                raw_count = request_body.get("packets")
             try:
-                duration_s = int(duration_s) if duration_s is not None else 10
-            except Exception:
-                duration_s = 10
-            try:
-                interval_ms = int(interval_ms) if interval_ms is not None else 20
-            except Exception:
-                interval_ms = 20
-            try:
-                target_port = int(target_port) if target_port is not None else 12345
-            except Exception:
-                target_port = 12345
-            try:
-                packet_size = int(packet_size) if packet_size is not None else 64
-            except Exception:
-                packet_size = 64
+                duration_s = _clamp_int(
+                    request_body.get("duration_s"),
+                    default=diagnostic_limits.UDP_DEFAULT_DURATION_S,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_DURATION_S,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_DURATION_S,
+                    warnings=warnings,
+                    name="duration_s",
+                )
+                interval_ms = _clamp_int(
+                    request_body.get("interval_ms"),
+                    default=diagnostic_limits.UDP_DEFAULT_INTERVAL_MS,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_INTERVAL_MS,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_INTERVAL_MS,
+                    warnings=warnings,
+                    name="interval_ms",
+                )
+                target_port = _clamp_int(
+                    request_body.get("target_port"),
+                    default=diagnostic_limits.UDP_DEFAULT_PORT,
+                    min_val=diagnostic_limits.UDP_MIN_PORT,
+                    max_val=diagnostic_limits.UDP_MAX_PORT,
+                    warnings=warnings,
+                    name="target_port",
+                )
+                packet_size = _clamp_int(
+                    request_body.get("packet_size"),
+                    default=diagnostic_limits.UDP_DEFAULT_PACKET_SIZE,
+                    min_val=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_SIZE,
+                    max_val=diagnostic_limits.DIAGNOSTIC_MAX_PACKET_SIZE,
+                    warnings=warnings,
+                    name="packet_size",
+                )
+                count = (
+                    diagnostic_limits.packet_count_for_budget(duration_s, interval_ms)
+                    if raw_count is None
+                    else _clamp_int(
+                        raw_count,
+                        default=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                        min_val=diagnostic_limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                        max_val=diagnostic_limits.DIAGNOSTIC_MAX_PACKET_COUNT,
+                        warnings=warnings,
+                        name="count",
+                    )
+                )
+            except ValueError:
+                self._respond(
+                    400,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code="invalid_request",
+                        warnings=warnings + ["invalid_diagnostic_params"],
+                    ),
+                )
+                return
 
             res = run_udp_latency_test(
                 target_ip=target_ip,
@@ -1792,8 +1906,9 @@ class APIHandler(BaseHTTPRequestHandler):
                 duration_s=duration_s,
                 interval_ms=interval_ms,
                 packet_size=packet_size,
+                count=count,
             )
-            self._respond(200, self._envelope(correlation_id=cid, data=res))
+            self._respond(200, self._envelope(correlation_id=cid, data=res, warnings=warnings))
             return
 
         self._respond(

--- a/backend/vr_hotspotd/diagnostics/limits.py
+++ b/backend/vr_hotspotd/diagnostics/limits.py
@@ -1,0 +1,62 @@
+import math
+from typing import Any
+
+
+DIAGNOSTIC_MIN_DURATION_S = 1
+DIAGNOSTIC_MAX_DURATION_S = 20
+DIAGNOSTIC_MIN_INTERVAL_MS = 10
+DIAGNOSTIC_MAX_INTERVAL_MS = 1000
+DIAGNOSTIC_MIN_PACKET_COUNT = 1
+DIAGNOSTIC_MAX_PACKET_COUNT = 2000
+DIAGNOSTIC_MIN_PACKET_SIZE = 16
+DIAGNOSTIC_MAX_PACKET_SIZE = 1472
+
+PING_DEFAULT_DURATION_S = 10
+PING_DEFAULT_INTERVAL_MS = 20
+PING_DEFAULT_PACKET_SIZE = 56
+PING_DEFAULT_REPLY_TIMEOUT_S = 2
+PING_MIN_REPLY_TIMEOUT_S = 1
+PING_MAX_REPLY_TIMEOUT_S = 5
+PING_SUBPROCESS_GRACE_S = 2.0
+
+UDP_DEFAULT_DURATION_S = 10
+UDP_DEFAULT_INTERVAL_MS = 20
+UDP_DEFAULT_PACKET_SIZE = 64
+UDP_DEFAULT_PORT = 12345
+UDP_MIN_PORT = 1
+UDP_MAX_PORT = 65535
+
+LOAD_MIN_DURATION_S = 3
+LOAD_MAX_DURATION_S = DIAGNOSTIC_MAX_DURATION_S
+LOAD_MIN_INTERVAL_MS = 10
+LOAD_MAX_INTERVAL_MS = 200
+LOAD_DEFAULT_MBPS = 150.0
+LOAD_MIN_MBPS = 10.0
+LOAD_MAX_MBPS = 400.0
+LOAD_DEFAULT_IPERF3_PORT = 5201
+LOAD_MIN_PORT = 1
+LOAD_MAX_PORT = 65535
+LOAD_MAX_URL_LENGTH = 2048
+LOAD_MAX_HOST_LENGTH = 253
+LOAD_PROCESS_GRACE_S = 2
+
+
+def clamp_int(value: Any, *, min_value: int, max_value: int) -> int:
+    parsed = int(value)
+    return max(min_value, min(max_value, parsed))
+
+
+def clamp_float(value: Any, *, min_value: float, max_value: float) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError("value must be finite")
+    return max(min_value, min(max_value, parsed))
+
+
+def packet_count_for_budget(duration_s: int, interval_ms: int) -> int:
+    count = math.ceil(int(duration_s) * 1000 / int(interval_ms))
+    return clamp_int(
+        count,
+        min_value=DIAGNOSTIC_MIN_PACKET_COUNT,
+        max_value=DIAGNOSTIC_MAX_PACKET_COUNT,
+    )

--- a/backend/vr_hotspotd/diagnostics/load.py
+++ b/backend/vr_hotspotd/diagnostics/load.py
@@ -1,8 +1,63 @@
+import ipaddress
+import re
 import shutil
 import subprocess
 from typing import List, Optional
+from urllib.parse import urlsplit
+
+from vr_hotspotd.diagnostics import limits
 
 DEFAULT_CURL_URL = "https://speed.cloudflare.com/__down?bytes=25000000"
+_DNS_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+
+def validate_network_host(value: str) -> str:
+    host = str(value or "").strip()
+    if not host or len(host) > limits.LOAD_MAX_HOST_LENGTH:
+        raise ValueError("invalid network host")
+    if host.startswith("-") or any(ch.isspace() or ord(ch) < 32 for ch in host):
+        raise ValueError("invalid network host")
+
+    try:
+        ipaddress.ip_address(host)
+        return host
+    except ValueError:
+        pass
+
+    dns_host = host[:-1] if host.endswith(".") else host
+    try:
+        ascii_host = dns_host.encode("idna").decode("ascii")
+    except UnicodeError as exc:
+        raise ValueError("invalid network host") from exc
+    if (
+        not ascii_host
+        or len(ascii_host) > limits.LOAD_MAX_HOST_LENGTH
+        or any(not _DNS_LABEL_RE.fullmatch(label) for label in ascii_host.split("."))
+    ):
+        raise ValueError("invalid network host")
+    return host
+
+
+def validate_curl_url(value: str) -> str:
+    url = str(value or "").strip() or DEFAULT_CURL_URL
+    if len(url) > limits.LOAD_MAX_URL_LENGTH:
+        raise ValueError("curl URL is too long")
+    if "\\" in url or any(ch.isspace() or ord(ch) < 32 for ch in url):
+        raise ValueError("invalid curl URL")
+
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("invalid curl URL") from exc
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError("unsupported curl URL scheme")
+    if not parsed.netloc or not parsed.hostname:
+        raise ValueError("invalid curl URL")
+    validate_network_host(parsed.hostname)
+    if port is not None and not limits.LOAD_MIN_PORT <= port <= limits.LOAD_MAX_PORT:
+        raise ValueError("invalid curl URL port")
+    return url
 
 
 class LoadGenerator:
@@ -17,12 +72,24 @@ class LoadGenerator:
         iperf3_port: int,
     ):
         self.method = (method or "").strip().lower() or "curl"
-        self.requested_mbps = float(mbps)
-        self.effective_mbps = float(mbps)
-        self.duration_s = int(duration_s)
-        self.url = url
-        self.iperf3_host = iperf3_host
-        self.iperf3_port = int(iperf3_port)
+        self.requested_mbps = limits.clamp_float(
+            mbps,
+            min_value=limits.LOAD_MIN_MBPS,
+            max_value=limits.LOAD_MAX_MBPS,
+        )
+        self.effective_mbps = self.requested_mbps
+        self.duration_s = limits.clamp_int(
+            duration_s,
+            min_value=limits.LOAD_MIN_DURATION_S,
+            max_value=limits.LOAD_MAX_DURATION_S,
+        )
+        self.url = str(url or "").strip()
+        self.iperf3_host = str(iperf3_host or "").strip()
+        self.iperf3_port = limits.clamp_int(
+            iperf3_port,
+            min_value=limits.LOAD_MIN_PORT,
+            max_value=limits.LOAD_MAX_PORT,
+        )
         self.notes: List[str] = []
         self.started = False
         self.proc: Optional[subprocess.Popen] = None
@@ -32,14 +99,20 @@ class LoadGenerator:
         return max(1, int(self.effective_mbps * 1_000_000 / 8.0))
 
     def _build_curl_cmd(self, curl_bin: str) -> List[str]:
-        url = self.url.strip() if self.url else DEFAULT_CURL_URL
+        url = validate_curl_url(self.url)
         limit_bps = str(self._bytes_per_sec())
-        max_time = str(self.duration_s + 2)
+        max_time = str(self.duration_s + limits.LOAD_PROCESS_GRACE_S)
         return [
             curl_bin,
-            "-L",
+            "--disable",
+            "--globoff",
+            "--no-location",
             "--silent",
             "--show-error",
+            "--proto",
+            "=http,https",
+            "--max-redirs",
+            "0",
             "--output",
             "/dev/null",
             "--limit-rate",
@@ -52,10 +125,11 @@ class LoadGenerator:
         ]
 
     def _build_iperf3_cmd(self, iperf3_bin: str) -> List[str]:
+        host = validate_network_host(self.iperf3_host)
         return [
             iperf3_bin,
             "-c",
-            self.iperf3_host,
+            host,
             "-p",
             str(self.iperf3_port),
             "-t",
@@ -72,27 +146,33 @@ class LoadGenerator:
             self.effective_mbps = 0.0
             return
 
-        if self.method == "curl":
-            curl_bin = shutil.which("curl")
-            if not curl_bin:
-                self.notes.append("curl_not_found")
-                self.method = "none"
-                self.effective_mbps = 0.0
-                return
-            cmd = self._build_curl_cmd(curl_bin)
-        else:
-            iperf3_bin = shutil.which("iperf3")
-            if not iperf3_bin:
-                self.notes.append("iperf3_not_found")
-                self.method = "none"
-                self.effective_mbps = 0.0
-                return
-            if not self.iperf3_host:
-                self.notes.append("iperf3_host_missing")
-                self.method = "none"
-                self.effective_mbps = 0.0
-                return
-            cmd = self._build_iperf3_cmd(iperf3_bin)
+        try:
+            if self.method == "curl":
+                curl_bin = shutil.which("curl")
+                if not curl_bin:
+                    self.notes.append("curl_not_found")
+                    self.method = "none"
+                    self.effective_mbps = 0.0
+                    return
+                cmd = self._build_curl_cmd(curl_bin)
+            else:
+                iperf3_bin = shutil.which("iperf3")
+                if not iperf3_bin:
+                    self.notes.append("iperf3_not_found")
+                    self.method = "none"
+                    self.effective_mbps = 0.0
+                    return
+                if not self.iperf3_host:
+                    self.notes.append("iperf3_host_missing")
+                    self.method = "none"
+                    self.effective_mbps = 0.0
+                    return
+                cmd = self._build_iperf3_cmd(iperf3_bin)
+        except ValueError:
+            self.notes.append("load_params_invalid")
+            self.method = "none"
+            self.effective_mbps = 0.0
+            return
 
         try:
             self.command = cmd

--- a/backend/vr_hotspotd/diagnostics/ping.py
+++ b/backend/vr_hotspotd/diagnostics/ping.py
@@ -4,7 +4,9 @@ import shutil
 import subprocess
 from typing import Dict, List, Optional
 
-_MAX_SAMPLES = 2000
+from vr_hotspotd.diagnostics import limits
+
+_MAX_SAMPLES = limits.DIAGNOSTIC_MAX_PACKET_COUNT
 
 
 def ping_available() -> bool:
@@ -67,34 +69,87 @@ def _parse_ping_output(text: str) -> Dict[str, Optional[float]]:
 
 def run_ping(
     target_ip: str,
-    duration_s: int = 10,
-    interval_ms: int = 20,
-    timeout_s: int = 2,
+    duration_s: int = limits.PING_DEFAULT_DURATION_S,
+    interval_ms: int = limits.PING_DEFAULT_INTERVAL_MS,
+    timeout_s: int = limits.PING_DEFAULT_REPLY_TIMEOUT_S,
+    count: Optional[int] = None,
+    packet_size: int = limits.PING_DEFAULT_PACKET_SIZE,
 ) -> dict:
     if not target_ip:
         return {"error": {"code": "invalid_target", "message": "target_ip is required"}}
+
+    try:
+        duration_s = limits.clamp_int(
+            duration_s,
+            min_value=limits.DIAGNOSTIC_MIN_DURATION_S,
+            max_value=limits.DIAGNOSTIC_MAX_DURATION_S,
+        )
+        interval_ms = limits.clamp_int(
+            interval_ms,
+            min_value=limits.DIAGNOSTIC_MIN_INTERVAL_MS,
+            max_value=limits.DIAGNOSTIC_MAX_INTERVAL_MS,
+        )
+        reply_timeout_s = limits.clamp_int(
+            timeout_s,
+            min_value=limits.PING_MIN_REPLY_TIMEOUT_S,
+            max_value=limits.PING_MAX_REPLY_TIMEOUT_S,
+        )
+        packet_size = limits.clamp_int(
+            packet_size,
+            min_value=limits.DIAGNOSTIC_MIN_PACKET_SIZE,
+            max_value=limits.DIAGNOSTIC_MAX_PACKET_SIZE,
+        )
+        packet_count = (
+            limits.packet_count_for_budget(duration_s, interval_ms)
+            if count is None
+            else limits.clamp_int(
+                count,
+                min_value=limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                max_value=limits.DIAGNOSTIC_MAX_PACKET_COUNT,
+            )
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        return {"error": {"code": "invalid_params", "message": str(exc)}}
 
     ping_bin = shutil.which("ping")
     if not ping_bin:
         return {"error": {"code": "ping_not_found", "message": "ping not found in PATH"}}
 
+    interval_s = interval_ms / 1000.0
+    cmd = [
+        ping_bin,
+        "-n",
+        "-c",
+        str(packet_count),
+        "-i",
+        f"{interval_s:.3f}",
+        "-w",
+        str(duration_s),
+        "-W",
+        str(reply_timeout_s),
+        "-s",
+        str(packet_size),
+        target_ip,
+    ]
+
+    subprocess_timeout_s = duration_s + limits.PING_SUBPROCESS_GRACE_S
     try:
-        interval_s = max(1, int(interval_ms)) / 1000.0
-        cmd = [
-            ping_bin,
-            "-n",
-            "-i",
-            f"{interval_s:.3f}",
-            "-w",
-            str(int(duration_s)),
-            "-W",
-            str(int(timeout_s)),
-            target_ip,
-        ]
-    except Exception as exc:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=subprocess_timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "error": {
+                "code": "ping_timeout",
+                "message": "ping exceeded the diagnostic execution budget",
+            }
+        }
+    except OSError as exc:
         return {"error": {"code": "ping_failed", "message": str(exc)}}
 
-    proc = subprocess.run(cmd, capture_output=True, text=True)
     output = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
 
     if proc.returncode != 0:

--- a/backend/vr_hotspotd/diagnostics/udp_latency.py
+++ b/backend/vr_hotspotd/diagnostics/udp_latency.py
@@ -5,15 +5,18 @@ VR streaming typically uses UDP, so this provides more relevant metrics than TCP
 import socket
 import time
 import struct
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+from vr_hotspotd.diagnostics import limits
 
 
 def run_udp_latency_test(
     target_ip: str,
-    target_port: int = 12345,
-    duration_s: int = 10,
-    interval_ms: int = 20,
-    packet_size: int = 64,
+    target_port: int = limits.UDP_DEFAULT_PORT,
+    duration_s: int = limits.UDP_DEFAULT_DURATION_S,
+    interval_ms: int = limits.UDP_DEFAULT_INTERVAL_MS,
+    packet_size: int = limits.UDP_DEFAULT_PACKET_SIZE,
+    count: Optional[int] = None,
 ) -> Dict:
     """
     Run UDP latency test by sending UDP packets and measuring round-trip time.
@@ -24,7 +27,40 @@ def run_udp_latency_test(
     """
     if not target_ip:
         return {"error": {"code": "invalid_target", "message": "target_ip is required"}}
-    
+
+    try:
+        target_port = limits.clamp_int(
+            target_port,
+            min_value=limits.UDP_MIN_PORT,
+            max_value=limits.UDP_MAX_PORT,
+        )
+        duration_s = limits.clamp_int(
+            duration_s,
+            min_value=limits.DIAGNOSTIC_MIN_DURATION_S,
+            max_value=limits.DIAGNOSTIC_MAX_DURATION_S,
+        )
+        interval_ms = limits.clamp_int(
+            interval_ms,
+            min_value=limits.DIAGNOSTIC_MIN_INTERVAL_MS,
+            max_value=limits.DIAGNOSTIC_MAX_INTERVAL_MS,
+        )
+        packet_size = limits.clamp_int(
+            packet_size,
+            min_value=limits.DIAGNOSTIC_MIN_PACKET_SIZE,
+            max_value=limits.DIAGNOSTIC_MAX_PACKET_SIZE,
+        )
+        packet_count = (
+            limits.packet_count_for_budget(duration_s, interval_ms)
+            if count is None
+            else limits.clamp_int(
+                count,
+                min_value=limits.DIAGNOSTIC_MIN_PACKET_COUNT,
+                max_value=limits.DIAGNOSTIC_MAX_PACKET_COUNT,
+            )
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        return {"error": {"code": "invalid_params", "message": str(exc)}}
+
     samples: List[float] = []
     sent = 0
     received = 0
@@ -37,9 +73,12 @@ def run_udp_latency_test(
         sock.settimeout(interval_s * 2)
         
         seq = 0
-        while time.time() < deadline:
+        while sent < packet_count and time.time() < deadline:
             send_time = time.time()
             seq += 1
+
+            remaining_s = deadline - send_time
+            sock.settimeout(max(0.001, min(interval_s * 2, remaining_s)))
             
             # Send UDP packet with sequence number and timestamp
             payload = struct.pack("!Qd", seq, send_time)  # 8 bytes seq + 8 bytes timestamp

--- a/tests/test_diagnostic_input_budgets.py
+++ b/tests/test_diagnostic_input_budgets.py
@@ -1,0 +1,385 @@
+import io
+import json
+import struct
+from email.message import Message
+
+import pytest
+
+from vr_hotspotd import api
+from vr_hotspotd.diagnostics import limits
+from vr_hotspotd.diagnostics import udp_latency
+
+
+def _make_handler(path: str, body: dict, token: str = "secret"):
+    raw = json.dumps(body).encode("utf-8")
+    handler = api.APIHandler.__new__(api.APIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.headers["Content-Length"] = str(len(raw))
+    handler.headers["X-Api-Token"] = token
+    handler.command = "POST"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"POST {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _post(monkeypatch, path: str, body: dict):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    handler = _make_handler(path, body)
+    handler.do_POST()
+    return handler, json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_ping_route_preserves_valid_inputs(monkeypatch):
+    captured = {}
+
+    def fake_run_ping(**kwargs):
+        captured.update(kwargs)
+        return {"target_ip": kwargs["target_ip"], "sent": 1, "received": 1}
+
+    monkeypatch.setattr(api, "run_ping", fake_run_ping)
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/ping",
+        {
+            "target_ip": "192.168.1.1",
+            "duration_s": 5,
+            "interval_ms": 50,
+            "timeout_s": 2,
+            "count": 25,
+            "packet_size": 128,
+        },
+    )
+
+    assert handler._last_code == 200
+    assert captured == {
+        "target_ip": "192.168.1.1",
+        "duration_s": 5,
+        "interval_ms": 50,
+        "timeout_s": 2,
+        "count": 25,
+        "packet_size": 128,
+    }
+    assert payload["data"]["sent"] == 1
+    assert payload["warnings"] == []
+
+
+def test_ping_route_clamps_extreme_inputs(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        api,
+        "run_ping",
+        lambda **kwargs: captured.update(kwargs) or {"sent": 0, "received": 0},
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/ping",
+        {
+            "target_ip": "192.168.1.1",
+            "duration_s": 999,
+            "interval_ms": 0,
+            "timeout_s": 999,
+            "count": 999_999,
+            "packet_size": 999_999,
+        },
+    )
+
+    assert handler._last_code == 200
+    assert captured["duration_s"] == limits.DIAGNOSTIC_MAX_DURATION_S
+    assert captured["interval_ms"] == limits.DIAGNOSTIC_MIN_INTERVAL_MS
+    assert captured["timeout_s"] == limits.PING_MAX_REPLY_TIMEOUT_S
+    assert captured["count"] == limits.DIAGNOSTIC_MAX_PACKET_COUNT
+    assert captured["packet_size"] == limits.DIAGNOSTIC_MAX_PACKET_SIZE
+    assert {
+        "duration_s_clamped",
+        "interval_ms_clamped",
+        "timeout_s_clamped",
+        "count_clamped",
+        "packet_size_clamped",
+    }.issubset(payload["warnings"])
+
+
+def test_udp_route_preserves_valid_inputs(monkeypatch):
+    captured = {}
+
+    def fake_udp(**kwargs):
+        captured.update(kwargs)
+        return {"target_ip": kwargs["target_ip"], "sent": 3, "received": 3}
+
+    monkeypatch.setattr(api, "run_udp_latency_test", fake_udp)
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/udp_latency",
+        {
+            "target_ip": "192.168.1.2",
+            "duration_s": 4,
+            "interval_ms": 40,
+            "target_port": 23456,
+            "packet_size": 256,
+            "count": 30,
+        },
+    )
+
+    assert handler._last_code == 200
+    assert captured == {
+        "target_ip": "192.168.1.2",
+        "target_port": 23456,
+        "duration_s": 4,
+        "interval_ms": 40,
+        "packet_size": 256,
+        "count": 30,
+    }
+    assert payload["data"]["received"] == 3
+    assert payload["warnings"] == []
+
+
+def test_udp_route_clamps_extreme_inputs_and_packets_alias(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        api,
+        "run_udp_latency_test",
+        lambda **kwargs: captured.update(kwargs) or {"sent": 0, "received": 0},
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/udp_latency",
+        {
+            "target_ip": "192.168.1.2",
+            "duration_s": 999,
+            "interval_ms": 0,
+            "target_port": 0,
+            "packet_size": 999_999,
+            "packets": 999_999,
+        },
+    )
+
+    assert handler._last_code == 200
+    assert captured["duration_s"] == limits.DIAGNOSTIC_MAX_DURATION_S
+    assert captured["interval_ms"] == limits.DIAGNOSTIC_MIN_INTERVAL_MS
+    assert captured["target_port"] == limits.UDP_MIN_PORT
+    assert captured["packet_size"] == limits.DIAGNOSTIC_MAX_PACKET_SIZE
+    assert captured["count"] == limits.DIAGNOSTIC_MAX_PACKET_COUNT
+    assert {
+        "duration_s_clamped",
+        "interval_ms_clamped",
+        "target_port_clamped",
+        "packet_size_clamped",
+        "count_clamped",
+    }.issubset(payload["warnings"])
+
+
+def test_udp_route_rejects_non_numeric_port_without_running_test(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "run_udp_latency_test",
+        lambda **_kwargs: pytest.fail("invalid UDP port reached diagnostic helper"),
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/udp_latency",
+        {"target_ip": "192.168.1.2", "target_port": "not-a-port"},
+    )
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == "invalid_request"
+    assert "invalid_diagnostic_params" in payload["warnings"]
+
+
+class _FakeUdpSocket:
+    def __init__(self):
+        self.sent = 0
+        self.last_payload = b""
+        self.last_target = None
+        self.timeouts = []
+        self.closed = False
+
+    def settimeout(self, timeout):
+        self.timeouts.append(timeout)
+
+    def sendto(self, payload, target):
+        self.sent += 1
+        self.last_payload = payload
+        self.last_target = target
+
+    def recvfrom(self, _size):
+        return self.last_payload, self.last_target
+
+    def close(self):
+        self.closed = True
+
+
+def test_udp_helper_bounds_count_duration_size_interval_and_port(monkeypatch):
+    fake_socket = _FakeUdpSocket()
+    monkeypatch.setattr(udp_latency.socket, "socket", lambda *_args, **_kwargs: fake_socket)
+    monkeypatch.setattr(udp_latency.time, "time", lambda: 0.0)
+    monkeypatch.setattr(udp_latency.time, "sleep", lambda _seconds: None)
+
+    result = udp_latency.run_udp_latency_test(
+        "192.168.1.2",
+        target_port=999_999,
+        duration_s=999,
+        interval_ms=0,
+        packet_size=999_999,
+        count=999_999,
+    )
+
+    assert result["target_port"] == limits.UDP_MAX_PORT
+    assert result["duration_s"] == limits.DIAGNOSTIC_MAX_DURATION_S
+    assert result["interval_ms"] == limits.DIAGNOSTIC_MIN_INTERVAL_MS
+    assert result["sent"] == limits.DIAGNOSTIC_MAX_PACKET_COUNT
+    assert len(fake_socket.last_payload) == limits.DIAGNOSTIC_MAX_PACKET_SIZE
+    assert struct.unpack("!Q", fake_socket.last_payload[:8])[0] == result["sent"]
+    assert fake_socket.last_target == ("192.168.1.2", limits.UDP_MAX_PORT)
+    assert fake_socket.closed is True
+
+
+class _FakeLoad:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.method = kwargs["method"]
+        self.requested_mbps = kwargs["mbps"]
+        self.effective_mbps = kwargs["mbps"]
+        self.started = False
+        self.notes = []
+        self.__class__.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        return None
+
+    def info(self):
+        return {
+            "method": self.method,
+            "requested_mbps": self.requested_mbps,
+            "effective_mbps": self.effective_mbps,
+            "notes": self.notes,
+            "started": self.started,
+        }
+
+
+def _successful_ping(**kwargs):
+    return {
+        "target_ip": kwargs["target_ip"],
+        "duration_s": kwargs["duration_s"],
+        "interval_ms": kwargs["interval_ms"],
+        "sent": 1,
+        "received": 1,
+        "packet_loss_pct": 0.0,
+        "rtt_ms": {"min": 1.0, "avg": 1.0, "p50": 1.0, "p95": 1.0, "p99": 1.0},
+        "samples_ms": [1.0],
+    }
+
+
+def test_ping_under_load_clamps_duration_intensity_and_iperf3_port(monkeypatch):
+    _FakeLoad.instances.clear()
+    ping_calls = []
+    monkeypatch.setattr(api, "LoadGenerator", _FakeLoad)
+    monkeypatch.setattr(api, "ping_available", lambda: True)
+    monkeypatch.setattr(
+        api,
+        "run_ping",
+        lambda **kwargs: ping_calls.append(kwargs) or _successful_ping(**kwargs),
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/ping_under_load",
+        {
+            "target_ip": "192.168.1.1",
+            "duration_s": 999,
+            "interval_ms": 999,
+            "load": {
+                "method": "iperf3",
+                "mbps": 999_999,
+                "iperf3_host": "example.com",
+                "iperf3_port": 999_999,
+            },
+        },
+    )
+
+    assert handler._last_code == 200
+    load_kwargs = _FakeLoad.instances[-1].kwargs
+    assert load_kwargs["duration_s"] == limits.LOAD_MAX_DURATION_S
+    assert load_kwargs["mbps"] == limits.LOAD_MAX_MBPS
+    assert load_kwargs["iperf3_port"] == limits.LOAD_MAX_PORT
+    assert load_kwargs["iperf3_host"] == "example.com"
+    assert ping_calls[-1]["duration_s"] == limits.LOAD_MAX_DURATION_S
+    assert ping_calls[-1]["interval_ms"] == limits.LOAD_MAX_INTERVAL_MS
+    assert {
+        "duration_s_clamped",
+        "interval_ms_clamped",
+        "mbps_clamped",
+        "iperf3_port_clamped",
+    }.issubset(payload["warnings"])
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "file:///etc/passwd",
+        "ftp://example.com/file",
+        "gopher://example.com/1",
+        "rm -rf /tmp/vrhotspot-test",
+    ),
+)
+def test_ping_under_load_rejects_unsupported_curl_urls_before_execution(monkeypatch, url):
+    monkeypatch.setattr(
+        api,
+        "ping_available",
+        lambda: pytest.fail("invalid curl URL reached ping availability check"),
+    )
+    monkeypatch.setattr(
+        api,
+        "LoadGenerator",
+        lambda **_kwargs: pytest.fail("invalid curl URL reached load generator"),
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/ping_under_load",
+        {
+            "target_ip": "192.168.1.1",
+            "load": {"method": "curl", "url": url},
+        },
+    )
+
+    assert handler._last_code == 400
+    assert payload["data"]["error"]["code"] == "invalid_params"
+
+
+@pytest.mark.parametrize("host", ("-R", "bad host", "example.com;id", "a" * 254))
+def test_ping_under_load_rejects_invalid_iperf3_hosts_before_execution(monkeypatch, host):
+    monkeypatch.setattr(
+        api,
+        "ping_available",
+        lambda: pytest.fail("invalid iperf3 host reached ping availability check"),
+    )
+
+    handler, payload = _post(
+        monkeypatch,
+        "/v1/diagnostics/ping_under_load",
+        {
+            "target_ip": "192.168.1.1",
+            "load": {"method": "iperf3", "iperf3_host": host},
+        },
+    )
+
+    assert handler._last_code == 400
+    assert payload["data"]["error"]["code"] == "invalid_params"

--- a/tests/test_diagnostics_ping.py
+++ b/tests/test_diagnostics_ping.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from vr_hotspotd.diagnostics import ping
+from vr_hotspotd.diagnostics import limits
 
 
 class TestDiagnosticsPing(unittest.TestCase):
@@ -33,3 +34,51 @@ class TestDiagnosticsPing(unittest.TestCase):
         self.assertAlmostEqual(rtt["p95"], 38.5, places=6)
         self.assertAlmostEqual(rtt["p99"], 39.7, places=6)
         self.assertAlmostEqual(rtt["p99_9"], 39.97, places=6)
+
+    def test_ping_command_and_subprocess_timeout_are_bounded(self):
+        captured = {}
+        output = "1 packets transmitted, 1 received, 0% packet loss\n"
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout=output, stderr="")
+
+        with patch.object(ping.shutil, "which", return_value="/bin/ping"), patch.object(
+            ping.subprocess,
+            "run",
+            fake_run,
+        ):
+            res = ping.run_ping(
+                "192.168.1.1",
+                duration_s=999,
+                interval_ms=0,
+                timeout_s=999,
+                count=999_999,
+                packet_size=999_999,
+            )
+
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("-c") + 1] == str(limits.DIAGNOSTIC_MAX_PACKET_COUNT)
+        assert cmd[cmd.index("-i") + 1] == "0.010"
+        assert cmd[cmd.index("-w") + 1] == str(limits.DIAGNOSTIC_MAX_DURATION_S)
+        assert cmd[cmd.index("-W") + 1] == str(limits.PING_MAX_REPLY_TIMEOUT_S)
+        assert cmd[cmd.index("-s") + 1] == str(limits.DIAGNOSTIC_MAX_PACKET_SIZE)
+        assert captured["kwargs"]["timeout"] == (
+            limits.DIAGNOSTIC_MAX_DURATION_S + limits.PING_SUBPROCESS_GRACE_S
+        )
+        assert res["duration_s"] == limits.DIAGNOSTIC_MAX_DURATION_S
+        assert res["interval_ms"] == limits.DIAGNOSTIC_MIN_INTERVAL_MS
+
+    def test_ping_subprocess_timeout_returns_structured_error(self):
+        def fake_run(cmd, **kwargs):
+            raise ping.subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+        with patch.object(ping.shutil, "which", return_value="/bin/ping"), patch.object(
+            ping.subprocess,
+            "run",
+            fake_run,
+        ):
+            res = ping.run_ping("192.168.1.1", duration_s=3)
+
+        assert res["error"]["code"] == "ping_timeout"

--- a/tests/test_load_generator_curl_cmd.py
+++ b/tests/test_load_generator_curl_cmd.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
+import pytest
+
 from vr_hotspotd.diagnostics import load
+from vr_hotspotd.diagnostics import limits
 
 
 def test_curl_cmd_contains_limit_and_output(monkeypatch):
@@ -29,3 +32,92 @@ def test_curl_cmd_contains_limit_and_output(monkeypatch):
     assert "/dev/null" in cmd
     assert cmd[cmd.index("--limit-rate") + 1] == str(int(100.0 * 1_000_000 / 8.0))
     assert cmd[cmd.index("--max-time") + 1] == "12"
+    assert "-L" not in cmd
+    assert "--location" not in cmd
+    assert cmd[1] == "--disable"
+    assert "--globoff" in cmd
+    assert "--no-location" in cmd
+    assert cmd[cmd.index("--max-redirs") + 1] == "0"
+    assert cmd[cmd.index("--proto") + 1] == "=http,https"
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "file:///etc/passwd",
+        "ftp://example.com/file",
+        "gopher://example.com/1",
+        "$(touch /tmp/vrhotspot-test)",
+        "https://example.com; touch /tmp/vrhotspot-test",
+    ),
+)
+def test_curl_url_rejects_unsupported_or_shell_like_values(url):
+    with pytest.raises(ValueError):
+        load.validate_curl_url(url)
+
+
+def test_invalid_curl_url_never_starts_a_process(monkeypatch):
+    monkeypatch.setattr(load.shutil, "which", lambda name: "/usr/bin/curl")
+
+    def fail_popen(*_args, **_kwargs):
+        pytest.fail("invalid curl URL reached subprocess.Popen")
+
+    monkeypatch.setattr(load.subprocess, "Popen", fail_popen)
+    gen = load.LoadGenerator(
+        method="curl",
+        mbps=100.0,
+        duration_s=10,
+        url="file:///etc/passwd",
+        iperf3_host="",
+        iperf3_port=5201,
+    )
+
+    gen.start()
+
+    assert gen.started is False
+    assert "load_params_invalid" in gen.notes
+
+
+def test_iperf3_command_inputs_are_bounded(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(
+            poll=lambda: None,
+            terminate=lambda: None,
+            wait=lambda timeout=None: None,
+            kill=lambda: None,
+        )
+
+    monkeypatch.setattr(
+        load.shutil,
+        "which",
+        lambda name: "/usr/bin/iperf3" if name == "iperf3" else None,
+    )
+    monkeypatch.setattr(load.subprocess, "Popen", fake_popen)
+    gen = load.LoadGenerator(
+        method="iperf3",
+        mbps=999_999.0,
+        duration_s=999,
+        url="",
+        iperf3_host="example.com",
+        iperf3_port=999_999,
+    )
+
+    gen.start()
+
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("-t") + 1] == str(limits.LOAD_MAX_DURATION_S)
+    assert cmd[cmd.index("-p") + 1] == str(limits.LOAD_MAX_PORT)
+    assert cmd[cmd.index("-b") + 1] == f"{limits.LOAD_MAX_MBPS}M"
+    assert gen.requested_mbps == limits.LOAD_MAX_MBPS
+
+
+@pytest.mark.parametrize(
+    "host",
+    ("", "-R", "bad host", "example.com;id", "a" * 254),
+)
+def test_iperf3_host_rejects_invalid_or_option_like_values(host):
+    with pytest.raises(ValueError):
+        load.validate_network_host(host)


### PR DESCRIPTION
Hardens diagnostic input validation and execution budgets for existing diagnostics.

What changed:
- Adds shared diagnostic input limits.
- Bounds ping duration, interval, count, packet size, and reply timeout.
- Adds an independent subprocess timeout for ping execution.
- Bounds UDP latency duration, interval, packet count, packet size, and port.
- Keeps existing defaults unchanged.
- Clamps numeric extremes with warnings.
- Returns 400 for malformed values.
- Keeps ping-under-load bounded to the existing duration, interval, and Mbps limits.
- Restricts curl load URLs to HTTP/S.
- Disables curl redirects, config loading, and globbing.
- Restricts curl protocols to HTTP/S.
- Bounds iperf3 host, port, duration, and Mbps inputs.

Safety:
- No passphrase argv cleanup.
- No UI changes.
- No adapter changes.
- No firewall mutation changes.
- No installer or uninstaller changes.
- No docs cleanup.
- No Flatpak/desktop work.
- No support-bundle work.
- No auth redesign.
- No TLS/remote-access redesign.
- No rate limiting/global worker-pool changes.
- No new diagnostics features.

Tests:
- Adds mocked API-budget and fake-UDP coverage.
- Expands ping timeout/argv tests.
- Expands curl URL policy tests.
- Expands iperf3 command validation tests.
- Confirms no real ping, curl, iperf3, UDP, or host-network commands run.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `460 passed, 4 subtests passed`