### PR TITLE
fix: keep hotspot passphrase out of process argv

### DIFF
--- a/backend/vendor/bin/lnxrouter
+++ b/backend/vendor/bin/lnxrouter
@@ -80,6 +80,7 @@ Options:
                             Create WiFi access point
     -p, --password <password>
                             WiFi password
+    --password-fd <fd>      Read WiFi password from an inherited file descriptor
     --qr                    Show WiFi QR code in terminal (need qrencode)
 
     --hidden                Hide access point (not broadcast SSID)
@@ -400,6 +401,22 @@ parse_user_options(){
             -p|--password)
                 shift
                 PASSPHRASE="$1"
+                shift
+                ;;
+            --password-fd)
+                shift
+                PASSPHRASE_FD="$1"
+                if [[ ! "$PASSPHRASE_FD" =~ ^[0-9]+$ ]]; then
+                    echo "ERROR: Invalid password file descriptor" >&2
+                    exit 1
+                fi
+                PASSPHRASE=
+                IFS= read -r -d '' PASSPHRASE <&"$PASSPHRASE_FD" || true
+                exec {PASSPHRASE_FD}<&-
+                if [[ -z "$PASSPHRASE" ]]; then
+                    echo "ERROR: Could not read WiFi password" >&2
+                    exit 1
+                fi
                 shift
                 ;;
             --qr)
@@ -1992,6 +2009,7 @@ dealwith_mac() {
 }
 
 write_hostapd_conf() {
+    (umask 077; : > "$CONFDIR/hostapd.conf") || die "Failed creating hostapd config"
     cat <<- EOF > "$CONFDIR/hostapd.conf"
 		beacon_int=100
 		ssid=${SSID}

--- a/backend/vr_hotspotd/engine/hostapd6_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd6_engine.py
@@ -11,6 +11,11 @@ import time
 from typing import Optional, List, Tuple
 
 from vr_hotspotd import host_probes
+from vr_hotspotd.engine.secret_io import (
+    add_passphrase_arguments,
+    read_passphrase,
+    write_protected_text,
+)
 
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 
@@ -284,10 +289,7 @@ def _write_hostapd_6ghz_conf(
     if tx_power is not None:
         lines.append(f"tx_power={tx_power}")
 
-    with open(path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
-
-    os.chmod(path, 0o600)
+    write_protected_text(path, "\n".join(lines) + "\n")
 
 
 def _write_dnsmasq_conf(
@@ -322,7 +324,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ap-ifname", required=True)
     ap.add_argument("--ssid", required=True)
-    ap.add_argument("--passphrase", required=True)
+    add_passphrase_arguments(ap)
     ap.add_argument("--country", default=None)
     ap.add_argument("--channel", type=int, default=1)
     ap.add_argument("--no-virt", action="store_true")
@@ -338,8 +340,9 @@ def main() -> int:
     ap.add_argument("--short-guard-interval", action="store_true", default=True)
     ap.add_argument("--tx-power", type=int, default=None)
     args = ap.parse_args()
+    passphrase = read_passphrase(args)
 
-    if len(args.passphrase) < 8:
+    if len(passphrase) < 8:
         raise RuntimeError("invalid_passphrase_min_length_8")
 
     _maybe_set_regdom(args.country)
@@ -409,32 +412,60 @@ def main() -> int:
             except Exception:
                 nat_rules = []
 
-    # Write configs
-    _write_hostapd_6ghz_conf(
-        path=hostapd_conf,
-        ifname=ap_iface,
-        ssid=args.ssid,
-        passphrase=args.passphrase,
-        country=args.country,
-        channel=int(args.channel),
-        channel_width=args.channel_width,
-        beacon_interval=args.beacon_interval,
-        dtim_period=args.dtim_period,
-        short_guard_interval=args.short_guard_interval,
-        tx_power=args.tx_power,
-    )
-    _ensure_ctrl_interface_dir(hostapd_conf)
-    _write_dnsmasq_conf(dnsmasq_conf, ap_iface, gw_ip, dhcp_start, dhcp_end, dhcp_dns)
+    hostapd_p: Optional[subprocess.Popen] = None
+    dnsmasq_p: Optional[subprocess.Popen] = None
+    try:
+        # Write configs
+        _write_hostapd_6ghz_conf(
+            path=hostapd_conf,
+            ifname=ap_iface,
+            ssid=args.ssid,
+            passphrase=passphrase,
+            country=args.country,
+            channel=int(args.channel),
+            channel_width=args.channel_width,
+            beacon_interval=args.beacon_interval,
+            dtim_period=args.dtim_period,
+            short_guard_interval=args.short_guard_interval,
+            tx_power=args.tx_power,
+        )
+        _ensure_ctrl_interface_dir(hostapd_conf)
+        _write_dnsmasq_conf(dnsmasq_conf, ap_iface, gw_ip, dhcp_start, dhcp_end, dhcp_dns)
 
-    # Start processes
-    hostapd_cmd = [hostapd, hostapd_conf]
-    dnsmasq_cmd = [dnsmasq, "--no-daemon", f"--conf-file={dnsmasq_conf}"]
+        # Start processes
+        hostapd_cmd = [hostapd, hostapd_conf]
+        dnsmasq_cmd = [dnsmasq, "--no-daemon", f"--conf-file={dnsmasq_conf}"]
 
-    if args.debug:
-        hostapd_cmd = [hostapd, "-dd", hostapd_conf]
+        if args.debug:
+            hostapd_cmd = [hostapd, "-dd", hostapd_conf]
 
-    hostapd_p = subprocess.Popen(hostapd_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-    dnsmasq_p = subprocess.Popen(dnsmasq_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        hostapd_p = subprocess.Popen(
+            hostapd_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        dnsmasq_p = subprocess.Popen(
+            dnsmasq_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except Exception:
+        if hostapd_p is not None:
+            try:
+                hostapd_p.terminate()
+                hostapd_p.wait(timeout=2.0)
+            except Exception:
+                try:
+                    hostapd_p.kill()
+                except Exception:
+                    pass
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        raise
+
+    assert hostapd_p is not None
+    assert dnsmasq_p is not None
 
     stopping = False
 

--- a/backend/vr_hotspotd/engine/hostapd_bridge_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd_bridge_engine.py
@@ -10,6 +10,11 @@ import time
 from typing import List, Optional, Tuple
 
 from vr_hotspotd import host_probes
+from vr_hotspotd.engine.secret_io import (
+    add_passphrase_arguments,
+    read_passphrase,
+    write_protected_text,
+)
 
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 
@@ -319,16 +324,14 @@ def _write_hostapd_conf(
     if tx_power is not None:
         lines.append(f"tx_power={tx_power}")
 
-    with open(path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
-    os.chmod(path, 0o600)
+    write_protected_text(path, "\n".join(lines) + "\n")
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ap-ifname", required=True)
     ap.add_argument("--ssid", required=True)
-    ap.add_argument("--passphrase", required=True)
+    add_passphrase_arguments(ap)
     ap.add_argument("--band", required=True)
     ap.add_argument("--ap-security", default="wpa2")
     ap.add_argument("--country", default=None)
@@ -344,8 +347,9 @@ def main() -> int:
     ap.add_argument("--short-guard-interval", action="store_true", default=True)
     ap.add_argument("--tx-power", type=int, default=None)
     args = ap.parse_args()
+    passphrase = read_passphrase(args)
 
-    if len(args.passphrase) < 8:
+    if len(passphrase) < 8:
         raise RuntimeError("invalid_passphrase_min_length_8")
 
     band = str(args.band).strip().lower()
@@ -408,7 +412,7 @@ def main() -> int:
             path=hostapd_conf,
             ifname=ap_iface,
             ssid=args.ssid,
-            passphrase=args.passphrase,
+            passphrase=passphrase,
             country=args.country,
             band=band,
             channel=channel,

--- a/backend/vr_hotspotd/engine/hostapd_nat_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd_nat_engine.py
@@ -14,6 +14,11 @@ from pathlib import Path
 from typing import Optional, List, Tuple
 
 from vr_hotspotd import host_probes, os_release
+from vr_hotspotd.engine.secret_io import (
+    add_passphrase_arguments,
+    read_passphrase,
+    write_protected_text,
+)
 
 _CTRL_DIR_RE = re.compile(r"DIR=([^\s]+)")
 _CMD_TIMEOUT_S = 4.0
@@ -677,9 +682,7 @@ def _write_hostapd_conf(
     if tx_power is not None:
         lines.append(f"tx_power={tx_power}")
 
-    with open(path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines) + "\n")
-    os.chmod(path, 0o600)
+    write_protected_text(path, "\n".join(lines) + "\n")
 
 
 def _write_dnsmasq_conf(
@@ -713,7 +716,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--ap-ifname", required=True)
     ap.add_argument("--ssid", required=True)
-    ap.add_argument("--passphrase", required=True)
+    add_passphrase_arguments(ap)
     ap.add_argument("--band", required=True)
     ap.add_argument("--ap-security", default="wpa2")
     ap.add_argument("--country", default=None)
@@ -733,8 +736,9 @@ def main() -> int:
     ap.add_argument("--tx-power", type=int, default=None)
     ap.add_argument("--strict-width", action="store_true")
     args = ap.parse_args()
+    passphrase = read_passphrase(args)
 
-    if len(args.passphrase) < 8:
+    if len(passphrase) < 8:
         raise RuntimeError("invalid_passphrase_min_length_8")
 
     band = str(args.band).strip().lower()
@@ -887,7 +891,7 @@ def main() -> int:
                 path=hostapd_conf,
                 ifname=ap_iface,
                 ssid=args.ssid,
-                passphrase=args.passphrase,
+                passphrase=passphrase,
                 country=args.country,
                 band=band,
                 channel=channel,

--- a/backend/vr_hotspotd/engine/secret_io.py
+++ b/backend/vr_hotspotd/engine/secret_io.py
@@ -1,0 +1,45 @@
+import os
+from typing import Any
+
+
+def add_passphrase_arguments(parser: Any) -> None:
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--passphrase")
+    group.add_argument(
+        "--passphrase-fd",
+        type=int,
+        help="read the passphrase from an inherited file descriptor",
+    )
+
+
+def read_passphrase(args: Any) -> str:
+    passphrase_fd = getattr(args, "passphrase_fd", None)
+    if passphrase_fd is None:
+        passphrase = getattr(args, "passphrase", None)
+        if not isinstance(passphrase, str):
+            raise RuntimeError("passphrase_missing")
+        return passphrase
+
+    try:
+        fd = int(passphrase_fd)
+        if fd < 0:
+            raise ValueError("negative file descriptor")
+        with os.fdopen(fd, "rb", closefd=True) as stream:
+            payload = stream.read()
+        return payload.decode("utf-8")
+    except (OSError, TypeError, UnicodeError, ValueError) as exc:
+        raise RuntimeError("passphrase_fd_read_failed") from exc
+
+
+def write_protected_text(path: str, content: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        stream = os.fdopen(fd, "w", encoding="utf-8", closefd=True)
+        fd = -1
+        with stream:
+            stream.write(content)
+    finally:
+        if fd >= 0:
+            os.close(fd)

--- a/backend/vr_hotspotd/engine/supervisor.py
+++ b/backend/vr_hotspotd/engine/supervisor.py
@@ -30,6 +30,11 @@ _last_firewalld_cfg: Dict[str, object] = {}
 _stdout_line_observer: Optional[Callable[[str], None]] = None
 
 _HOSTAPD_UNKNOWN_RE = re.compile(r"unknown configuration item '([^']+)'", re.IGNORECASE)
+_PASSPHRASE_FD_FLAG = {
+    "-p": "--password-fd",
+    "--password": "--password-fd",
+    "--passphrase": "--passphrase-fd",
+}
 
 
 class VendorSelectionError(RuntimeError):
@@ -743,10 +748,10 @@ def _kill_process_group(pid: int, sig: int) -> None:
 def _redact_cmd(cmd: List[str]) -> List[str]:
     """
     Prevent secrets leaking into /v1/status:
-    - Replace the value after -p or --passphrase with ********.
+    - Replace the value after a supported passphrase flag with ********.
     """
     out = list(cmd)
-    for flag in ("-p", "--passphrase"):
+    for flag in ("-p", "--password", "--passphrase"):
         try:
             i = out.index(flag)
             if i + 1 < len(out):
@@ -754,6 +759,37 @@ def _redact_cmd(cmd: List[str]) -> List[str]:
         except ValueError:
             pass
     return out
+
+
+def _prepare_passphrase_fd(cmd: List[str]) -> Tuple[List[str], Optional[int]]:
+    """Replace a passphrase argv value with an inherited anonymous pipe fd."""
+    spawn_cmd = list(cmd)
+    for index, item in enumerate(spawn_cmd):
+        fd_flag = _PASSPHRASE_FD_FLAG.get(item)
+        if fd_flag is None:
+            continue
+        if index + 1 >= len(spawn_cmd):
+            raise ValueError("passphrase_value_missing")
+
+        payload = str(spawn_cmd[index + 1]).encode("utf-8")
+        read_fd, write_fd = os.pipe()
+        try:
+            offset = 0
+            while offset < len(payload):
+                written = os.write(write_fd, payload[offset:])
+                if written <= 0:
+                    raise OSError("passphrase_pipe_write_failed")
+                offset += written
+        except Exception:
+            os.close(read_fd)
+            raise
+        finally:
+            os.close(write_fd)
+
+        spawn_cmd[index : index + 2] = [fd_flag, str(read_fd)]
+        return spawn_cmd, read_fd
+
+    return spawn_cmd, None
 
 
 def start_engine(
@@ -836,17 +872,39 @@ def start_engine(
             started_ts=None,
         )
 
+    passphrase_fd: Optional[int] = None
     try:
+        spawn_cmd, passphrase_fd = _prepare_passphrase_fd(cmd)
+    except Exception:
+        if ap_ifname:
+            _cleanup_firewalld(ap_ifname, firewalld_cfg)
+        return EngineStartResult(
+            ok=False,
+            pid=None,
+            exit_code=None,
+            stdout_tail=[],
+            stderr_tail=[],
+            error="spawn_failed: passphrase_transport_failed",
+            cmd=_redact_cmd(cmd),
+            started_ts=None,
+        )
+
+    try:
+        popen_kwargs = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "bufsize": 1,
+            "close_fds": True,
+            "env": env,
+            # Isolate the engine into its own session/PGID so its whole tree can be killed.
+            "start_new_session": True,
+        }
+        if passphrase_fd is not None:
+            popen_kwargs["pass_fds"] = (passphrase_fd,)
         _ln_proc = subprocess.Popen(
-            cmd,  # IMPORTANT: full cmd used to spawn (includes real passphrase)
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-            close_fds=True,
-            env=env,
-            # isolate lnxrouter into its own session/PGID so we can reliably kill its whole tree
-            start_new_session=True,
+            spawn_cmd,
+            **popen_kwargs,
         )
     except Exception as e:
         _ln_proc = None
@@ -862,6 +920,12 @@ def start_engine(
             cmd=_redact_cmd(cmd),
             started_ts=None,
         )
+    finally:
+        if passphrase_fd is not None:
+            try:
+                os.close(passphrase_fd)
+            except OSError:
+                pass
 
     assert _ln_proc.stdout is not None
     assert _ln_proc.stderr is not None

--- a/tests/test_cmd_builders.py
+++ b/tests/test_cmd_builders.py
@@ -1,6 +1,8 @@
 import sys
 
 from vr_hotspotd.engine.hostapd6_cmd import build_cmd_6ghz
+from vr_hotspotd.engine.hostapd_bridge_cmd import build_cmd_bridge
+from vr_hotspotd.engine.hostapd_nat_cmd import build_cmd_nat
 from vr_hotspotd.engine.lnxrouter_cmd import build_cmd
 from vr_hotspotd.lifecycle import _precreated_ap_ifname
 
@@ -61,6 +63,65 @@ def test_hostapd6_cmd_builds_flags():
     assert "--debug" in cmd
 
 
+def test_hostapd_nat_cmd_preserves_non_secret_arguments():
+    cmd = build_cmd_nat(
+        ap_ifname="wlan1",
+        ssid="NatHotspot",
+        passphrase="password123",
+        band="5ghz",
+        ap_security="wpa2",
+        country="US",
+        channel=149,
+        no_virt=True,
+        debug=False,
+        wifi6=True,
+        gateway_ip="192.168.68.1",
+        dhcp_dns="1.1.1.1",
+        channel_width="80",
+        strict_width=True,
+    )
+
+    assert cmd[:3] == [sys.executable, "-m", "vr_hotspotd.engine.hostapd_nat_engine"]
+    assert cmd[cmd.index("--ap-ifname") + 1] == "wlan1"
+    assert cmd[cmd.index("--ssid") + 1] == "NatHotspot"
+    assert cmd[cmd.index("--band") + 1] == "5ghz"
+    assert cmd[cmd.index("--channel") + 1] == "149"
+    assert cmd[cmd.index("--gateway-ip") + 1] == "192.168.68.1"
+    assert cmd[cmd.index("--dhcp-dns") + 1] == "1.1.1.1"
+    assert cmd[cmd.index("--channel-width") + 1] == "80"
+    assert "--no-virt" in cmd
+    assert "--wifi6" in cmd
+    assert "--strict-width" in cmd
+
+
+def test_hostapd_bridge_cmd_preserves_non_secret_arguments():
+    cmd = build_cmd_bridge(
+        ap_ifname="wlan1",
+        ssid="BridgeHotspot",
+        passphrase="password123",
+        band="5ghz",
+        ap_security="wpa2",
+        country="US",
+        channel=36,
+        no_virt=True,
+        debug=True,
+        wifi6=True,
+        bridge_name="vrbr0",
+        bridge_uplink="eth0",
+        channel_width="80",
+    )
+
+    assert cmd[:3] == [sys.executable, "-m", "vr_hotspotd.engine.hostapd_bridge_engine"]
+    assert cmd[cmd.index("--ap-ifname") + 1] == "wlan1"
+    assert cmd[cmd.index("--ssid") + 1] == "BridgeHotspot"
+    assert cmd[cmd.index("--bridge-name") + 1] == "vrbr0"
+    assert cmd[cmd.index("--bridge-uplink") + 1] == "eth0"
+    assert cmd[cmd.index("--channel-width") + 1] == "80"
+    assert "--no-virt" in cmd
+    assert "--debug" in cmd
+    assert "--wifi6" in cmd
+
+
 def test_lnxrouter_cmd_virt_mode_uses_precreated_ap_ifname():
     ap_ifname = _precreated_ap_ifname("wlan0")
     cmd = build_cmd(
@@ -115,4 +176,3 @@ def test_lnxrouter_cmd_does_not_set_virt_name_when_no_virt_enabled():
         no_virt=True,
     )
     assert "--virt-name" not in cmd
-

--- a/tests/test_engine_passphrase_security.py
+++ b/tests/test_engine_passphrase_security.py
@@ -1,0 +1,359 @@
+import io
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vr_hotspotd import state
+from vr_hotspotd.engine import (
+    hostapd6_engine,
+    hostapd_bridge_engine,
+    hostapd_nat_engine,
+    supervisor,
+)
+from vr_hotspotd.engine.hostapd6_cmd import build_cmd_6ghz
+from vr_hotspotd.engine.hostapd_bridge_cmd import build_cmd_bridge
+from vr_hotspotd.engine.hostapd_nat_cmd import build_cmd_nat
+from vr_hotspotd.engine.lnxrouter_cmd import build_cmd
+from vr_hotspotd.engine.secret_io import read_passphrase
+
+
+SECRET = "argv-secret-123"
+
+
+def _lnxrouter_command(secret: str):
+    return build_cmd(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        band_preference="5ghz",
+        country="US",
+        channel=36,
+        no_virt=True,
+        wifi6=True,
+    )
+
+
+def _nat_command(secret: str):
+    return build_cmd_nat(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        band="5ghz",
+        ap_security="wpa2",
+        country="US",
+        channel=36,
+        no_virt=True,
+        debug=False,
+        wifi6=True,
+    )
+
+
+def _six_ghz_command(secret: str):
+    return build_cmd_6ghz(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        country="US",
+        channel=5,
+        no_virt=True,
+        debug=False,
+    )
+
+
+def _bridge_command(secret: str):
+    return build_cmd_bridge(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        band="5ghz",
+        ap_security="wpa2",
+        country="US",
+        channel=36,
+        no_virt=True,
+        debug=False,
+        wifi6=True,
+        bridge_name="vrbr0",
+        bridge_uplink="eth0",
+    )
+
+
+class _RunningProcess:
+    def __init__(self):
+        self.pid = 4242
+        self.returncode = None
+        self.stdout = io.StringIO("")
+        self.stderr = io.StringIO("")
+
+    def poll(self):
+        return None
+
+
+@pytest.mark.parametrize(
+    ("build_command", "fd_flag", "expected_arguments"),
+    [
+        (_lnxrouter_command, "--password-fd", ("--ap", "wlan1", "--freq-band", "5")),
+        (_nat_command, "--passphrase-fd", ("--ap-ifname", "wlan1", "--band", "5ghz")),
+        (_six_ghz_command, "--passphrase-fd", ("--ap-ifname", "wlan1", "--channel", "5")),
+        (_bridge_command, "--passphrase-fd", ("--bridge-name", "vrbr0", "--bridge-uplink", "eth0")),
+    ],
+)
+def test_supervisor_passes_each_engine_passphrase_by_fd_not_argv(
+    monkeypatch,
+    tmp_path,
+    build_command,
+    fd_flag,
+    expected_arguments,
+):
+    command = build_command(SECRET)
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = dict(kwargs)
+        inherited_fd = kwargs["pass_fds"][0]
+        captured["fd"] = inherited_fd
+        captured["passphrase"] = os.read(inherited_fd, 4096).decode("utf-8")
+        return _RunningProcess()
+
+    supervisor._ln_proc = None
+    monkeypatch.setattr(supervisor, "_build_engine_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(supervisor.subprocess, "Popen", fake_popen)
+
+    result = supervisor.start_engine(
+        command,
+        early_fail_window_s=0,
+        firewalld_cfg={"firewalld_enabled": False},
+    )
+
+    assert result.ok is True
+    assert captured["passphrase"] == SECRET
+    assert SECRET not in captured["argv"]
+    assert fd_flag in captured["argv"]
+    assert captured["kwargs"]["close_fds"] is True
+    assert "shell" not in captured["kwargs"]
+    for argument in expected_arguments:
+        assert argument in captured["argv"]
+    with pytest.raises(OSError):
+        os.fstat(captured["fd"])
+
+    assert result.cmd == supervisor._redact_cmd(command)
+    result_payload = json.dumps(result.__dict__, sort_keys=True)
+    assert SECRET not in result_payload
+    assert fd_flag not in result_payload
+    assert "********" in result.cmd
+    assert SECRET not in "\n".join(result.stdout_tail + result.stderr_tail)
+
+    monkeypatch.setattr(state, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(state, "STATE_TMP", tmp_path / "state.json.tmp")
+    state.update_state(
+        engine={
+            "pid": result.pid,
+            "cmd": result.cmd,
+            "started_ts": result.started_ts,
+            "last_error": result.error,
+        }
+    )
+    persisted = state.STATE_PATH.read_text(encoding="utf-8")
+    assert SECRET not in persisted
+    assert fd_flag not in persisted
+    assert "********" in persisted
+
+    supervisor._ln_proc = None
+
+
+def test_supervisor_spawn_failure_closes_fd_and_returns_no_passphrase(monkeypatch):
+    command = _nat_command(SECRET)
+    captured = {}
+
+    def fail_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["fd"] = kwargs["pass_fds"][0]
+        raise OSError("synthetic spawn failure")
+
+    supervisor._ln_proc = None
+    monkeypatch.setattr(supervisor, "_build_engine_env", lambda: {"PATH": "/usr/bin"})
+    monkeypatch.setattr(supervisor.subprocess, "Popen", fail_popen)
+
+    result = supervisor.start_engine(
+        command,
+        early_fail_window_s=0,
+        firewalld_cfg={"firewalld_enabled": False},
+    )
+
+    assert result.ok is False
+    assert SECRET not in captured["argv"]
+    assert SECRET not in json.dumps(result.__dict__, sort_keys=True)
+    assert result.cmd == supervisor._redact_cmd(command)
+    with pytest.raises(OSError):
+        os.fstat(captured["fd"])
+    supervisor._ln_proc = None
+
+
+def test_passphrase_reader_consumes_and_closes_inherited_fd():
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, SECRET.encode("utf-8"))
+    os.close(write_fd)
+
+    value = read_passphrase(SimpleNamespace(passphrase=None, passphrase_fd=read_fd))
+
+    assert value == SECRET
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+
+def test_vendor_lnxrouter_reads_password_fd_without_password_in_argv():
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, SECRET.encode("utf-8"))
+    os.close(write_fd)
+    argv = [
+        str(Path(__file__).resolve().parents[1] / "backend" / "vendor" / "bin" / "lnxrouter"),
+        "--password-fd",
+        str(read_fd),
+        "--version",
+    ]
+    try:
+        completed = subprocess.run(
+            argv,
+            pass_fds=(read_fd,),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        os.close(read_fd)
+
+    assert completed.returncode == 0
+    assert "0.8.1" in completed.stdout
+    assert SECRET not in argv
+    assert SECRET not in completed.stdout
+    assert SECRET not in completed.stderr
+
+
+def _write_nat_config(path: Path, secret: str) -> None:
+    hostapd_nat_engine._write_hostapd_conf(
+        path=str(path),
+        ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        country="US",
+        band="5ghz",
+        channel=36,
+        ap_security="wpa2",
+        wifi6=True,
+    )
+
+
+def _write_six_ghz_config(path: Path, secret: str) -> None:
+    hostapd6_engine._write_hostapd_6ghz_conf(
+        path=str(path),
+        ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        country="US",
+        channel=5,
+    )
+
+
+def _write_bridge_config(path: Path, secret: str) -> None:
+    hostapd_bridge_engine._write_hostapd_conf(
+        path=str(path),
+        ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        country="US",
+        band="5ghz",
+        channel=36,
+        ap_security="wpa2",
+        wifi6=True,
+        bridge="vrbr0",
+    )
+
+
+@pytest.mark.parametrize(
+    "write_config",
+    [_write_nat_config, _write_six_ghz_config, _write_bridge_config],
+)
+def test_secret_bearing_hostapd_configs_are_mode_0600(tmp_path, write_config):
+    config_path = tmp_path / "hostapd.conf"
+
+    write_config(config_path, SECRET)
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+    assert SECRET in config_path.read_text(encoding="utf-8")
+
+
+def test_6ghz_spawn_failure_removes_protected_secret_config(
+    monkeypatch,
+    mock_missing_system_commands,
+    tmp_path,
+    capsys,
+):
+    args = SimpleNamespace(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=SECRET,
+        country="US",
+        channel=5,
+        no_virt=True,
+        debug=False,
+        gateway_ip="192.168.68.1",
+        dhcp_start="192.168.68.10",
+        dhcp_end="192.168.68.250",
+        dhcp_dns="gateway",
+        no_internet=True,
+        channel_width="80",
+        beacon_interval=50,
+        dtim_period=1,
+        short_guard_interval=True,
+        tx_power=None,
+    )
+    config_dir = tmp_path / "vr-hotspotd-6ghz.TEST"
+    config_dir.mkdir()
+    captured = {}
+
+    def fail_popen(command, **_kwargs):
+        config_path = Path(command[-1])
+        captured["path"] = config_path
+        captured["mode"] = stat.S_IMODE(config_path.stat().st_mode)
+        captured["content"] = config_path.read_text(encoding="utf-8")
+        raise OSError("synthetic hostapd spawn failure")
+
+    monkeypatch.setattr(
+        hostapd6_engine.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: args,
+    )
+    monkeypatch.setattr(
+        hostapd6_engine.tempfile,
+        "mkdtemp",
+        lambda prefix: str(config_dir),
+    )
+    monkeypatch.setattr(
+        hostapd6_engine,
+        "_resolve_binary",
+        lambda name, env_key: f"/usr/sbin/{name}",
+    )
+    monkeypatch.setattr(hostapd6_engine, "_maybe_set_regdom", lambda _country: None)
+    monkeypatch.setattr(hostapd6_engine, "_iface_up", lambda _ifname: None)
+    monkeypatch.setattr(hostapd6_engine, "_assign_ip", lambda _ifname, _cidr: None)
+    monkeypatch.setattr(hostapd6_engine, "_default_uplink_iface", lambda: None)
+    monkeypatch.setattr(hostapd6_engine, "_ensure_ctrl_interface_dir", lambda _path: None)
+    monkeypatch.setattr(hostapd6_engine.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(OSError, match="synthetic hostapd spawn failure"):
+        hostapd6_engine.main()
+
+    assert captured["mode"] == 0o600
+    assert SECRET in captured["content"]
+    assert not captured["path"].exists()
+    assert not config_dir.exists()
+    output = capsys.readouterr()
+    assert SECRET not in output.out
+    assert SECRET not in output.err
+    assert str(captured["path"]) not in output.out
+    assert str(captured["path"]) not in output.err

--- a/tests/test_hostapd_nat_engine_bootstrap_cleanup.py
+++ b/tests/test_hostapd_nat_engine_bootstrap_cleanup.py
@@ -1,6 +1,9 @@
 import argparse
+import io
 import os
+import stat
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -78,3 +81,100 @@ def test_main_bootstrap_failure_restores_managed_state(
 
     assert ("set_type_managed", "wlan1") in calls
     assert ("nm_set_managed", "wlan1", True) in calls
+
+
+def test_main_early_hostapd_failure_removes_protected_secret_config(
+    monkeypatch,
+    mock_missing_system_commands,
+    tmp_path,
+    capsys,
+):
+    import vr_hotspotd.engine.hostapd_nat_engine as eng
+
+    secret = "cleanup-secret-123"
+    args = argparse.Namespace(
+        ap_ifname="wlan1",
+        ssid="VR-Hotspot",
+        passphrase=secret,
+        band="5ghz",
+        ap_security="wpa2",
+        country="US",
+        channel=36,
+        no_virt=True,
+        debug=False,
+        wifi6=False,
+        gateway_ip="192.168.68.1",
+        dhcp_start="192.168.68.10",
+        dhcp_end="192.168.68.250",
+        dhcp_dns="gateway",
+        no_internet=False,
+        channel_width="80",
+        beacon_interval=50,
+        dtim_period=1,
+        short_guard_interval=True,
+        tx_power=None,
+        strict_width=True,
+    )
+    lnxrouter_tmp = tmp_path / "lnxrouter_tmp"
+    conf_dir = lnxrouter_tmp / "lnxrouter.wlan1.conf.TEST"
+    conf_dir.mkdir(parents=True)
+    captured = {}
+
+    class FailedHostapd:
+        pid = 4141
+        returncode = 1
+
+        def __init__(self):
+            self.stdout = io.StringIO("synthetic hostapd failure\n")
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            return self.returncode
+
+        def kill(self):
+            return None
+
+    def fake_popen(command, **_kwargs):
+        config_path = Path(command[-1])
+        captured["path"] = config_path
+        captured["mode"] = stat.S_IMODE(config_path.stat().st_mode)
+        captured["content"] = config_path.read_text(encoding="utf-8")
+        return FailedHostapd()
+
+    monkeypatch.setenv("VR_HOTSPOT_LNXROUTER_TMPDIR", str(lnxrouter_tmp))
+    monkeypatch.setattr(eng.argparse.ArgumentParser, "parse_args", lambda self: args)
+    monkeypatch.setattr(eng.tempfile, "mkdtemp", lambda prefix, dir: str(conf_dir))
+    monkeypatch.setattr(eng, "_resolve_binary", lambda name, env_key: f"/usr/sbin/{name}")
+    monkeypatch.setattr(eng, "_is_bazzite", lambda: False)
+    monkeypatch.setattr(eng, "_maybe_set_regdom", lambda _country: None)
+    monkeypatch.setattr(eng, "_remove_p2p_dev_ifaces", lambda _ifname: [])
+    monkeypatch.setattr(eng, "_iwd_is_active", lambda: False)
+    monkeypatch.setattr(eng, "_is_nm_running", lambda: False)
+    monkeypatch.setattr(eng, "_rfkill_unblock_wifi", lambda: None)
+    monkeypatch.setattr(eng, "_iface_down", lambda _ifname: None)
+    monkeypatch.setattr(eng, "_flush_ip", lambda _ifname: None)
+    monkeypatch.setattr(eng, "_set_iface_type_ap", lambda _ifname: True)
+    monkeypatch.setattr(eng, "_set_iface_type_managed", lambda _ifname: True)
+    monkeypatch.setattr(eng, "_iface_up_with_recovery", lambda _ifname, no_virt=False: None)
+    monkeypatch.setattr(eng, "_ensure_ctrl_interface_dir", lambda _path: None)
+    monkeypatch.setattr(eng.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(eng.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(eng.signal, "signal", lambda *_args: None)
+
+    rc = eng.main()
+
+    assert rc == 1
+    assert captured["mode"] == 0o600
+    assert secret in captured["content"]
+    assert not captured["path"].exists()
+    assert not conf_dir.exists()
+    output = capsys.readouterr()
+    assert secret not in output.out
+    assert secret not in output.err
+    assert str(captured["path"]) not in output.out
+    assert str(captured["path"]) not in output.err


### PR DESCRIPTION
Hardens managed engine launch paths so hotspot passphrases are not exposed through child process argv.

What changed:
- Removes the real hotspot passphrase from VRHotspot-managed child process argv.
- Supervisor replaces secret-bearing arguments with `--password-fd` / `--passphrase-fd`.
- Delivers the secret through an anonymous pipe using `pass_fds`.
- Preserves `close_fds=True`.
- Keeps `EngineStartResult` and persisted state redacted.
- Adds shared secret FD handling.
- Updates vendored `lnxrouter` minimally to support FD-based passphrase delivery.
- Ensures native hostapd config files are created with restrictive permissions.
- Hardens cleanup for NAT, bridge, lnxrouter, and 6 GHz secret-bearing config paths.

Safety:
- No shell execution introduced.
- No temporary passphrase handoff file created by supervisor.
- Parent descriptors close on successful and failed spawn.
- Child descriptors close after reading.
- Secret contents and paths are not exposed through status, API, state, logs, or returned errors.
- Legacy direct/manual argv passphrase flags remain available only for compatibility; VRHotspot-managed launches no longer use them.

Scope:
- No API/auth changes.
- No UI changes.
- No adapter changes.
- No firewall mutation changes.
- No installer or uninstaller changes.
- No diagnostics-budget changes.
- No TLS/remote-access changes.
- No support-bundle changes.
- No Flatpak/desktop work.
- No rate-limiting/global-worker-pool work.
- No docs cleanup.

Tests:
- Verifies all managed `Popen` argv paths are secret-free.
- Verifies FD delivery and closure.
- Verifies redacted result/state behavior.
- Verifies spawn failures do not leak passphrases.
- Verifies native config files are mode `0600`.
- Verifies NAT and 6 GHz failure cleanup.
- Verifies non-secret command-builder arguments are preserved.
- Preserves the system-command safety guard.

Validation:
- `bash -n install.sh`
- `bash -n backend/scripts/install.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `474 passed, 4 subtests passed`