### PR TITLE
feat: add host facts snapshot model

### DIFF
--- a/backend/vr_hotspotd/host_facts.py
+++ b/backend/vr_hotspotd/host_facts.py
@@ -1,0 +1,232 @@
+"""Immutable internal models for one read-only host-facts collection window.
+
+These types are intentionally unused by runtime consumers in their first PR.
+They contain facts and provenance only; adapter scoring, readiness, lifecycle,
+preflight, firewall mutation, and public response policy remain elsewhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class SnapshotMetadata:
+    snapshot_id: str
+    operation_kind: str
+    source: str
+    started_at_utc: str
+    completed_at_utc: str
+    monotonic_duration_ms: int
+    builder_version: str
+
+
+@dataclass(frozen=True)
+class ProbeRecord:
+    probe_id: str
+    source_kind: str
+    source: Tuple[str, ...]
+    started_offset_ms: int
+    completed_offset_ms: int
+    exit_status: Optional[int]
+    timed_out: bool
+    missing: bool
+    permission_denied: bool
+    output_truncated: bool
+
+
+@dataclass(frozen=True)
+class ProbeError:
+    probe_id: str
+    kind: str
+    message: str
+    exit_status: Optional[int]
+
+
+@dataclass(frozen=True)
+class OsReleaseFact:
+    key: str
+    value: str
+
+
+@dataclass(frozen=True)
+class PlatformFacts:
+    os_release: Tuple[OsReleaseFact, ...]
+    os_id: Optional[str]
+    os_name: Optional[str]
+    version_id: Optional[str]
+    variant_id: Optional[str]
+    id_like: Tuple[str, ...]
+    flavor: str
+    family: Optional[str]
+    package_manager_family: Optional[str]
+    host_kind: str
+    is_immutable: Optional[bool]
+    immutability_signals: Tuple[str, ...]
+    source_probe_id: str
+
+
+@dataclass(frozen=True)
+class DefaultRouteFact:
+    interface: Optional[str]
+    gateway: Optional[str]
+    metric: Optional[int]
+    protocol: Optional[str]
+
+
+@dataclass(frozen=True)
+class DefaultUplinkFacts:
+    selected_interface: Optional[str]
+    routes: Tuple[DefaultRouteFact, ...]
+    source_probe_id: str
+
+
+@dataclass(frozen=True)
+class IwInterfaceFacts:
+    ifname: str
+    phy: Optional[str]
+    interface_type: Optional[str]
+    ssid_present: Optional[bool]
+
+
+@dataclass(frozen=True)
+class IwDevFacts:
+    interfaces: Tuple[IwInterfaceFacts, ...]
+    source_probe_id: str
+
+
+@dataclass(frozen=True)
+class FrequencyFacts:
+    frequency_mhz: int
+    channel: int
+    band: str
+    disabled: bool
+    no_ir: bool
+    dfs: bool
+
+
+@dataclass(frozen=True)
+class IwPhyFacts:
+    phy: str
+    interface_modes_known: bool
+    supported_interface_modes: Tuple[str, ...]
+    supports_ap: Optional[bool]
+    supports_2ghz: Optional[bool]
+    supports_5ghz: Optional[bool]
+    supports_6ghz: Optional[bool]
+    supports_80mhz: Optional[bool]
+    supports_wifi6: Optional[bool]
+    supports_ap_managed_concurrency: Optional[bool]
+    frequencies: Tuple[FrequencyFacts, ...]
+    source_probe_id: str
+
+
+@dataclass(frozen=True)
+class RegulatoryDomainFacts:
+    phy: str
+    country: Optional[str]
+    source: str
+    raw_header: Optional[str]
+
+
+@dataclass(frozen=True)
+class RegulatoryFacts:
+    global_country: Optional[str]
+    global_raw_header: Optional[str]
+    phys: Tuple[RegulatoryDomainFacts, ...]
+    source_probe_id: str
+
+
+@dataclass(frozen=True)
+class NetworkManagerFacts:
+    binary_present: bool
+    nmcli_present: bool
+    nmcli_running: Optional[bool]
+    service_state: Optional[str]
+    service_active: Optional[bool]
+    source_probe_ids: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class IwdFacts:
+    binary_present: bool
+    iwctl_present: bool
+    service_state: Optional[str]
+    service_active: Optional[bool]
+    associated_interfaces: Tuple[str, ...]
+    source_probe_ids: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FirewallBackendFacts:
+    name: str
+    tool_present: bool
+    functional_active: Optional[bool]
+    service_state: Optional[str]
+    service_active: Optional[bool]
+    variant: Optional[str]
+    source_probe_ids: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FirewallFacts:
+    backends: Tuple[FirewallBackendFacts, ...]
+    selected_backend: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class AdapterFacts:
+    ifname: str
+    phy: Optional[str]
+    interface_type: Optional[str]
+    associated: Optional[bool]
+    bus: str
+    supports_ap: Optional[bool]
+    supports_2ghz: Optional[bool]
+    supports_5ghz: Optional[bool]
+    supports_6ghz: Optional[bool]
+    supports_80mhz: Optional[bool]
+    supports_wifi6: Optional[bool]
+    regulatory_country: Optional[str]
+    regulatory_source: Optional[str]
+    source_probe_ids: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HostFactsSnapshot:
+    schema_version: int
+    metadata: SnapshotMetadata
+    platform: PlatformFacts
+    default_uplink: DefaultUplinkFacts
+    iw_dev: IwDevFacts
+    iw_phys: Tuple[IwPhyFacts, ...]
+    regulatory: RegulatoryFacts
+    network_manager: NetworkManagerFacts
+    iwd: IwdFacts
+    firewall: FirewallFacts
+    adapters: Tuple[AdapterFacts, ...]
+    probe_records: Tuple[ProbeRecord, ...]
+    probe_errors: Tuple[ProbeError, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a recursively JSON-serializable copy of the snapshot."""
+
+        value = _to_serializable(self)
+        if not isinstance(value, dict):  # pragma: no cover - defensive typing guard
+            raise TypeError("snapshot serialization did not produce a dictionary")
+        return value
+
+
+def _to_serializable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {
+            item.name: _to_serializable(getattr(value, item.name))
+            for item in fields(value)
+        }
+    if isinstance(value, tuple):
+        return [_to_serializable(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    raise TypeError(f"unsupported snapshot value: {type(value).__name__}")

--- a/backend/vr_hotspotd/host_facts_builder.py
+++ b/backend/vr_hotspotd/host_facts_builder.py
@@ -1,0 +1,1225 @@
+"""Read-only builder for an operation-scoped :class:`HostFactsSnapshot`.
+
+The builder is deliberately not imported by lifecycle, diagnostics, adapter,
+API, engine, installer, or support-bundle code yet.  Command execution and
+filesystem access are injectable so unit tests use deterministic fakes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, Sequence, Tuple
+
+from vr_hotspotd import host_probes, os_release
+from vr_hotspotd.host_facts import (
+    AdapterFacts,
+    DefaultRouteFact,
+    DefaultUplinkFacts,
+    FirewallBackendFacts,
+    FirewallFacts,
+    FrequencyFacts,
+    HostFactsSnapshot,
+    IwDevFacts,
+    IwdFacts,
+    IwInterfaceFacts,
+    IwPhyFacts,
+    NetworkManagerFacts,
+    OsReleaseFact,
+    PlatformFacts,
+    ProbeError,
+    ProbeRecord,
+    RegulatoryDomainFacts,
+    RegulatoryFacts,
+    SnapshotMetadata,
+)
+
+
+SNAPSHOT_SCHEMA_VERSION = 1
+BUILDER_VERSION = "1"
+MAX_CAPTURE_CHARS = 64 * 1024
+MAX_ERROR_MESSAGE_CHARS = 240
+MAX_OS_RELEASE_ENTRIES = 64
+MAX_OS_RELEASE_VALUE_CHARS = 512
+
+CommandRunner = Callable[..., Any]
+ExecutableResolver = Callable[[str], Optional[str]]
+OsReleaseReader = Callable[[], Mapping[str, str]]
+SysfsReader = Callable[[str], Optional[str]]
+SnapshotIdFactory = Callable[[], str]
+
+_VALID_IFNAME_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,15}$")
+_VALID_PHY_RE = re.compile(r"^phy\d+$")
+
+
+class SnapshotClock(Protocol):
+    def utc_now(self) -> datetime:
+        ...
+
+    def monotonic(self) -> float:
+        ...
+
+
+class SystemSnapshotClock:
+    def utc_now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+
+def _default_sysfs_reader(path: str) -> Optional[str]:
+    if not os.path.lexists(path):
+        return None
+    return os.path.realpath(path)
+
+
+def _default_snapshot_id() -> str:
+    return str(uuid.uuid4())
+
+
+@dataclass(frozen=True)
+class _CommandCapture:
+    result: host_probes.CommandResult
+    output: str
+    output_truncated: bool
+
+
+class HostFactsSnapshotBuilder:
+    """Collect one immutable snapshot through read-only injected dependencies."""
+
+    def __init__(
+        self,
+        *,
+        runner: Optional[CommandRunner] = None,
+        executable_resolver: Optional[ExecutableResolver] = None,
+        os_release_reader: Optional[OsReleaseReader] = None,
+        sysfs_reader: Optional[SysfsReader] = None,
+        clock: Optional[SnapshotClock] = None,
+        snapshot_id_factory: Optional[SnapshotIdFactory] = None,
+    ) -> None:
+        self._runner = runner
+        self._executable_resolver = executable_resolver or shutil.which
+        self._os_release_reader = os_release_reader or os_release.read_os_release
+        self._sysfs_reader = sysfs_reader or _default_sysfs_reader
+        self._clock = clock or SystemSnapshotClock()
+        self._snapshot_id_factory = snapshot_id_factory or _default_snapshot_id
+
+    def build(self, *, operation_kind: str = "unspecified") -> HostFactsSnapshot:
+        collector = _SnapshotCollector(
+            runner=self._runner,
+            executable_resolver=self._executable_resolver,
+            os_release_reader=self._os_release_reader,
+            sysfs_reader=self._sysfs_reader,
+            clock=self._clock,
+            snapshot_id_factory=self._snapshot_id_factory,
+        )
+        return collector.collect(operation_kind=operation_kind)
+
+
+def build_host_facts_snapshot(
+    *,
+    operation_kind: str = "unspecified",
+    runner: Optional[CommandRunner] = None,
+    executable_resolver: Optional[ExecutableResolver] = None,
+    os_release_reader: Optional[OsReleaseReader] = None,
+    sysfs_reader: Optional[SysfsReader] = None,
+    clock: Optional[SnapshotClock] = None,
+    snapshot_id_factory: Optional[SnapshotIdFactory] = None,
+) -> HostFactsSnapshot:
+    """Convenience wrapper that creates a fresh operation-scoped builder."""
+
+    return HostFactsSnapshotBuilder(
+        runner=runner,
+        executable_resolver=executable_resolver,
+        os_release_reader=os_release_reader,
+        sysfs_reader=sysfs_reader,
+        clock=clock,
+        snapshot_id_factory=snapshot_id_factory,
+    ).build(operation_kind=operation_kind)
+
+
+class _SnapshotCollector:
+    def __init__(
+        self,
+        *,
+        runner: Optional[CommandRunner],
+        executable_resolver: ExecutableResolver,
+        os_release_reader: OsReleaseReader,
+        sysfs_reader: SysfsReader,
+        clock: SnapshotClock,
+        snapshot_id_factory: SnapshotIdFactory,
+    ) -> None:
+        self._runner = runner
+        self._executable_resolver = executable_resolver
+        self._os_release_reader = os_release_reader
+        self._sysfs_reader = sysfs_reader
+        self._clock = clock
+        self._snapshot_id_factory = snapshot_id_factory
+        self._records: List[ProbeRecord] = []
+        self._errors: List[ProbeError] = []
+        self._resolved_tools: Dict[str, Optional[str]] = {}
+        self._started_monotonic = 0.0
+
+    def collect(self, *, operation_kind: str) -> HostFactsSnapshot:
+        self._started_monotonic = self._clock.monotonic()
+        started_at_utc = _format_utc(self._clock.utc_now())
+
+        os_info = self._capture_os_release()
+        platform = self._build_platform_facts(os_info)
+        iw_dev, iw_phys = self._capture_iw_facts()
+        regulatory = self._capture_regulatory_facts()
+        default_uplink = self._capture_default_uplink()
+        network_manager = self._capture_network_manager()
+        iwd = self._capture_iwd(iw_dev)
+        firewall = self._capture_firewall()
+        adapters = self._build_adapter_facts(iw_dev, iw_phys, regulatory)
+
+        completed_monotonic = self._clock.monotonic()
+        completed_at_utc = _format_utc(self._clock.utc_now())
+        duration_ms = _duration_ms(self._started_monotonic, completed_monotonic)
+        snapshot_id = _bounded_text(self._snapshot_id_factory(), 128) or "unknown"
+        normalized_operation = _bounded_text(operation_kind, 64) or "unspecified"
+
+        return HostFactsSnapshot(
+            schema_version=SNAPSHOT_SCHEMA_VERSION,
+            metadata=SnapshotMetadata(
+                snapshot_id=snapshot_id,
+                operation_kind=normalized_operation,
+                source="host_facts_builder",
+                started_at_utc=started_at_utc,
+                completed_at_utc=completed_at_utc,
+                monotonic_duration_ms=duration_ms,
+                builder_version=BUILDER_VERSION,
+            ),
+            platform=platform,
+            default_uplink=default_uplink,
+            iw_dev=iw_dev,
+            iw_phys=iw_phys,
+            regulatory=regulatory,
+            network_manager=network_manager,
+            iwd=iwd,
+            firewall=firewall,
+            adapters=adapters,
+            probe_records=tuple(self._records),
+            probe_errors=tuple(self._errors),
+        )
+
+    def _capture_os_release(self) -> Dict[str, str]:
+        probe_id = "platform.os_release"
+        started = self._clock.monotonic()
+        permission_denied = False
+        missing = False
+        truncated = False
+        normalized: Dict[str, str] = {}
+        try:
+            raw_info = self._os_release_reader()
+            if not isinstance(raw_info, Mapping):
+                raise TypeError("OS release reader did not return a mapping")
+            for index, (raw_key, raw_value) in enumerate(
+                sorted(raw_info.items(), key=lambda item: str(item[0]).lower())
+            ):
+                if index >= MAX_OS_RELEASE_ENTRIES:
+                    truncated = True
+                    break
+                key = _bounded_text(raw_key, 64).strip().lower()
+                value_text = str(raw_value)
+                value = _bounded_text(value_text, MAX_OS_RELEASE_VALUE_CHARS)
+                truncated = truncated or len(value_text) > len(value)
+                if key:
+                    normalized[key] = value
+            if not normalized:
+                missing = True
+                self._add_error(probe_id, "missing", "OS release data is unavailable")
+            if truncated:
+                self._add_error(
+                    probe_id,
+                    "truncated",
+                    "OS release input exceeded the snapshot budget",
+                )
+        except PermissionError as exc:
+            permission_denied = True
+            self._add_error(probe_id, "permission", exc, exit_status=None)
+        except FileNotFoundError as exc:
+            missing = True
+            self._add_error(probe_id, "missing", exc, exit_status=None)
+        except Exception as exc:
+            self._add_error(probe_id, "io", exc, exit_status=None)
+        completed = self._clock.monotonic()
+        self._records.append(
+            self._probe_record(
+                probe_id=probe_id,
+                source_kind="file",
+                source=("/etc/os-release", "/usr/lib/os-release"),
+                started=started,
+                completed=completed,
+                exit_status=0 if normalized else None,
+                timed_out=False,
+                missing=missing,
+                permission_denied=permission_denied,
+                output_truncated=truncated,
+            )
+        )
+        return normalized
+
+    def _build_platform_facts(self, info: Mapping[str, str]) -> PlatformFacts:
+        classification = host_probes.classify_os_flavor(info)
+        flavor = str(classification.get("flavor") or "unknown")
+        family_value = classification.get("family")
+        family = str(family_value) if isinstance(family_value, str) else None
+
+        signals: List[str] = []
+        if flavor in ("steamos", "bazzite", "fedora_atomic"):
+            signals.append(f"flavor:{flavor}")
+        if self._resolve_tool("rpm-ostree"):
+            signals.append("tool:rpm-ostree")
+        if self._resolve_tool("steamos-readonly"):
+            signals.append("tool:steamos-readonly")
+
+        if signals:
+            is_immutable: Optional[bool] = True
+        elif info:
+            is_immutable = False
+        else:
+            is_immutable = None
+
+        if flavor == "steamos":
+            host_kind = "steamos"
+        elif is_immutable is True:
+            host_kind = "immutable_linux"
+        elif info:
+            host_kind = "mutable_linux"
+        else:
+            host_kind = "unknown"
+
+        return PlatformFacts(
+            os_release=tuple(
+                OsReleaseFact(key=key, value=value)
+                for key, value in sorted(info.items())
+            ),
+            os_id=_optional_text(info.get("id")),
+            os_name=_optional_text(info.get("pretty_name") or info.get("name")),
+            version_id=_optional_text(info.get("version_id")),
+            variant_id=_optional_text(info.get("variant_id")),
+            id_like=tuple(host_probes.split_tokens(info.get("id_like"))),
+            flavor=flavor,
+            family=family,
+            package_manager_family=_package_manager_family(
+                family=family,
+                flavor=flavor,
+                immutable=is_immutable,
+            ),
+            host_kind=host_kind,
+            is_immutable=is_immutable,
+            immutability_signals=tuple(signals),
+            source_probe_id="platform.os_release",
+        )
+
+    def _capture_iw_facts(self) -> Tuple[IwDevFacts, Tuple[IwPhyFacts, ...]]:
+        iw = self._resolve_tool("iw")
+        if not iw:
+            self._missing_command("iw.dev", ("iw", "dev"), "iw")
+            return IwDevFacts(interfaces=(), source_probe_id="iw.dev"), ()
+
+        capture = self._capture_command("iw.dev", (iw, "dev"), timeout_s=3.0)
+        interfaces: List[IwInterfaceFacts] = []
+        discovered_phys: List[str] = []
+        if capture.result.ok:
+            try:
+                parsed = host_probes.parse_iw_dev_facts(capture.output)
+            except Exception as exc:
+                parsed = []
+                self._add_error(
+                    "iw.dev",
+                    "parse",
+                    f"iw dev parsing failed: {exc}",
+                    capture.result.exit_status,
+                )
+            if capture.output.strip() and not parsed:
+                self._add_error(
+                    "iw.dev",
+                    "parse",
+                    "iw dev output contained no parseable interfaces",
+                    capture.result.exit_status,
+                )
+            for item in parsed:
+                ifname = str(item.get("ifname") or "").strip()
+                if not ifname:
+                    self._add_error(
+                        "iw.dev",
+                        "parse",
+                        "iw dev contained an interface without a name",
+                        capture.result.exit_status,
+                    )
+                    continue
+                raw_phy = item.get("phy")
+                phy = str(raw_phy) if isinstance(raw_phy, str) and raw_phy else None
+                if phy is None or not _VALID_PHY_RE.match(phy):
+                    self._add_error(
+                        "iw.dev",
+                        "parse",
+                        f"interface {ifname} has no valid phy identifier",
+                        capture.result.exit_status,
+                    )
+                    phy = None
+                elif phy not in discovered_phys:
+                    discovered_phys.append(phy)
+                interface_type = _optional_text(item.get("interface_type"))
+                interfaces.append(
+                    IwInterfaceFacts(
+                        ifname=_bounded_text(ifname, 64),
+                        phy=phy,
+                        interface_type=interface_type,
+                        ssid_present=bool(item.get("ssid_present")),
+                    )
+                )
+
+        phy_facts = tuple(self._capture_one_phy(iw, phy) for phy in discovered_phys)
+        return (
+            IwDevFacts(interfaces=tuple(interfaces), source_probe_id="iw.dev"),
+            phy_facts,
+        )
+
+    def _capture_one_phy(self, iw: str, phy: str) -> IwPhyFacts:
+        probe_id = f"iw.phy.{phy}"
+        capture = self._capture_command(
+            probe_id,
+            (iw, "phy", phy, "info"),
+            timeout_s=4.0,
+        )
+        if not capture.result.ok:
+            return _empty_phy_facts(phy, probe_id)
+
+        try:
+            modes = host_probes.parse_all_supported_interface_modes(capture.output)
+            frequency_items = host_probes.parse_iw_frequencies(capture.output)
+            bands = host_probes.parse_band_support(capture.output)
+            supports_ap = _modes_support_ap(modes)
+            supports_80mhz = host_probes.supports_80mhz(capture.output)
+            supports_wifi6 = host_probes.supports_wifi6(capture.output)
+            concurrency = host_probes.parse_ap_managed_concurrency(capture.output)
+        except Exception as exc:
+            self._add_error(
+                probe_id,
+                "parse",
+                f"wireless phy parsing failed: {exc}",
+                capture.result.exit_status,
+            )
+            return _empty_phy_facts(phy, probe_id)
+        if not modes:
+            self._add_error(
+                probe_id,
+                "parse",
+                "supported interface mode facts were not found",
+                capture.result.exit_status,
+            )
+        if not frequency_items:
+            self._add_error(
+                probe_id,
+                "parse",
+                "wireless frequency facts were not found",
+                capture.result.exit_status,
+            )
+        frequencies = tuple(
+            FrequencyFacts(
+                frequency_mhz=int(item["frequency_mhz"]),
+                channel=int(item["channel"]),
+                band=str(item["band"]),
+                disabled=bool(item["disabled"]),
+                no_ir=bool(item["no_ir"]),
+                dfs=bool(item["dfs"]),
+            )
+            for item in frequency_items
+        )
+        structurally_complete = bool(modes) and bool(frequency_items)
+        return IwPhyFacts(
+            phy=phy,
+            interface_modes_known=bool(modes),
+            supported_interface_modes=tuple(modes or ()),
+            supports_ap=supports_ap if modes else None,
+            supports_2ghz=(bool(bands.get("supports_2ghz")) if frequency_items else None),
+            supports_5ghz=(bool(bands.get("supports_5ghz")) if frequency_items else None),
+            supports_6ghz=(bool(bands.get("supports_6ghz")) if frequency_items else None),
+            supports_80mhz=supports_80mhz if structurally_complete else None,
+            supports_wifi6=supports_wifi6 if structurally_complete else None,
+            supports_ap_managed_concurrency=concurrency,
+            frequencies=frequencies,
+            source_probe_id=probe_id,
+        )
+
+    def _capture_regulatory_facts(self) -> RegulatoryFacts:
+        probe_id = "iw.regulatory"
+        iw = self._resolve_tool("iw")
+        if not iw:
+            self._missing_command(probe_id, ("iw", "reg", "get"), "iw")
+            return RegulatoryFacts(
+                global_country=None,
+                global_raw_header=None,
+                phys=(),
+                source_probe_id=probe_id,
+            )
+
+        capture = self._capture_command(
+            probe_id,
+            (iw, "reg", "get"),
+            timeout_s=2.0,
+        )
+        if not capture.result.ok:
+            return RegulatoryFacts(
+                global_country=None,
+                global_raw_header=None,
+                phys=(),
+                source_probe_id=probe_id,
+            )
+
+        try:
+            parsed = host_probes.parse_regulatory_domains(capture.output)
+        except Exception as exc:
+            self._add_error(
+                probe_id,
+                "parse",
+                f"regulatory parsing failed: {exc}",
+                capture.result.exit_status,
+            )
+            return RegulatoryFacts(
+                global_country=None,
+                global_raw_header=None,
+                phys=(),
+                source_probe_id=probe_id,
+            )
+        global_data = parsed.get("global", {})
+        global_country = _country_or_none(global_data.get("country"))
+        raw_phys = parsed.get("phys", {})
+        phys: List[RegulatoryDomainFacts] = []
+        if isinstance(raw_phys, Mapping):
+            for phy, raw_value in sorted(raw_phys.items(), key=lambda item: str(item[0])):
+                value = raw_value if isinstance(raw_value, Mapping) else {}
+                phys.append(
+                    RegulatoryDomainFacts(
+                        phy=_bounded_text(phy, 64),
+                        country=_country_or_none(value.get("country")),
+                        source=_bounded_text(value.get("source") or "unknown", 64),
+                        raw_header=_optional_bounded_text(value.get("raw_header"), 256),
+                    )
+                )
+        if global_country is None and not any(item.country for item in phys):
+            self._add_error(
+                probe_id,
+                "parse",
+                "regulatory output contained no country facts",
+                capture.result.exit_status,
+            )
+        return RegulatoryFacts(
+            global_country=global_country,
+            global_raw_header=_optional_bounded_text(global_data.get("raw_header"), 256),
+            phys=tuple(phys),
+            source_probe_id=probe_id,
+        )
+
+    def _capture_default_uplink(self) -> DefaultUplinkFacts:
+        probe_id = "network.default_uplink"
+        ip = self._resolve_tool("ip")
+        if not ip:
+            self._missing_command(
+                probe_id,
+                ("ip", "route", "show", "default"),
+                "ip",
+            )
+            return DefaultUplinkFacts(
+                selected_interface=None,
+                routes=(),
+                source_probe_id=probe_id,
+            )
+
+        capture = self._capture_command(
+            probe_id,
+            (ip, "route", "show", "default"),
+            timeout_s=2.0,
+        )
+        if not capture.result.ok:
+            return DefaultUplinkFacts(
+                selected_interface=None,
+                routes=(),
+                source_probe_id=probe_id,
+            )
+        try:
+            route_items = host_probes.parse_default_routes(capture.output)
+            selected_interface = host_probes.parse_default_uplink(capture.output)
+        except Exception as exc:
+            self._add_error(
+                probe_id,
+                "parse",
+                f"default-route parsing failed: {exc}",
+                capture.result.exit_status,
+            )
+            return DefaultUplinkFacts(
+                selected_interface=None,
+                routes=(),
+                source_probe_id=probe_id,
+            )
+        if capture.output.strip() and not route_items:
+            self._add_error(
+                probe_id,
+                "parse",
+                "default-route output contained no parseable default routes",
+                capture.result.exit_status,
+            )
+        routes = tuple(
+            DefaultRouteFact(
+                interface=_optional_bounded_text(item.get("interface"), 64),
+                gateway=_optional_bounded_text(item.get("gateway"), 128),
+                metric=item.get("metric") if isinstance(item.get("metric"), int) else None,
+                protocol=_optional_bounded_text(item.get("protocol"), 64),
+            )
+            for item in route_items
+        )
+        return DefaultUplinkFacts(
+            selected_interface=_optional_bounded_text(
+                selected_interface,
+                64,
+            ),
+            routes=routes,
+            source_probe_id=probe_id,
+        )
+
+    def _capture_network_manager(self) -> NetworkManagerFacts:
+        nmcli_probe = "network_manager.nmcli"
+        nmcli = self._resolve_tool("nmcli")
+        nmcli_running: Optional[bool] = None
+        if not nmcli:
+            self._missing_command(
+                nmcli_probe,
+                ("nmcli", "-t", "-f", "RUNNING", "g"),
+                "nmcli",
+            )
+        else:
+            capture = self._capture_command(
+                nmcli_probe,
+                (nmcli, "-t", "-f", "RUNNING", "g"),
+                timeout_s=1.0,
+            )
+            if capture.result.ok:
+                status = _first_output_line(capture.output)
+                if status == "running":
+                    nmcli_running = True
+                elif status == "not running":
+                    nmcli_running = False
+                else:
+                    self._add_error(
+                        nmcli_probe,
+                        "parse",
+                        "nmcli returned an unrecognized global running state",
+                        capture.result.exit_status,
+                    )
+
+        service_probe = "network_manager.service"
+        service_state, service_active = self._capture_service(
+            service_probe,
+            "NetworkManager",
+        )
+        return NetworkManagerFacts(
+            binary_present=bool(self._resolve_tool("NetworkManager")),
+            nmcli_present=bool(nmcli),
+            nmcli_running=nmcli_running,
+            service_state=service_state,
+            service_active=service_active,
+            source_probe_ids=(nmcli_probe, service_probe),
+        )
+
+    def _capture_iwd(self, iw_dev: IwDevFacts) -> IwdFacts:
+        service_probe = "iwd.service"
+        service_state, service_active = self._capture_service(service_probe, "iwd")
+        associated = tuple(
+            item.ifname for item in iw_dev.interfaces if item.ssid_present is True
+        )
+        return IwdFacts(
+            binary_present=bool(self._resolve_tool("iwd")),
+            iwctl_present=bool(self._resolve_tool("iwctl")),
+            service_state=service_state,
+            service_active=service_active,
+            associated_interfaces=associated,
+            source_probe_ids=(service_probe, iw_dev.source_probe_id),
+        )
+
+    def _capture_firewall(self) -> FirewallFacts:
+        firewall_cmd = self._resolve_tool("firewall-cmd")
+        firewalld_probe = "firewall.firewalld.functional"
+        firewalld_active: Optional[bool] = None
+        if not firewall_cmd:
+            self._missing_command(
+                firewalld_probe,
+                ("firewall-cmd", "--state"),
+                "firewall-cmd",
+            )
+        else:
+            capture = self._capture_command(
+                firewalld_probe,
+                (firewall_cmd, "--state"),
+                timeout_s=1.0,
+            )
+            if capture.result.ok and not capture.output_truncated:
+                state = _parse_exact_status_line(capture.output)
+                if state == "running":
+                    firewalld_active = True
+                elif state in ("not running", "stopped"):
+                    firewalld_active = False
+                else:
+                    self._add_error(
+                        firewalld_probe,
+                        "parse",
+                        "firewall-cmd returned an unrecognized state",
+                        capture.result.exit_status,
+                    )
+        firewalld_service_probe = "firewall.firewalld.service"
+        firewalld_service_state, firewalld_service_active = self._capture_service(
+            firewalld_service_probe,
+            "firewalld",
+        )
+
+        ufw = self._resolve_tool("ufw")
+        ufw_probe = "firewall.ufw.functional"
+        ufw_active: Optional[bool] = None
+        if not ufw:
+            self._missing_command(ufw_probe, ("ufw", "status"), "ufw")
+        else:
+            capture = self._capture_command(
+                ufw_probe,
+                (ufw, "status"),
+                timeout_s=1.5,
+            )
+            if capture.result.ok:
+                parsed_ufw = _parse_ufw_active(capture.output)
+                if parsed_ufw is not None:
+                    ufw_active = parsed_ufw
+                else:
+                    self._add_error(
+                        ufw_probe,
+                        "parse",
+                        "ufw output contained no parseable status field",
+                        capture.result.exit_status,
+                    )
+        ufw_service_probe = "firewall.ufw.service"
+        ufw_service_state, ufw_service_active = self._capture_service(
+            ufw_service_probe,
+            "ufw",
+        )
+
+        nft = self._resolve_tool("nft")
+        iptables = self._resolve_tool("iptables")
+        iptables_probe = "firewall.iptables.version"
+        iptables_variant: Optional[str] = None
+        if not iptables:
+            self._missing_command(
+                iptables_probe,
+                ("iptables", "--version"),
+                "iptables",
+            )
+        else:
+            capture = self._capture_command(
+                iptables_probe,
+                (iptables, "--version"),
+                timeout_s=1.0,
+            )
+            if capture.result.ok:
+                lowered = capture.output.lower()
+                if "nf_tables" in lowered or "nft" in lowered:
+                    iptables_variant = "iptables-nft"
+                elif "legacy" in lowered:
+                    iptables_variant = "iptables-legacy"
+                else:
+                    iptables_variant = "iptables-unknown"
+
+        if firewalld_active is True:
+            selected = "firewalld"
+            rationale = "firewalld_running"
+        elif ufw_active is True:
+            selected = "ufw"
+            rationale = "ufw_active"
+        elif nft:
+            selected = "nftables"
+            rationale = "nft_present"
+        elif iptables:
+            selected = "iptables"
+            rationale = "iptables_present"
+        else:
+            selected = "unknown"
+            rationale = "no_firewall_detected"
+
+        return FirewallFacts(
+            backends=(
+                FirewallBackendFacts(
+                    name="firewalld",
+                    tool_present=bool(firewall_cmd),
+                    functional_active=firewalld_active,
+                    service_state=firewalld_service_state,
+                    service_active=firewalld_service_active,
+                    variant=None,
+                    source_probe_ids=(firewalld_probe, firewalld_service_probe),
+                ),
+                FirewallBackendFacts(
+                    name="ufw",
+                    tool_present=bool(ufw),
+                    functional_active=ufw_active,
+                    service_state=ufw_service_state,
+                    service_active=ufw_service_active,
+                    variant=None,
+                    source_probe_ids=(ufw_probe, ufw_service_probe),
+                ),
+                FirewallBackendFacts(
+                    name="nftables",
+                    tool_present=bool(nft),
+                    functional_active=None,
+                    service_state=None,
+                    service_active=None,
+                    variant=None,
+                    source_probe_ids=(),
+                ),
+                FirewallBackendFacts(
+                    name="iptables",
+                    tool_present=bool(iptables),
+                    functional_active=None,
+                    service_state=None,
+                    service_active=None,
+                    variant=iptables_variant,
+                    source_probe_ids=(iptables_probe,),
+                ),
+            ),
+            selected_backend=selected,
+            rationale=rationale,
+        )
+
+    def _build_adapter_facts(
+        self,
+        iw_dev: IwDevFacts,
+        iw_phys: Tuple[IwPhyFacts, ...],
+        regulatory: RegulatoryFacts,
+    ) -> Tuple[AdapterFacts, ...]:
+        phy_by_name = {item.phy: item for item in iw_phys}
+        regulatory_by_phy = {item.phy: item for item in regulatory.phys}
+        adapters: List[AdapterFacts] = []
+        for interface in iw_dev.interfaces:
+            phy = phy_by_name.get(interface.phy or "")
+            reg = regulatory_by_phy.get(interface.phy or "")
+            bus, sysfs_probe = self._capture_adapter_bus(interface.ifname)
+            source_ids = [iw_dev.source_probe_id]
+            if phy is not None:
+                source_ids.append(phy.source_probe_id)
+            source_ids.append(regulatory.source_probe_id)
+            if sysfs_probe:
+                source_ids.append(sysfs_probe)
+            adapters.append(
+                AdapterFacts(
+                    ifname=interface.ifname,
+                    phy=interface.phy,
+                    interface_type=interface.interface_type,
+                    associated=interface.ssid_present,
+                    bus=bus,
+                    supports_ap=phy.supports_ap if phy else None,
+                    supports_2ghz=phy.supports_2ghz if phy else None,
+                    supports_5ghz=phy.supports_5ghz if phy else None,
+                    supports_6ghz=phy.supports_6ghz if phy else None,
+                    supports_80mhz=phy.supports_80mhz if phy else None,
+                    supports_wifi6=phy.supports_wifi6 if phy else None,
+                    regulatory_country=(
+                        reg.country if reg and reg.country else regulatory.global_country
+                    ),
+                    regulatory_source=(
+                        reg.source if reg else ("global" if regulatory.global_country else None)
+                    ),
+                    source_probe_ids=tuple(source_ids),
+                )
+            )
+        return tuple(adapters)
+
+    def _capture_adapter_bus(self, ifname: str) -> Tuple[str, Optional[str]]:
+        probe_id = f"sysfs.adapter.{_bounded_text(ifname, 64)}.device"
+        if not _VALID_IFNAME_RE.match(ifname):
+            self._add_error(
+                probe_id,
+                "parse",
+                "interface name is unsafe for a sysfs lookup",
+            )
+            return "unknown", None
+
+        path = f"/sys/class/net/{ifname}/device"
+        started = self._clock.monotonic()
+        missing = False
+        permission_denied = False
+        truncated = False
+        target: Optional[str] = None
+        try:
+            target = self._sysfs_reader(path)
+            if target is not None:
+                target_text = str(target)
+                target = _bounded_text(target_text, 1024)
+                truncated = len(target_text) > len(target)
+                if truncated:
+                    self._add_error(
+                        probe_id,
+                        "truncated",
+                        "adapter sysfs target exceeded the snapshot budget",
+                    )
+            if not target:
+                missing = True
+                self._add_error(probe_id, "missing", "adapter sysfs device link is absent")
+        except PermissionError as exc:
+            permission_denied = True
+            self._add_error(probe_id, "permission", exc)
+        except FileNotFoundError as exc:
+            missing = True
+            self._add_error(probe_id, "missing", exc)
+        except Exception as exc:
+            self._add_error(probe_id, "io", exc)
+        completed = self._clock.monotonic()
+        self._records.append(
+            self._probe_record(
+                probe_id=probe_id,
+                source_kind="sysfs",
+                source=(path,),
+                started=started,
+                completed=completed,
+                exit_status=0 if target else None,
+                timed_out=False,
+                missing=missing,
+                permission_denied=permission_denied,
+                output_truncated=truncated,
+            )
+        )
+        return _bus_from_sysfs_target(target), probe_id
+
+    def _capture_service(
+        self,
+        probe_id: str,
+        unit: str,
+    ) -> Tuple[Optional[str], Optional[bool]]:
+        systemctl = self._resolve_tool("systemctl")
+        if not systemctl:
+            self._missing_command(
+                probe_id,
+                ("systemctl", "is-active", unit),
+                "systemctl",
+            )
+            return None, None
+        capture = self._capture_command(
+            probe_id,
+            (systemctl, "is-active", unit),
+            timeout_s=1.0,
+        )
+        if not capture.result.ok or capture.output_truncated:
+            return None, None
+        state = _parse_exact_status_line(capture.output)
+        if state != "active":
+            self._add_error(
+                probe_id,
+                "parse",
+                f"systemctl returned an unrecognized state for {unit}",
+                capture.result.exit_status,
+            )
+            return None, None
+        return state, True
+
+    def _capture_command(
+        self,
+        probe_id: str,
+        argv: Sequence[str],
+        *,
+        timeout_s: float,
+    ) -> _CommandCapture:
+        started = self._clock.monotonic()
+        try:
+            result = host_probes.run_command(
+                argv,
+                timeout_s=timeout_s,
+                runner=self._runner,
+            )
+        except Exception as exc:
+            result = host_probes.CommandResult(
+                argv=tuple(str(item) for item in argv),
+                exit_status=127,
+                error=f"{type(exc).__name__}: {exc}",
+                exception=exc,
+            )
+        completed = self._clock.monotonic()
+        raw_output = result.combined_output(include_error=False)
+        output = raw_output[:MAX_CAPTURE_CHARS]
+        truncated = len(raw_output) > len(output)
+        self._records.append(
+            self._probe_record(
+                probe_id=probe_id,
+                source_kind="command",
+                source=tuple(result.argv),
+                started=started,
+                completed=completed,
+                exit_status=result.exit_status,
+                timed_out=result.timed_out,
+                missing=result.missing,
+                permission_denied=result.permission_denied,
+                output_truncated=truncated,
+            )
+        )
+        if result.timed_out:
+            self._add_error(probe_id, "timeout", "read-only command timed out", result.exit_status)
+        elif result.missing:
+            self._add_error(probe_id, "missing", result.error or "command is missing", result.exit_status)
+        elif result.permission_denied:
+            self._add_error(
+                probe_id,
+                "permission",
+                result.error or "command permission was denied",
+                result.exit_status,
+            )
+        elif result.error:
+            self._add_error(probe_id, "execution", result.error, result.exit_status)
+        elif result.exit_status != 0:
+            self._add_error(
+                probe_id,
+                "nonzero",
+                f"read-only command exited with status {result.exit_status}",
+                result.exit_status,
+            )
+        if truncated:
+            self._add_error(
+                probe_id,
+                "truncated",
+                f"command output exceeded {MAX_CAPTURE_CHARS} characters",
+                result.exit_status,
+            )
+        return _CommandCapture(
+            result=result,
+            output=output,
+            output_truncated=truncated,
+        )
+
+    def _missing_command(
+        self,
+        probe_id: str,
+        argv: Sequence[str],
+        tool: str,
+    ) -> None:
+        started = self._clock.monotonic()
+        completed = self._clock.monotonic()
+        self._records.append(
+            self._probe_record(
+                probe_id=probe_id,
+                source_kind="command",
+                source=tuple(str(item) for item in argv),
+                started=started,
+                completed=completed,
+                exit_status=None,
+                timed_out=False,
+                missing=True,
+                permission_denied=False,
+                output_truncated=False,
+            )
+        )
+        self._add_error(probe_id, "missing", f"required tool is unavailable: {tool}")
+
+    def _resolve_tool(self, name: str) -> Optional[str]:
+        if name in self._resolved_tools:
+            return self._resolved_tools[name]
+        probe_id = f"tool.{name}"
+        started = self._clock.monotonic()
+        resolution_failed = False
+        try:
+            value = self._executable_resolver(name)
+            resolved = os.fspath(value) if value else None
+        except Exception as exc:
+            resolved = None
+            resolution_failed = True
+            self._add_error(
+                probe_id,
+                "io",
+                f"executable resolution failed: {exc}",
+            )
+        completed = self._clock.monotonic()
+        self._records.append(
+            self._probe_record(
+                probe_id=probe_id,
+                source_kind="environment",
+                source=(name,),
+                started=started,
+                completed=completed,
+                exit_status=0 if resolved else None,
+                timed_out=False,
+                missing=resolved is None and not resolution_failed,
+                permission_denied=False,
+                output_truncated=False,
+            )
+        )
+        self._resolved_tools[name] = resolved
+        return resolved
+
+    def _probe_record(
+        self,
+        *,
+        probe_id: str,
+        source_kind: str,
+        source: Tuple[str, ...],
+        started: float,
+        completed: float,
+        exit_status: Optional[int],
+        timed_out: bool,
+        missing: bool,
+        permission_denied: bool,
+        output_truncated: bool,
+    ) -> ProbeRecord:
+        return ProbeRecord(
+            probe_id=_bounded_text(probe_id, 128),
+            source_kind=source_kind,
+            source=tuple(_bounded_text(item, 512) for item in source),
+            started_offset_ms=_duration_ms(self._started_monotonic, started),
+            completed_offset_ms=_duration_ms(self._started_monotonic, completed),
+            exit_status=exit_status,
+            timed_out=timed_out,
+            missing=missing,
+            permission_denied=permission_denied,
+            output_truncated=output_truncated,
+        )
+
+    def _add_error(
+        self,
+        probe_id: str,
+        kind: str,
+        message: object,
+        exit_status: Optional[int] = None,
+    ) -> None:
+        self._errors.append(
+            ProbeError(
+                probe_id=_bounded_text(probe_id, 128),
+                kind=_bounded_text(kind, 32),
+                message=_sanitized_error(message),
+                exit_status=exit_status,
+            )
+        )
+
+
+def _empty_phy_facts(phy: str, probe_id: str) -> IwPhyFacts:
+    return IwPhyFacts(
+        phy=phy,
+        interface_modes_known=False,
+        supported_interface_modes=(),
+        supports_ap=None,
+        supports_2ghz=None,
+        supports_5ghz=None,
+        supports_6ghz=None,
+        supports_80mhz=None,
+        supports_wifi6=None,
+        supports_ap_managed_concurrency=None,
+        frequencies=(),
+        source_probe_id=probe_id,
+    )
+
+
+def _format_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    normalized = value.astimezone(timezone.utc).isoformat(timespec="milliseconds")
+    return normalized.replace("+00:00", "Z")
+
+
+def _duration_ms(started: float, completed: float) -> int:
+    return max(0, int(round((completed - started) * 1000.0)))
+
+
+def _bounded_text(value: object, limit: int) -> str:
+    return str(value)[:limit]
+
+
+def _optional_text(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_bounded_text(value: object, limit: int) -> Optional[str]:
+    text = _optional_text(value)
+    return _bounded_text(text, limit) if text is not None else None
+
+
+def _sanitized_error(value: object) -> str:
+    normalized = " ".join(str(value).replace("\x00", "").split())
+    return normalized[:MAX_ERROR_MESSAGE_CHARS] or "unknown probe error"
+
+
+def _first_output_line(output: str) -> Optional[str]:
+    for raw in output.splitlines():
+        line = raw.strip().lower()
+        if line:
+            return _bounded_text(line, 128)
+    return None
+
+
+def _parse_exact_status_line(output: str) -> Optional[str]:
+    lines = [raw.strip().lower() for raw in output.splitlines() if raw.strip()]
+    if len(lines) != 1:
+        return None
+    return _bounded_text(lines[0], 128)
+
+
+def _parse_ufw_active(output: str) -> Optional[bool]:
+    for raw in output.splitlines():
+        label, separator, _value = raw.partition(":")
+        if separator and label.strip().casefold() == "status":
+            return host_probes.parse_ufw_status(output)
+    return None
+
+
+def _modes_support_ap(modes: Optional[List[str]]) -> Optional[bool]:
+    if modes is None:
+        return None
+    for mode in modes:
+        normalized = mode.upper()
+        if (
+            normalized == "AP"
+            or normalized.startswith("AP/")
+            or normalized.startswith("AP-")
+        ):
+            return True
+    return False
+
+
+def _country_or_none(value: object) -> Optional[str]:
+    country = _optional_text(value)
+    if not country or country.lower() == "unknown":
+        return None
+    return _bounded_text(country, 16)
+
+
+def _bus_from_sysfs_target(target: Optional[str]) -> str:
+    if not target:
+        return "unknown"
+    lowered = target.lower()
+    if "/virtual/" in lowered:
+        return "virtual"
+    if "/usb" in lowered:
+        return "usb"
+    if "/pci" in lowered:
+        return "pci"
+    if "/sdio" in lowered:
+        return "sdio"
+    if "/platform" in lowered:
+        return "platform"
+    return "unknown"
+
+
+def _package_manager_family(
+    *,
+    family: Optional[str],
+    flavor: str,
+    immutable: Optional[bool],
+) -> Optional[str]:
+    if flavor == "bazzite" or (flavor == "fedora_atomic" and immutable is True):
+        return "rpm-ostree"
+    if family == "arch":
+        return "pacman"
+    if family == "debian":
+        return "apt"
+    if family == "fedora":
+        return "rpm-ostree" if immutable is True else "dnf"
+    return None

--- a/backend/vr_hotspotd/host_probes.py
+++ b/backend/vr_hotspotd/host_probes.py
@@ -220,6 +220,56 @@ def parse_iw_dev_interfaces(text: str) -> List[Dict[str, str]]:
     return interfaces
 
 
+def parse_iw_dev_facts(text: str) -> List[Dict[str, Any]]:
+    """Parse one ``iw dev`` capture without retaining SSID values.
+
+    The richer shape is intended for immutable host-fact snapshots.  Existing
+    inventory callers keep using :func:`parse_iw_dev_interfaces` and therefore
+    retain their current compatibility behavior.
+    """
+
+    interfaces: List[Dict[str, Any]] = []
+    current_phy: Optional[str] = None
+    current: Optional[Dict[str, Any]] = None
+
+    def finish_current() -> None:
+        nonlocal current
+        if current is not None:
+            interfaces.append(current)
+            current = None
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("phy#"):
+            finish_current()
+            suffix = line.split("#", 1)[1].strip()
+            number = suffix.split()[0] if suffix else ""
+            current_phy = f"phy{number}" if number else None
+            continue
+        if line.startswith("Interface "):
+            finish_current()
+            parts = line.split()
+            if len(parts) >= 2:
+                current = {
+                    "ifname": parts[1].strip(),
+                    "phy": current_phy,
+                    "interface_type": None,
+                    "ssid_present": False,
+                }
+            continue
+        if current is None:
+            continue
+        if line.startswith("type "):
+            value = line.split(None, 1)[1].strip()
+            current["interface_type"] = value or None
+        elif line.startswith("ssid "):
+            # Association presence is useful evidence; the SSID itself is not.
+            current["ssid_present"] = True
+
+    finish_current()
+    return interfaces
+
+
 def split_wiphy_sections(text: str) -> Dict[str, str]:
     sections: Dict[str, List[str]] = {}
     current: Optional[str] = None
@@ -253,6 +303,34 @@ def parse_supported_interface_modes(text: str) -> Optional[List[str]]:
             modes.append(line.lstrip("*").strip())
         elif line:
             break
+    return modes
+
+
+def parse_all_supported_interface_modes(text: str) -> Optional[List[str]]:
+    """Return modes from every ``Supported interface modes`` block.
+
+    Inventory's compatibility parser deliberately continues scanning after an
+    earlier block.  The snapshot uses this additive parser so one captured phy
+    can retain that factual evidence without changing existing callers.
+    """
+
+    if not text or "Supported interface modes" not in text:
+        return None
+    modes: List[str] = []
+    in_modes = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("Supported interface modes"):
+            in_modes = True
+            continue
+        if not in_modes:
+            continue
+        if line.startswith("*"):
+            mode = line.lstrip("*").strip()
+            if mode and mode not in modes:
+                modes.append(mode)
+        elif line:
+            in_modes = False
     return modes
 
 
@@ -410,6 +488,43 @@ def parse_band_support(text: str) -> Dict[str, bool]:
     return supports
 
 
+def parse_iw_frequencies(text: str) -> List[Dict[str, Any]]:
+    """Return curated frequency/channel facts from ``iw phy`` output."""
+
+    frequencies: List[Dict[str, Any]] = []
+    for raw in text.splitlines():
+        match = _IW_FREQ_LINE_RE.match(raw.strip())
+        if not match:
+            continue
+        try:
+            mhz = int(float(match.group(1)))
+            channel = int(match.group(2))
+        except Exception:
+            continue
+
+        lowered = (match.group(3) or "").lower()
+        if 2400 <= mhz <= 2500:
+            band = "2.4ghz"
+        elif 4900 <= mhz <= 5900:
+            band = "5ghz"
+        elif 5925 <= mhz <= 7125:
+            band = "6ghz"
+        else:
+            band = "unknown"
+        no_ir = "no ir" in lowered or "no-ir" in lowered or "no_ir" in lowered
+        frequencies.append(
+            {
+                "frequency_mhz": mhz,
+                "channel": channel,
+                "band": band,
+                "disabled": "disabled" in lowered,
+                "no_ir": no_ir,
+                "dfs": "radar detection" in lowered or "dfs" in lowered,
+            }
+        )
+    return frequencies
+
+
 def parse_5ghz_channels(text: str) -> List[Dict[str, Any]]:
     channels: List[Dict[str, Any]] = []
     in_frequencies = False
@@ -514,6 +629,44 @@ def parse_default_uplink(text: str) -> Optional[str]:
         if index + 1 < len(parts):
             return parts[index + 1]
     return None
+
+
+def parse_default_routes(text: str) -> List[Dict[str, Any]]:
+    """Parse curated facts for every ``default`` route line.
+
+    This deliberately does not sort or choose a route.  Snapshot callers can
+    retain the command order while :func:`parse_default_uplink` preserves the
+    existing first-``dev`` compatibility selection.
+    """
+
+    routes: List[Dict[str, Any]] = []
+    for raw in text.splitlines():
+        parts = raw.strip().split()
+        if not parts or parts[0] != "default":
+            continue
+
+        def value_after(token: str) -> Optional[str]:
+            if token not in parts:
+                return None
+            index = parts.index(token)
+            if index + 1 >= len(parts):
+                return None
+            return parts[index + 1]
+
+        metric_text = value_after("metric")
+        try:
+            metric = int(metric_text) if metric_text is not None else None
+        except ValueError:
+            metric = None
+        routes.append(
+            {
+                "interface": value_after("dev"),
+                "gateway": value_after("via"),
+                "metric": metric,
+                "protocol": value_after("proto"),
+            }
+        )
+    return routes
 
 
 def probe_default_uplink(

--- a/tests/test_host_facts_builder.py
+++ b/tests/test_host_facts_builder.py
@@ -1,0 +1,565 @@
+import json
+import subprocess
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from vr_hotspotd.host_facts_builder import (
+    MAX_CAPTURE_CHARS,
+    MAX_ERROR_MESSAGE_CHARS,
+    HostFactsSnapshotBuilder,
+)
+
+
+IW_DEV_OUTPUT = """
+phy#0
+    Interface wlan0
+        ifindex 3
+        type managed
+        ssid Upstream Network Must Stay Private
+phy#1
+    Interface wlan1
+        ifindex 7
+        type managed
+"""
+
+IW_PHY0_OUTPUT = """
+Wiphy phy0
+  Supported interface modes:
+     * managed
+     * AP
+  Band 1:
+    Frequencies:
+      * 2412.0 MHz [1] (22.0 dBm)
+"""
+
+IW_PHY1_OUTPUT = """
+Wiphy phy1
+  Supported interface modes:
+     * managed
+     * AP/VLAN
+  valid interface combinations:
+     * #{ managed } <= 1, #{ AP, P2P-client } <= 1,
+       total <= 2, #channels <= 1
+  Band 1:
+    Frequencies:
+      * 2412.0 MHz [1] (22.0 dBm)
+  Band 2:
+    HE Iftypes: AP, managed
+    HE40/HE80/5GHz
+    Frequencies:
+      * 5180.0 MHz [36] (23.0 dBm)
+      * 5200.0 MHz [40] (no IR)
+"""
+
+IW_REG_OUTPUT = """
+global
+country US: DFS-FCC
+phy#0
+country US: DFS-FCC
+phy#1 (self-managed)
+country CA: DFS-FCC
+"""
+
+TOOL_PATHS = {
+    "iw": "/usr/sbin/iw",
+    "ip": "/usr/sbin/ip",
+    "nmcli": "/usr/bin/nmcli",
+    "NetworkManager": "/usr/sbin/NetworkManager",
+    "systemctl": "/usr/bin/systemctl",
+    "iwd": "/usr/lib/iwd",
+    "iwctl": "/usr/bin/iwctl",
+    "firewall-cmd": "/usr/bin/firewall-cmd",
+    "ufw": "/usr/sbin/ufw",
+    "nft": "/usr/sbin/nft",
+    "iptables": "/usr/sbin/iptables",
+}
+
+EXPECTED_COMMANDS = [
+    ("/usr/sbin/iw", "dev"),
+    ("/usr/sbin/iw", "phy", "phy0", "info"),
+    ("/usr/sbin/iw", "phy", "phy1", "info"),
+    ("/usr/sbin/iw", "reg", "get"),
+    ("/usr/sbin/ip", "route", "show", "default"),
+    ("/usr/bin/nmcli", "-t", "-f", "RUNNING", "g"),
+    ("/usr/bin/systemctl", "is-active", "NetworkManager"),
+    ("/usr/bin/systemctl", "is-active", "iwd"),
+    ("/usr/bin/firewall-cmd", "--state"),
+    ("/usr/bin/systemctl", "is-active", "firewalld"),
+    ("/usr/sbin/ufw", "status"),
+    ("/usr/bin/systemctl", "is-active", "ufw"),
+    ("/usr/sbin/iptables", "--version"),
+]
+
+
+class FakeClock:
+    def __init__(self):
+        self._monotonic = 100.0
+        self._utc = datetime(2026, 7, 21, 16, 0, tzinfo=timezone.utc)
+
+    def monotonic(self):
+        value = self._monotonic
+        self._monotonic += 0.001
+        return value
+
+    def utc_now(self):
+        value = self._utc
+        self._utc += timedelta(seconds=1)
+        return value
+
+
+class FakeRunner:
+    def __init__(self, responses):
+        self.responses = dict(responses)
+        self.calls = []
+
+    def __call__(self, argv, **kwargs):
+        key = tuple(argv)
+        self.calls.append((key, dict(kwargs)))
+        response = self.responses[key]
+        if isinstance(response, BaseException):
+            raise response
+        returncode, stdout, stderr = response
+        return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _responses():
+    return {
+        ("/usr/sbin/iw", "dev"): (0, IW_DEV_OUTPUT, ""),
+        ("/usr/sbin/iw", "phy", "phy0", "info"): (0, IW_PHY0_OUTPUT, ""),
+        ("/usr/sbin/iw", "phy", "phy1", "info"): (0, IW_PHY1_OUTPUT, ""),
+        ("/usr/sbin/iw", "reg", "get"): (0, IW_REG_OUTPUT, ""),
+        ("/usr/sbin/ip", "route", "show", "default"): (
+            0,
+            "\n".join(
+                [
+                    "default via 192.0.2.1 dev enp4s0 proto dhcp metric 100",
+                    "default via 198.51.100.1 dev wlan0 proto dhcp metric 600",
+                ]
+            ),
+            "",
+        ),
+        ("/usr/bin/nmcli", "-t", "-f", "RUNNING", "g"): (0, "running\n", ""),
+        ("/usr/bin/systemctl", "is-active", "NetworkManager"): (0, "active\n", ""),
+        ("/usr/bin/systemctl", "is-active", "iwd"): (0, "active\n", ""),
+        ("/usr/bin/firewall-cmd", "--state"): (0, "running\n", ""),
+        ("/usr/bin/systemctl", "is-active", "firewalld"): (0, "active\n", ""),
+        ("/usr/sbin/ufw", "status"): (0, "Status: active\n", ""),
+        ("/usr/bin/systemctl", "is-active", "ufw"): (0, "active\n", ""),
+        ("/usr/sbin/iptables", "--version"): (
+            0,
+            "iptables v1.8.10 (nf_tables)\n",
+            "",
+        ),
+    }
+
+
+def _build_snapshot(*, response_overrides=None, tool_paths=None):
+    responses = _responses()
+    responses.update(response_overrides or {})
+    runner = FakeRunner(responses)
+    paths = TOOL_PATHS if tool_paths is None else tool_paths
+    sysfs_targets = {
+        "/sys/class/net/wlan0/device": "/devices/pci0000:00/0000:00:14.3",
+        "/sys/class/net/wlan1/device": (
+            "/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2:1.0"
+        ),
+    }
+    builder = HostFactsSnapshotBuilder(
+        runner=runner,
+        executable_resolver=lambda name: paths.get(name),
+        os_release_reader=lambda: {
+            "id": "ubuntu",
+            "id_like": "debian",
+            "pretty_name": "Ubuntu 24.04 LTS",
+            "version_id": "24.04",
+        },
+        sysfs_reader=lambda path: sysfs_targets.get(path),
+        clock=FakeClock(),
+        snapshot_id_factory=lambda: "snapshot-test-1",
+    )
+    return builder.build(operation_kind="unit-test"), runner
+
+
+def _firewall_backend(snapshot, name):
+    return next(item for item in snapshot.firewall.backends if item.name == name)
+
+
+def _probe_record(snapshot, probe_id):
+    return next(item for item in snapshot.probe_records if item.probe_id == probe_id)
+
+
+def _probe_error(snapshot, probe_id, kind):
+    return next(
+        item
+        for item in snapshot.probe_errors
+        if item.probe_id == probe_id and item.kind == kind
+    )
+
+
+def test_builder_collects_serializable_immutable_snapshot_with_fake_runner():
+    snapshot, runner = _build_snapshot()
+
+    assert snapshot.schema_version == 1
+    assert snapshot.metadata.snapshot_id == "snapshot-test-1"
+    assert snapshot.metadata.operation_kind == "unit-test"
+    assert snapshot.metadata.source == "host_facts_builder"
+    assert snapshot.metadata.started_at_utc == "2026-07-21T16:00:00.000Z"
+    assert snapshot.metadata.completed_at_utc == "2026-07-21T16:00:01.000Z"
+    assert snapshot.metadata.monotonic_duration_ms > 0
+
+    assert snapshot.platform.os_id == "ubuntu"
+    assert snapshot.platform.family == "debian"
+    assert snapshot.platform.package_manager_family == "apt"
+    assert snapshot.platform.host_kind == "mutable_linux"
+    assert snapshot.platform.is_immutable is False
+
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+    assert [item.interface for item in snapshot.default_uplink.routes] == [
+        "enp4s0",
+        "wlan0",
+    ]
+    assert [(item.ifname, item.phy, item.ssid_present) for item in snapshot.iw_dev.interfaces] == [
+        ("wlan0", "phy0", True),
+        ("wlan1", "phy1", False),
+    ]
+
+    phys = {item.phy: item for item in snapshot.iw_phys}
+    assert phys["phy0"].supports_2ghz is True
+    assert phys["phy1"].supports_ap is True
+    assert phys["phy1"].supports_5ghz is True
+    assert phys["phy1"].supports_80mhz is True
+    assert phys["phy1"].supports_wifi6 is True
+    assert phys["phy1"].supports_ap_managed_concurrency is True
+
+    assert snapshot.regulatory.global_country == "US"
+    assert {item.phy: item.country for item in snapshot.regulatory.phys} == {
+        "phy0": "US",
+        "phy1": "CA",
+    }
+    assert snapshot.network_manager.nmcli_running is True
+    assert snapshot.network_manager.service_active is True
+    assert snapshot.iwd.service_active is True
+    assert snapshot.iwd.associated_interfaces == ("wlan0",)
+    assert snapshot.firewall.selected_backend == "firewalld"
+    assert snapshot.firewall.rationale == "firewalld_running"
+
+    adapters = {item.ifname: item for item in snapshot.adapters}
+    assert adapters["wlan0"].bus == "pci"
+    assert adapters["wlan1"].bus == "usb"
+    assert adapters["wlan1"].regulatory_country == "CA"
+    assert snapshot.probe_errors == ()
+
+    serialized = snapshot.to_dict()
+    encoded = json.dumps(serialized, sort_keys=True)
+    assert serialized["schema_version"] == 1
+    assert "Upstream Network Must Stay Private" not in encoded
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.schema_version = 2
+    with pytest.raises(FrozenInstanceError):
+        snapshot.metadata.operation_kind = "changed"
+    assert isinstance(snapshot.adapters, tuple)
+
+    assert [argv for argv, _kwargs in runner.calls] == EXPECTED_COMMANDS
+    for _argv, kwargs in runner.calls:
+        assert kwargs["text"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["timeout"] > 0
+        assert "shell" not in kwargs
+
+
+def test_partial_command_failures_remain_data_and_keep_successful_siblings():
+    phy1_command = ("/usr/sbin/iw", "phy", "phy1", "info")
+    ufw_command = ("/usr/sbin/ufw", "status")
+    iwd_service = ("/usr/bin/systemctl", "is-active", "iwd")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={
+            phy1_command: subprocess.TimeoutExpired(
+                cmd=list(phy1_command),
+                timeout=4.0,
+                output="partial wireless output",
+            ),
+            ufw_command: PermissionError("permission denied by fake runner"),
+            iwd_service: (3, "inactive\n", ""),
+        }
+    )
+
+    errors = {(item.probe_id, item.kind) for item in snapshot.probe_errors}
+    assert ("iw.phy.phy1", "timeout") in errors
+    assert ("firewall.ufw.functional", "permission") in errors
+    assert ("iwd.service", "nonzero") in errors
+
+    phys = {item.phy: item for item in snapshot.iw_phys}
+    assert phys["phy0"].supports_2ghz is True
+    assert phys["phy1"].supports_ap is None
+    assert phys["phy1"].frequencies == ()
+    assert snapshot.iwd.service_state is None
+    assert snapshot.iwd.service_active is None
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+    records = {item.probe_id: item for item in snapshot.probe_records}
+    assert records["iw.phy.phy1"].timed_out is True
+    assert records["firewall.ufw.functional"].permission_denied is True
+
+
+def test_systemctl_nonzero_exit_does_not_produce_a_confident_service_status():
+    probe_id = "network_manager.service"
+    command = ("/usr/bin/systemctl", "is-active", "NetworkManager")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={command: (3, "inactive\n", "unit is not active\n")}
+    )
+
+    assert snapshot.network_manager.service_state is None
+    assert snapshot.network_manager.service_active is None
+    assert snapshot.network_manager.nmcli_running is True
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+    error = _probe_error(snapshot, probe_id, "nonzero")
+    record = _probe_record(snapshot, probe_id)
+    assert error.exit_status == 3
+    assert record.exit_status == 3
+    assert record.timed_out is False
+
+
+@pytest.mark.parametrize(
+    "malformed_output",
+    (
+        "inactive\n",
+        "active\nunexpected diagnostic\n",
+        "Failed to connect to bus: malformed fake response\n",
+    ),
+)
+def test_systemctl_malformed_output_keeps_service_status_indeterminate(
+    malformed_output,
+):
+    probe_id = "iwd.service"
+    command = ("/usr/bin/systemctl", "is-active", "iwd")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={command: (0, malformed_output, "")}
+    )
+
+    assert snapshot.iwd.service_state is None
+    assert snapshot.iwd.service_active is None
+    assert snapshot.network_manager.service_active is True
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+    error = _probe_error(snapshot, probe_id, "parse")
+    record = _probe_record(snapshot, probe_id)
+    assert error.exit_status == 0
+    assert record.exit_status == 0
+
+
+def test_missing_systemctl_is_a_probe_error_and_all_service_statuses_are_unknown():
+    tool_paths = dict(TOOL_PATHS)
+    tool_paths.pop("systemctl")
+    snapshot, runner = _build_snapshot(tool_paths=tool_paths)
+
+    assert snapshot.network_manager.service_state is None
+    assert snapshot.network_manager.service_active is None
+    assert snapshot.iwd.service_state is None
+    assert snapshot.iwd.service_active is None
+    assert all(
+        backend.service_state is None and backend.service_active is None
+        for backend in snapshot.firewall.backends
+    )
+    assert snapshot.network_manager.nmcli_running is True
+    assert _firewall_backend(snapshot, "firewalld").functional_active is True
+
+    service_probe_ids = {
+        "network_manager.service",
+        "iwd.service",
+        "firewall.firewalld.service",
+        "firewall.ufw.service",
+    }
+    errors = {(item.probe_id, item.kind) for item in snapshot.probe_errors}
+    assert {(probe_id, "missing") for probe_id in service_probe_ids} <= errors
+    assert all(_probe_record(snapshot, probe_id).missing for probe_id in service_probe_ids)
+    assert all("systemctl" not in command[0] for command, _kwargs in runner.calls)
+
+
+def test_firewall_cmd_nonzero_exit_does_not_produce_a_confident_functional_status():
+    probe_id = "firewall.firewalld.functional"
+    command = ("/usr/bin/firewall-cmd", "--state")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={
+            command: (2, "running\n", "failed fake firewalld status probe\n")
+        }
+    )
+
+    firewalld = _firewall_backend(snapshot, "firewalld")
+    ufw = _firewall_backend(snapshot, "ufw")
+    assert firewalld.tool_present is True
+    assert firewalld.functional_active is None
+    assert firewalld.service_active is True
+    assert ufw.functional_active is True
+    assert snapshot.firewall.selected_backend == "ufw"
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+    error = _probe_error(snapshot, probe_id, "nonzero")
+    record = _probe_record(snapshot, probe_id)
+    assert error.exit_status == 2
+    assert record.exit_status == 2
+
+
+def test_firewall_cmd_malformed_output_keeps_functional_status_indeterminate():
+    probe_id = "firewall.firewalld.functional"
+    command = ("/usr/bin/firewall-cmd", "--state")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={command: (0, "running\nunexpected diagnostic\n", "")}
+    )
+
+    firewalld = _firewall_backend(snapshot, "firewalld")
+    assert firewalld.functional_active is None
+    assert firewalld.service_active is True
+    assert _firewall_backend(snapshot, "ufw").functional_active is True
+    assert snapshot.firewall.selected_backend == "ufw"
+    assert snapshot.network_manager.nmcli_running is True
+
+    error = _probe_error(snapshot, probe_id, "parse")
+    record = _probe_record(snapshot, probe_id)
+    assert error.exit_status == 0
+    assert record.exit_status == 0
+
+
+def test_missing_firewall_cmd_is_a_probe_error_and_functional_status_is_unknown():
+    tool_paths = dict(TOOL_PATHS)
+    tool_paths.pop("firewall-cmd")
+    probe_id = "firewall.firewalld.functional"
+    snapshot, runner = _build_snapshot(tool_paths=tool_paths)
+
+    firewalld = _firewall_backend(snapshot, "firewalld")
+    assert firewalld.tool_present is False
+    assert firewalld.functional_active is None
+    assert firewalld.service_active is True
+    assert _probe_error(snapshot, probe_id, "missing").exit_status is None
+    record = _probe_record(snapshot, probe_id)
+    assert record.missing is True
+    assert record.exit_status is None
+    assert all("firewall-cmd" not in command[0] for command, _kwargs in runner.calls)
+
+
+def test_timeout_partial_status_output_is_not_promoted_to_service_or_firewall_facts():
+    iwd_command = ("/usr/bin/systemctl", "is-active", "iwd")
+    firewalld_command = ("/usr/bin/firewall-cmd", "--state")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={
+            iwd_command: subprocess.TimeoutExpired(
+                cmd=list(iwd_command),
+                timeout=1.0,
+                output="active\n",
+            ),
+            firewalld_command: subprocess.TimeoutExpired(
+                cmd=list(firewalld_command),
+                timeout=1.0,
+                output="running\n",
+            ),
+        }
+    )
+
+    assert snapshot.iwd.service_state is None
+    assert snapshot.iwd.service_active is None
+    assert _firewall_backend(snapshot, "firewalld").functional_active is None
+    assert snapshot.network_manager.service_active is True
+    assert _firewall_backend(snapshot, "ufw").functional_active is True
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+    for probe_id in ("iwd.service", "firewall.firewalld.functional"):
+        assert _probe_error(snapshot, probe_id, "timeout").exit_status == 124
+        assert _probe_record(snapshot, probe_id).timed_out is True
+
+
+def test_failed_status_probe_evidence_is_bounded_and_sanitized():
+    probe_id = "firewall.firewalld.functional"
+    command = ("/usr/bin/firewall-cmd", "--state")
+    unsafe_message = "fake permission denied\x00\n\t" + ("x" * 500)
+    snapshot, _runner = _build_snapshot(
+        response_overrides={command: PermissionError(unsafe_message)}
+    )
+
+    assert _firewall_backend(snapshot, "firewalld").functional_active is None
+    assert snapshot.network_manager.nmcli_running is True
+
+    error = _probe_error(snapshot, probe_id, "permission")
+    record = _probe_record(snapshot, probe_id)
+    assert 0 < len(error.message) <= MAX_ERROR_MESSAGE_CHARS
+    assert "\x00" not in error.message
+    assert "\n" not in error.message
+    assert "\t" not in error.message
+    assert record.permission_denied is True
+    assert record.source == command
+    assert all(len(item) <= 512 for item in record.source)
+
+
+def test_missing_tools_are_probe_errors_and_never_call_the_runner():
+    snapshot, runner = _build_snapshot(tool_paths={})
+
+    assert runner.calls == []
+    assert snapshot.iw_dev.interfaces == ()
+    assert snapshot.iw_phys == ()
+    assert snapshot.default_uplink.selected_interface is None
+    assert snapshot.network_manager.nmcli_running is None
+    assert snapshot.iwd.service_active is None
+    assert snapshot.firewall.selected_backend == "unknown"
+
+    errors = {(item.probe_id, item.kind) for item in snapshot.probe_errors}
+    assert ("iw.dev", "missing") in errors
+    assert ("iw.regulatory", "missing") in errors
+    assert ("network.default_uplink", "missing") in errors
+    assert ("network_manager.nmcli", "missing") in errors
+    assert ("network_manager.service", "missing") in errors
+    assert ("iwd.service", "missing") in errors
+    assert ("firewall.firewalld.functional", "missing") in errors
+    assert ("firewall.ufw.functional", "missing") in errors
+    assert ("firewall.iptables.version", "missing") in errors
+    assert all(item.missing for item in snapshot.probe_records if item.probe_id in {
+        "iw.dev",
+        "iw.regulatory",
+        "network.default_uplink",
+    })
+
+
+def test_malformed_and_truncated_inputs_are_explicit_probe_errors():
+    phy0_command = ("/usr/sbin/iw", "phy", "phy0", "info")
+    reg_command = ("/usr/sbin/iw", "reg", "get")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={
+            phy0_command: (
+                0,
+                IW_PHY0_OUTPUT + ("x" * (MAX_CAPTURE_CHARS + 128)),
+                "",
+            ),
+            reg_command: (0, "localized or malformed regulatory output\n", ""),
+        }
+    )
+
+    errors = {(item.probe_id, item.kind) for item in snapshot.probe_errors}
+    assert ("iw.phy.phy0", "truncated") in errors
+    assert ("iw.regulatory", "parse") in errors
+
+    records = {item.probe_id: item for item in snapshot.probe_records}
+    assert records["iw.phy.phy0"].output_truncated is True
+    assert snapshot.regulatory.global_country is None
+    assert {item.phy for item in snapshot.iw_phys} == {"phy0", "phy1"}
+    assert snapshot.default_uplink.selected_interface == "enp4s0"
+
+
+def test_malformed_phy_output_produces_unknown_capabilities_not_false_facts():
+    phy1_command = ("/usr/sbin/iw", "phy", "phy1", "info")
+    snapshot, _runner = _build_snapshot(
+        response_overrides={phy1_command: (0, "malformed phy output\n", "")}
+    )
+
+    phy1 = next(item for item in snapshot.iw_phys if item.phy == "phy1")
+    assert phy1.supports_ap is None
+    assert phy1.supports_2ghz is None
+    assert phy1.supports_5ghz is None
+    assert phy1.supports_6ghz is None
+    assert phy1.supports_80mhz is None
+    assert phy1.supports_wifi6 is None
+    assert phy1.frequencies == ()
+    assert ("iw.phy.phy1", "parse") in {
+        (item.probe_id, item.kind) for item in snapshot.probe_errors
+    }

--- a/tests/test_host_facts_parsers.py
+++ b/tests/test_host_facts_parsers.py
@@ -1,0 +1,144 @@
+from vr_hotspotd import host_probes
+
+
+def test_parse_iw_dev_facts_keeps_type_and_association_without_ssid_value():
+    output = """
+phy#1
+    Interface wlan1
+        ifindex 8
+        type managed
+        ssid Private Upstream Name
+    Interface p2p-dev-wlan1
+        type P2P-device
+phy#0
+    Interface wlan0
+        type AP
+"""
+
+    facts = host_probes.parse_iw_dev_facts(output)
+
+    assert facts == [
+        {
+            "ifname": "wlan1",
+            "phy": "phy1",
+            "interface_type": "managed",
+            "ssid_present": True,
+        },
+        {
+            "ifname": "p2p-dev-wlan1",
+            "phy": "phy1",
+            "interface_type": "P2P-device",
+            "ssid_present": False,
+        },
+        {
+            "ifname": "wlan0",
+            "phy": "phy0",
+            "interface_type": "AP",
+            "ssid_present": False,
+        },
+    ]
+    assert "Private Upstream Name" not in repr(facts)
+
+
+def test_parse_iw_dev_facts_tolerates_a_malformed_phy_header():
+    assert host_probes.parse_iw_dev_facts("phy#\n  Interface wlan9\n    type managed") == [
+        {
+            "ifname": "wlan9",
+            "phy": None,
+            "interface_type": "managed",
+            "ssid_present": False,
+        }
+    ]
+
+
+def test_snapshot_mode_parser_keeps_ap_evidence_from_later_mode_blocks():
+    output = """
+Supported interface modes:
+    * managed
+Band 1:
+Supported interface modes:
+    * AP
+    * AP/VLAN
+"""
+
+    assert host_probes.parse_all_supported_interface_modes(output) == [
+        "managed",
+        "AP",
+        "AP/VLAN",
+    ]
+
+
+def test_parse_iw_frequencies_keeps_curated_band_and_restriction_facts():
+    output = """
+Band 1:
+    Frequencies:
+        * 2412.0 MHz [1] (22.0 dBm)
+Band 2:
+    Frequencies:
+        * 5180 MHz [36] (23.0 dBm)
+        * 5260 MHz [52] (20.0 dBm) (no IR, radar detection)
+Band 3:
+    Frequencies:
+        * 5955.0 MHz [1] (disabled)
+"""
+
+    assert host_probes.parse_iw_frequencies(output) == [
+        {
+            "frequency_mhz": 2412,
+            "channel": 1,
+            "band": "2.4ghz",
+            "disabled": False,
+            "no_ir": False,
+            "dfs": False,
+        },
+        {
+            "frequency_mhz": 5180,
+            "channel": 36,
+            "band": "5ghz",
+            "disabled": False,
+            "no_ir": False,
+            "dfs": False,
+        },
+        {
+            "frequency_mhz": 5260,
+            "channel": 52,
+            "band": "5ghz",
+            "disabled": False,
+            "no_ir": True,
+            "dfs": True,
+        },
+        {
+            "frequency_mhz": 5955,
+            "channel": 1,
+            "band": "6ghz",
+            "disabled": True,
+            "no_ir": False,
+            "dfs": False,
+        },
+    ]
+
+
+def test_parse_default_routes_preserves_command_order_without_selecting_policy():
+    output = "\n".join(
+        [
+            "default via 192.0.2.1 dev enp4s0 proto dhcp metric 100",
+            "default via 198.51.100.1 dev wlan0 proto dhcp metric 600",
+            "unreachable 203.0.113.0/24 metric 4278198272",
+        ]
+    )
+
+    assert host_probes.parse_default_routes(output) == [
+        {
+            "interface": "enp4s0",
+            "gateway": "192.0.2.1",
+            "metric": 100,
+            "protocol": "dhcp",
+        },
+        {
+            "interface": "wlan0",
+            "gateway": "198.51.100.1",
+            "metric": 600,
+            "protocol": "dhcp",
+        },
+    ]
+    assert host_probes.parse_default_uplink(output) == "enp4s0"


### PR DESCRIPTION
Introduces HostFactsSnapshot PR 1: an unused immutable host-facts snapshot model and read-only builder foundation.

What changed:
- Adds `backend/vr_hotspotd/host_facts.py`.
- Adds `backend/vr_hotspotd/host_facts_builder.py`.
- Adds parser and builder tests.
- Adds conservative parser reuse in `host_probes.py` without runtime behavior change.

Snapshot fields:
- `schema_version`
- `metadata`
- `platform`
- `default_uplink`
- `iw_dev`
- `iw_phys`
- `regulatory`
- `network_manager`
- `iwd`
- `firewall`
- `adapters`
- `probe_records`
- `probe_errors`

Safety:
- Foundation only; no runtime consumers yet.
- Lifecycle does not consume the snapshot.
- Preflight does not consume the snapshot.
- Adapter inventory/readiness/scoring/recommendation does not consume the snapshot.
- API routes and response shapes are unchanged.
- UI is unchanged.
- Installer/uninstaller behavior is unchanged.
- Firewall mutation and engine behavior are unchanged.
- Support bundle behavior is unchanged.
- Auth/token behavior is unchanged.
- Snapshot collection is read-only.
- No `shell=True`.
- Command execution is injectable/fakeable.
- Probe failures are represented as data.
- Failed/malformed `systemctl` and `firewall-cmd` results stay unknown/indeterminate rather than becoming misleading status facts.

Tests:
- Covers immutable model behavior.
- Covers serialization via `to_dict()`.
- Covers fake-runner snapshot building.
- Covers missing tools, timeouts, permission failures, nonzero exits, malformed output, and truncated output.
- Covers partial failures preserving successful facts.
- Tests avoid real host/networking commands.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `564 passed, 4 subtests passed`