### PR TITLE
feat: use host facts snapshot in preflight

### DIFF
--- a/backend/vr_hotspotd/diagnostics/preflight_report.py
+++ b/backend/vr_hotspotd/diagnostics/preflight_report.py
@@ -6,19 +6,19 @@ so CLI, HTTP, support-bundle, and future UI callers can share one contract.
 
 from __future__ import annotations
 
+import copy
 import os
 import re
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from vr_hotspotd import host_probes, preflight
-from vr_hotspotd.adapters.inventory import (
-    get_adapters,
-    probe_ap_managed_concurrency,
-)
+from vr_hotspotd.adapters.inventory import get_adapters, probe_ap_managed_concurrency
 from vr_hotspotd.adapters.readiness import build_readiness_model
 from vr_hotspotd.config import DEFAULT_CONFIG
 from vr_hotspotd.diagnostics.platform import collect_platform_matrix
 from vr_hotspotd.engine import supervisor
+from vr_hotspotd.host_facts import HostFactsSnapshot, ProbeError
+from vr_hotspotd.host_facts_builder import build_host_facts_snapshot
 from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
 from vr_hotspotd.vendor_paths import vendor_bin_dirs
 
@@ -272,6 +272,257 @@ def _normalize_probe_failures(value: Any) -> List[Dict[str, str]]:
     return failures
 
 
+def _unique_probe_failures(value: Any) -> List[Dict[str, str]]:
+    failures: List[Dict[str, str]] = []
+    seen = set()
+    for failure in _normalize_probe_failures(value):
+        key = (failure["probe"], failure["error"])
+        if key in seen:
+            continue
+        seen.add(key)
+        failures.append(failure)
+    return failures
+
+
+def _snapshot_probe_failure(error: ProbeError) -> Dict[str, str]:
+    return {
+        "probe": error.probe_id,
+        "error": f"{error.kind}: {error.message}",
+    }
+
+
+def _snapshot_probe_failures(snapshot: HostFactsSnapshot) -> List[Dict[str, str]]:
+    return [_snapshot_probe_failure(error) for error in snapshot.probe_errors]
+
+
+def _snapshot_warning_failures(snapshot: HostFactsSnapshot) -> List[Dict[str, str]]:
+    """Return failures that need a report warning in addition to evidence.
+
+    Missing optional tools and inactive service units are compatibility facts,
+    not by themselves reasons to downgrade a report.  They remain visible in
+    evidence.  Other failures can make a consumed fact indeterminate and keep
+    preflight from reporting a confident pass.
+    """
+
+    return [
+        _snapshot_probe_failure(error)
+        for error in snapshot.probe_errors
+        if error.kind != "missing" and not error.probe_id.endswith(".service")
+    ]
+
+
+def _snapshot_immutability_signal(snapshot: HostFactsSnapshot) -> str:
+    for signal in snapshot.platform.immutability_signals:
+        prefix, separator, value = signal.partition(":")
+        if separator and prefix == "tool" and value:
+            return value
+    return "unknown"
+
+
+def _snapshot_firewall_backends(snapshot: HostFactsSnapshot) -> Dict[str, Any]:
+    by_name = {item.name: item for item in snapshot.firewall.backends}
+
+    def backend(name: str) -> Any:
+        return by_name.get(name)
+
+    firewalld = backend("firewalld")
+    ufw = backend("ufw")
+    nftables = backend("nftables")
+    iptables = backend("iptables")
+    return {
+        "firewalld": {
+            "available": bool(firewalld and firewalld.tool_present),
+            "active": bool(
+                firewalld and firewalld.functional_active is True
+            ),
+        },
+        "ufw": {
+            "available": bool(ufw and ufw.tool_present),
+            "active": bool(ufw and ufw.functional_active is True),
+        },
+        "nftables": {
+            "available": bool(nftables and nftables.tool_present),
+        },
+        "iptables": {
+            "available": bool(iptables and iptables.tool_present),
+            "variant": iptables.variant if iptables is not None else None,
+        },
+        "selected_backend": snapshot.firewall.selected_backend,
+        "rationale": snapshot.firewall.rationale,
+    }
+
+
+def _snapshot_network_manager(snapshot: HostFactsSnapshot) -> Dict[str, Any]:
+    facts = snapshot.network_manager
+    present = bool(
+        facts.binary_present or facts.nmcli_present or facts.service_active is True
+    )
+    active = bool(facts.nmcli_running is True or facts.service_active is True)
+    return {
+        "present": present,
+        "active": active,
+        "running": facts.nmcli_running,
+        "status": facts.service_state or "unknown",
+        "nmcli": facts.nmcli_present,
+    }
+
+
+def _snapshot_iwd(snapshot: HostFactsSnapshot) -> Dict[str, Any]:
+    facts = snapshot.iwd
+    present = bool(
+        facts.binary_present or facts.iwctl_present or facts.service_active is True
+    )
+    active = facts.service_active is True
+    if not present:
+        status = "not_installed"
+    elif active:
+        status = "active"
+    else:
+        status = facts.service_state or "unknown"
+    return {
+        "present": present,
+        "active": active,
+        "status": status,
+        "iwctl": facts.iwctl_present,
+    }
+
+
+def _snapshot_platform_matrix(
+    snapshot: HostFactsSnapshot,
+    existing: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Overlay snapshot-owned facts while retaining non-snapshot debug fields."""
+
+    platform = copy.deepcopy(_as_dict(existing))
+    os_data = _as_dict(platform.get("os"))
+    os_data.update(
+        {
+            "pretty_name": snapshot.platform.os_name or "",
+            "id": snapshot.platform.os_id or "",
+            "version_id": snapshot.platform.version_id or "",
+            "variant_id": snapshot.platform.variant_id or "",
+            "id_like": list(snapshot.platform.id_like),
+        }
+    )
+    platform["os"] = os_data
+
+    immutability = _as_dict(platform.get("immutability"))
+    immutability.update(
+        {
+            "is_immutable": snapshot.platform.is_immutable is True,
+            "signal": _snapshot_immutability_signal(snapshot),
+        }
+    )
+    immutability.setdefault("writable_paths", {})
+    platform["immutability"] = immutability
+
+    integration = _as_dict(platform.get("integration"))
+    network_manager = _snapshot_network_manager(snapshot)
+    integration["network_manager"] = {
+        "present": network_manager["present"],
+        "active": network_manager["active"],
+        "nmcli": network_manager["nmcli"],
+    }
+    if "firewall" in integration:
+        firewall = _snapshot_firewall_backends(snapshot)
+        integration["firewall"] = {
+            "firewalld": {
+                "present": firewall["firewalld"]["available"],
+                "active": firewall["firewalld"]["active"],
+            },
+            "ufw": {
+                "present": firewall["ufw"]["available"],
+                "active": firewall["ufw"]["active"],
+            },
+            "nft": {"present": firewall["nftables"]["available"]},
+            "iptables": {"present": firewall["iptables"]["available"]},
+        }
+    platform["integration"] = integration
+    return platform
+
+
+def _snapshot_inventory(
+    snapshot: HostFactsSnapshot,
+    inventory: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Use snapshot facts without moving inventory scoring or selection policy."""
+
+    projected = copy.deepcopy(_as_dict(inventory))
+    facts_by_ifname = {item.ifname: item for item in snapshot.adapters}
+    regulatory_by_phy = {item.phy: item for item in snapshot.regulatory.phys}
+    adapters: List[Dict[str, Any]] = []
+    for raw_item in _as_list(projected.get("adapters")):
+        item = _as_dict(raw_item)
+        ifname = str(
+            item.get("ifname") or item.get("interface") or item.get("id") or ""
+        )
+        facts = facts_by_ifname.get(ifname)
+        if facts is None:
+            item.update(
+                {
+                    "phy": None,
+                    "bus": "unknown",
+                    "supports_ap": None,
+                    "supports_2ghz": None,
+                    "supports_5ghz": None,
+                    "supports_6ghz": None,
+                    "supports_80mhz": None,
+                    "supports_wifi6": None,
+                    "regdom": {
+                        "country": "unknown",
+                        "source": "unknown",
+                        "global_country": snapshot.regulatory.global_country
+                        or "unknown",
+                        "raw_phy": None,
+                        "raw_global": snapshot.regulatory.global_raw_header,
+                    },
+                }
+            )
+        else:
+            phy_regulatory = regulatory_by_phy.get(facts.phy or "")
+            item.update(
+                {
+                    "phy": facts.phy,
+                    "bus": facts.bus,
+                    "supports_ap": facts.supports_ap,
+                    "supports_2ghz": facts.supports_2ghz,
+                    "supports_5ghz": facts.supports_5ghz,
+                    "supports_6ghz": facts.supports_6ghz,
+                    "supports_80mhz": facts.supports_80mhz,
+                    "supports_wifi6": facts.supports_wifi6,
+                    "regdom": {
+                        "country": facts.regulatory_country or "unknown",
+                        "source": facts.regulatory_source or "unknown",
+                        "global_country": snapshot.regulatory.global_country
+                        or "unknown",
+                        "raw_phy": (
+                            phy_regulatory.raw_header
+                            if phy_regulatory is not None
+                            else None
+                        ),
+                        "raw_global": snapshot.regulatory.global_raw_header,
+                    },
+                }
+            )
+        adapters.append(item)
+
+    projected["adapters"] = adapters
+    projected["global_regdom"] = {
+        "country": snapshot.regulatory.global_country or "unknown",
+        "raw": snapshot.regulatory.global_raw_header,
+    }
+    if any(error.probe_id == "iw.dev" for error in snapshot.probe_errors):
+        projected.setdefault("error", "snapshot_iw_dev_unavailable")
+    return projected
+
+
+def _snapshot_concurrency(snapshot: HostFactsSnapshot) -> Dict[str, Optional[bool]]:
+    return {
+        item.phy: item.supports_ap_managed_concurrency
+        for item in snapshot.iw_phys
+    }
+
+
 def build_preflight_report(
     *,
     platform_matrix: Mapping[str, Any],
@@ -286,6 +537,7 @@ def build_preflight_report(
     existing_preflight: Optional[Mapping[str, Any]] = None,
     config: Optional[Mapping[str, Any]] = None,
     probe_failures: Optional[List[Mapping[str, Any]]] = None,
+    evidence_probe_failures: Optional[List[Mapping[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Build the v1 report from already-collected probe results only."""
 
@@ -410,7 +662,13 @@ def build_preflight_report(
     hostapd = _binary_view(_as_dict(binaries).get("hostapd"))
     dnsmasq = _binary_view(_as_dict(binaries).get("dnsmasq"))
     existing = _as_dict(existing_preflight)
-    failures = _normalize_probe_failures(probe_failures)
+    warning_failures = _normalize_probe_failures(probe_failures)
+    if evidence_probe_failures is None:
+        failures = warning_failures
+    else:
+        failures = _unique_probe_failures(
+            [*warning_failures, *_as_list(evidence_probe_failures)]
+        )
 
     issues: List[Dict[str, Any]] = []
     actions: List[Dict[str, str]] = []
@@ -449,7 +707,7 @@ def build_preflight_report(
             seen_actions.add(stable_code)
             actions.append({"code": stable_code, "message": action_message})
 
-    for failure in failures:
+    for failure in warning_failures:
         add_issue(
             "probe_unavailable",
             "warning",
@@ -735,38 +993,81 @@ def _safe_collect(
 
 def collect_preflight_report(
     config: Optional[Mapping[str, Any]] = None,
+    *,
+    host_facts_snapshot: Optional[HostFactsSnapshot] = None,
 ) -> Dict[str, Any]:
-    """Compose the existing read-only probes into the canonical report."""
+    """Compose one host-facts snapshot and the remaining read-only probes."""
 
     cfg: Dict[str, Any] = dict(DEFAULT_CONFIG)
     if isinstance(config, Mapping):
         cfg.update(config)
 
     failures: List[Dict[str, str]] = []
-    platform_matrix = _safe_collect(
+    snapshot = host_facts_snapshot
+    if snapshot is None:
+        snapshot = _safe_collect(
+            "host_facts_snapshot",
+            lambda: build_host_facts_snapshot(
+                operation_kind="diagnostics_preflight",
+            ),
+            None,
+            failures,
+        )
+    if snapshot is not None and not isinstance(snapshot, HostFactsSnapshot):
+        failures.append(
+            {
+                "probe": "host_facts_snapshot",
+                "error": "TypeError: snapshot builder returned an unexpected value",
+            }
+        )
+        snapshot = None
+
+    platform_matrix_base = _safe_collect(
         "platform",
         collect_platform_matrix,
         {},
         failures,
     )
-    firewall = _safe_collect(
-        "firewall",
-        host_probes.probe_firewall_backends,
-        {"selected_backend": "unknown", "rationale": "probe_failed"},
-        failures,
-    )
-    network_manager = _safe_collect(
-        "network_manager",
-        host_probes.probe_network_manager,
-        {"nmcli": False, "running": False},
-        failures,
-    )
-    iwd = _safe_collect(
-        "iwd",
-        host_probes.probe_iwd,
-        {"present": False, "active": False, "status": "unknown", "iwctl": False},
-        failures,
-    )
+    if snapshot is not None:
+        platform_matrix = _snapshot_platform_matrix(
+            snapshot,
+            _as_dict(platform_matrix_base),
+        )
+        firewall = _snapshot_firewall_backends(snapshot)
+        network_manager = _snapshot_network_manager(snapshot)
+        iwd = _snapshot_iwd(snapshot)
+        active_uplink: Optional[str] = snapshot.default_uplink.selected_interface
+    else:
+        platform_matrix = _as_dict(platform_matrix_base)
+        firewall = _safe_collect(
+            "firewall",
+            host_probes.probe_firewall_backends,
+            {"selected_backend": "unknown", "rationale": "probe_failed"},
+            failures,
+        )
+        network_manager = _safe_collect(
+            "network_manager",
+            host_probes.probe_network_manager,
+            {"nmcli": False, "running": False},
+            failures,
+        )
+        iwd = _safe_collect(
+            "iwd",
+            host_probes.probe_iwd,
+            {
+                "present": False,
+                "active": False,
+                "status": "unknown",
+                "iwctl": False,
+            },
+            failures,
+        )
+        active_uplink = _safe_collect(
+            "default_uplink",
+            host_probes.probe_default_uplink,
+            None,
+            failures,
+        )
     binaries = _safe_collect(
         "runtime_binaries",
         _collect_runtime_binaries,
@@ -777,7 +1078,7 @@ def collect_preflight_report(
         },
         failures,
     )
-    inventory = _safe_collect(
+    policy_inventory = _safe_collect(
         "adapter_inventory",
         get_adapters,
         {"error": "probe_failed", "adapters": [], "recommended": None},
@@ -785,29 +1086,30 @@ def collect_preflight_report(
     )
     readiness = _safe_collect(
         "adapter_readiness",
-        lambda: build_readiness_model(_as_dict(inventory)),
+        lambda: build_readiness_model(_as_dict(policy_inventory)),
         {"adapters": [], "recommended": None, "basic_mode_recommended": None},
         failures,
     )
-    active_uplink = _safe_collect(
-        "default_uplink",
-        host_probes.probe_default_uplink,
-        None,
-        failures,
+    inventory = (
+        _snapshot_inventory(snapshot, _as_dict(policy_inventory))
+        if snapshot is not None
+        else _as_dict(policy_inventory)
     )
-
-    concurrency_by_phy: Dict[str, Optional[bool]] = {}
-    for item in _as_list(_as_dict(inventory).get("adapters")):
-        adapter = _as_dict(item)
-        phy = adapter.get("phy")
-        if not isinstance(phy, str) or not phy or phy in concurrency_by_phy:
-            continue
-        concurrency_by_phy[phy] = _safe_collect(
-            f"sta_ap_concurrency:{phy}",
-            lambda phy_name=phy: probe_ap_managed_concurrency(phy_name),
-            None,
-            failures,
-        )
+    if snapshot is not None:
+        concurrency_by_phy = _snapshot_concurrency(snapshot)
+    else:
+        concurrency_by_phy: Dict[str, Optional[bool]] = {}
+        for item in _as_list(_as_dict(inventory).get("adapters")):
+            adapter_item = _as_dict(item)
+            phy = adapter_item.get("phy")
+            if not isinstance(phy, str) or not phy or phy in concurrency_by_phy:
+                continue
+            concurrency_by_phy[phy] = _safe_collect(
+                f"sta_ap_concurrency:{phy}",
+                lambda phy_name=phy: probe_ap_managed_concurrency(phy_name),
+                None,
+                failures,
+            )
 
     report_adapter_name = _report_adapter_name(_as_dict(inventory), cfg)
     adapter = _find_adapter(_as_dict(inventory), report_adapter_name)
@@ -829,6 +1131,10 @@ def collect_preflight_report(
         failures,
     )
 
+    snapshot_failures = _snapshot_probe_failures(snapshot) if snapshot is not None else []
+    snapshot_warning_failures = (
+        _snapshot_warning_failures(snapshot) if snapshot is not None else []
+    )
     return build_preflight_report(
         platform_matrix=_as_dict(platform_matrix),
         firewall=_as_dict(firewall),
@@ -843,5 +1149,6 @@ def collect_preflight_report(
         concurrency_by_phy=concurrency_by_phy,
         existing_preflight=_as_dict(existing_preflight),
         config=cfg,
-        probe_failures=failures,
+        probe_failures=[*failures, *snapshot_warning_failures],
+        evidence_probe_failures=snapshot_failures,
     )

--- a/tests/test_preflight_report.py
+++ b/tests/test_preflight_report.py
@@ -1,9 +1,11 @@
 import json
 from collections import deque
+from dataclasses import replace
 
 import pytest
 
 from vr_hotspotd import config as config_module
+from vr_hotspotd import host_facts
 from vr_hotspotd import host_probes
 from vr_hotspotd.diagnostics import preflight_report
 from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
@@ -100,6 +102,194 @@ READINESS = {
         }
     ],
 }
+
+
+def _host_facts_snapshot():
+    return host_facts.HostFactsSnapshot(
+        schema_version=1,
+        metadata=host_facts.SnapshotMetadata(
+            snapshot_id="preflight-snapshot-1",
+            operation_kind="diagnostics_preflight",
+            source="test",
+            started_at_utc="2026-07-22T12:00:00.000Z",
+            completed_at_utc="2026-07-22T12:00:00.050Z",
+            monotonic_duration_ms=50,
+            builder_version="1",
+        ),
+        platform=host_facts.PlatformFacts(
+            os_release=(
+                host_facts.OsReleaseFact(key="id", value="ubuntu"),
+                host_facts.OsReleaseFact(key="id_like", value="debian"),
+                host_facts.OsReleaseFact(
+                    key="pretty_name",
+                    value="Ubuntu 24.04 LTS",
+                ),
+                host_facts.OsReleaseFact(key="version_id", value="24.04"),
+            ),
+            os_id="ubuntu",
+            os_name="Ubuntu 24.04 LTS",
+            version_id="24.04",
+            variant_id=None,
+            id_like=("debian",),
+            flavor="ubuntu_debian",
+            family="debian",
+            package_manager_family="apt",
+            host_kind="mutable_linux",
+            is_immutable=False,
+            immutability_signals=(),
+            source_probe_id="platform.os_release",
+        ),
+        default_uplink=host_facts.DefaultUplinkFacts(
+            selected_interface="enp4s0",
+            routes=(
+                host_facts.DefaultRouteFact(
+                    interface="enp4s0",
+                    gateway="192.0.2.1",
+                    metric=100,
+                    protocol="dhcp",
+                ),
+            ),
+            source_probe_id="network.default_uplink",
+        ),
+        iw_dev=host_facts.IwDevFacts(
+            interfaces=(
+                host_facts.IwInterfaceFacts(
+                    ifname="wlan1",
+                    phy="phy1",
+                    interface_type="managed",
+                    ssid_present=False,
+                ),
+            ),
+            source_probe_id="iw.dev",
+        ),
+        iw_phys=(
+            host_facts.IwPhyFacts(
+                phy="phy1",
+                interface_modes_known=True,
+                supported_interface_modes=("managed", "AP"),
+                supports_ap=True,
+                supports_2ghz=True,
+                supports_5ghz=True,
+                supports_6ghz=False,
+                supports_80mhz=True,
+                supports_wifi6=True,
+                supports_ap_managed_concurrency=True,
+                frequencies=(),
+                source_probe_id="iw.phy.phy1",
+            ),
+        ),
+        regulatory=host_facts.RegulatoryFacts(
+            global_country="US",
+            global_raw_header=None,
+            phys=(
+                host_facts.RegulatoryDomainFacts(
+                    phy="phy1",
+                    country="US",
+                    source="kernel-managed",
+                    raw_header=None,
+                ),
+            ),
+            source_probe_id="iw.regulatory",
+        ),
+        network_manager=host_facts.NetworkManagerFacts(
+            binary_present=True,
+            nmcli_present=True,
+            nmcli_running=True,
+            service_state="active",
+            service_active=True,
+            source_probe_ids=(
+                "network_manager.nmcli",
+                "network_manager.service",
+            ),
+        ),
+        iwd=host_facts.IwdFacts(
+            binary_present=False,
+            iwctl_present=False,
+            service_state=None,
+            service_active=None,
+            associated_interfaces=(),
+            source_probe_ids=("iwd.service", "iw.dev"),
+        ),
+        firewall=host_facts.FirewallFacts(
+            backends=(
+                host_facts.FirewallBackendFacts(
+                    name="firewalld",
+                    tool_present=False,
+                    functional_active=False,
+                    service_state=None,
+                    service_active=None,
+                    variant=None,
+                    source_probe_ids=(),
+                ),
+                host_facts.FirewallBackendFacts(
+                    name="ufw",
+                    tool_present=False,
+                    functional_active=False,
+                    service_state=None,
+                    service_active=None,
+                    variant=None,
+                    source_probe_ids=(),
+                ),
+                host_facts.FirewallBackendFacts(
+                    name="nftables",
+                    tool_present=True,
+                    functional_active=None,
+                    service_state=None,
+                    service_active=None,
+                    variant=None,
+                    source_probe_ids=(),
+                ),
+                host_facts.FirewallBackendFacts(
+                    name="iptables",
+                    tool_present=True,
+                    functional_active=None,
+                    service_state=None,
+                    service_active=None,
+                    variant="iptables-nft",
+                    source_probe_ids=("firewall.iptables.version",),
+                ),
+            ),
+            selected_backend="nftables",
+            rationale="nft_present",
+        ),
+        adapters=(
+            host_facts.AdapterFacts(
+                ifname="wlan1",
+                phy="phy1",
+                interface_type="managed",
+                associated=False,
+                bus="usb",
+                supports_ap=True,
+                supports_2ghz=True,
+                supports_5ghz=True,
+                supports_6ghz=False,
+                supports_80mhz=True,
+                supports_wifi6=True,
+                regulatory_country="US",
+                regulatory_source="kernel-managed",
+                source_probe_ids=("iw.dev", "iw.phy.phy1", "iw.regulatory"),
+            ),
+        ),
+        probe_records=(),
+        probe_errors=(),
+    )
+
+
+def _patch_snapshot_collector_dependencies(monkeypatch, *, preflight_callback=None):
+    monkeypatch.setattr(preflight_report, "collect_platform_matrix", lambda: PLATFORM)
+    monkeypatch.setattr(preflight_report, "_collect_runtime_binaries", lambda: BINARIES)
+    monkeypatch.setattr(preflight_report, "get_adapters", lambda: INVENTORY)
+    monkeypatch.setattr(
+        preflight_report,
+        "build_readiness_model",
+        lambda _inventory: READINESS,
+    )
+    monkeypatch.setattr(
+        preflight_report.preflight,
+        "run",
+        preflight_callback
+        or (lambda _config, **_kwargs: {"errors": [], "warnings": [], "details": {}}),
+    )
 
 
 def _build(**overrides):
@@ -375,6 +565,26 @@ def test_non_conflicting_uplink_does_not_trigger_role_guard(
 
 def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
     calls = []
+    snapshot = _host_facts_snapshot()
+    snapshot = replace(
+        snapshot,
+        regulatory=replace(
+            snapshot.regulatory,
+            global_country="CA",
+            phys=(
+                replace(
+                    snapshot.regulatory.phys[0],
+                    country="CA",
+                ),
+            ),
+        ),
+        adapters=(
+            replace(
+                snapshot.adapters[0],
+                regulatory_country="CA",
+            ),
+        ),
+    )
 
     monkeypatch.setattr(
         preflight_report,
@@ -382,66 +592,10 @@ def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
         lambda: calls.append("platform") or PLATFORM,
     )
     monkeypatch.setattr(
-        preflight_report.host_probes,
-        "probe_firewall_backends",
-        lambda: calls.append("firewall") or FIREWALL,
+        preflight_report,
+        "_collect_runtime_binaries",
+        lambda: calls.append("binaries") or BINARIES,
     )
-    monkeypatch.setattr(
-        preflight_report.host_probes,
-        "probe_network_manager",
-        lambda: calls.append("network_manager")
-        or {"nmcli": True, "running": True},
-    )
-    monkeypatch.setattr(
-        preflight_report.host_probes,
-        "probe_iwd",
-        lambda: calls.append("iwd")
-        or {"present": False, "active": False, "status": "not_installed"},
-    )
-    monkeypatch.setattr(
-        preflight_report.supervisor,
-        "inspect_runtime_binaries",
-        lambda: calls.append("binaries")
-        or {
-            "hostapd": "/usr/sbin/hostapd",
-            "dnsmasq": "/usr/sbin/dnsmasq",
-            "selection_error": None,
-            "probe_environment": {},
-        },
-    )
-
-    def fail_engine_env(*_args, **_kwargs):
-        raise AssertionError("diagnostics called private lifecycle engine setup")
-
-    monkeypatch.setattr(
-        preflight_report.supervisor,
-        "_build_engine_env",
-        fail_engine_env,
-    )
-    monkeypatch.setattr(
-        preflight_report.preflight,
-        "probe_hostapd_capabilities",
-        lambda _path: {
-            "sae": True,
-            "he": True,
-            "raw": "hostapd v2.11\nSAE\nIEEE 802.11ax",
-        },
-    )
-    monkeypatch.setattr(
-        preflight_report.host_probes,
-        "run_command",
-        lambda argv, **_kwargs: host_probes.CommandResult(
-            argv=tuple(argv),
-            exit_status=0,
-            stdout="Dnsmasq version 2.90\n",
-        ),
-    )
-    monkeypatch.setattr(
-        preflight_report.supervisor,
-        "_stderr_tail",
-        deque(["existing supervisor stderr"]),
-    )
-    stderr_before = preflight_report.supervisor.get_tails()[1]
     monkeypatch.setattr(
         preflight_report,
         "get_adapters",
@@ -452,22 +606,43 @@ def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
         "build_readiness_model",
         lambda inventory: calls.append(("readiness", inventory)) or READINESS,
     )
+
+    def fake_preflight(config, **kwargs):
+        calls.append(("preflight", config, kwargs))
+        assert kwargs["adapter"]["regdom"]["country"] == "CA"
+        return {"errors": [], "warnings": [], "details": {}}
+
+    monkeypatch.setattr(preflight_report.preflight, "run", fake_preflight)
+
+    def fail_snapshot_reprobe(*_args, **_kwargs):
+        raise AssertionError("collector ignored the injected host-facts snapshot")
+
+    monkeypatch.setattr(
+        preflight_report,
+        "build_host_facts_snapshot",
+        fail_snapshot_reprobe,
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_firewall_backends",
+        fail_snapshot_reprobe,
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_network_manager",
+        fail_snapshot_reprobe,
+    )
+    monkeypatch.setattr(preflight_report.host_probes, "probe_iwd", fail_snapshot_reprobe)
     monkeypatch.setattr(
         preflight_report.host_probes,
         "probe_default_uplink",
-        lambda: calls.append("uplink") or "enp4s0",
+        fail_snapshot_reprobe,
     )
     monkeypatch.setattr(
         preflight_report,
         "probe_ap_managed_concurrency",
-        lambda phy: calls.append(("concurrency", phy)) or True,
+        fail_snapshot_reprobe,
     )
-
-    def fake_preflight(config, **kwargs):
-        calls.append(("preflight", config, kwargs))
-        return {"errors": [], "warnings": [], "details": {}}
-
-    monkeypatch.setattr(preflight_report.preflight, "run", fake_preflight)
 
     report = preflight_report.collect_preflight_report(
         {
@@ -475,15 +650,235 @@ def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
             "channel_width": "80",
             "enable_internet": True,
             "wpa2_passphrase": "must-not-be-reported",
-        }
+        },
+        host_facts_snapshot=snapshot,
     )
 
     assert report["overall_readiness"] == "ready"
     assert ("readiness", INVENTORY) in calls
-    assert ("concurrency", "phy1") in calls
+    assert report["network"]["active_uplink_interface"] == "enp4s0"
+    assert report["firewall"] == {
+        "backend": "nftables",
+        "status": "available",
+        "rationale": "nft_present",
+    }
+    assert (
+        report["wifi"]["adapters"][0]["capabilities"][
+            "supports_sta_ap_concurrency"
+        ]
+        is True
+    )
     assert any(call[0] == "preflight" for call in calls if isinstance(call, tuple))
     assert "must-not-be-reported" not in json.dumps(report)
-    assert preflight_report.supervisor.get_tails()[1] == stderr_before
+
+
+def test_snapshot_backed_collector_preserves_existing_report_projection(monkeypatch):
+    snapshot = _host_facts_snapshot()
+    built_for = []
+    config = {
+        "band_preference": "5ghz",
+        "channel_width": "80",
+        "allow_fallback_40mhz": False,
+        "enable_internet": True,
+    }
+    _patch_snapshot_collector_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        preflight_report,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: built_for.append(operation_kind) or snapshot,
+    )
+
+    actual = preflight_report.collect_preflight_report(config)
+    expected = _build(config=config)
+
+    assert actual == expected
+    assert built_for == ["diagnostics_preflight"]
+
+
+def test_partial_snapshot_failure_is_visible_and_prevents_confident_pass(monkeypatch):
+    snapshot = _host_facts_snapshot()
+    firewalld = replace(
+        snapshot.firewall.backends[0],
+        tool_present=True,
+        functional_active=None,
+    )
+    snapshot = replace(
+        snapshot,
+        firewall=replace(
+            snapshot.firewall,
+            backends=(firewalld, *snapshot.firewall.backends[1:]),
+        ),
+        probe_errors=(
+            host_facts.ProbeError(
+                probe_id="firewall.firewalld.functional",
+                kind="timeout",
+                message="read-only command timed out",
+                exit_status=124,
+            ),
+        ),
+    )
+    _patch_snapshot_collector_dependencies(monkeypatch)
+
+    report = preflight_report.collect_preflight_report(
+        {"enable_internet": True},
+        host_facts_snapshot=snapshot,
+    )
+
+    assert report["overall_readiness"] == "warning"
+    assert report["firewall"]["backend"] == "nftables"
+    assert report["evidence"]["raw_probe_results"]["firewall"]["firewalld"] == {
+        "available": True,
+        "active": False,
+    }
+    failure = {
+        "probe": "firewall.firewalld.functional",
+        "error": "timeout: read-only command timed out",
+    }
+    assert failure in report["evidence"]["probe_failures"]
+    assert any(
+        issue["code"] == "probe_unavailable" and issue["context"] == failure
+        for issue in report["issues"]
+    )
+
+
+def test_unknown_snapshot_uplink_and_firewall_remain_conservative(monkeypatch):
+    snapshot = _host_facts_snapshot()
+    snapshot = replace(
+        snapshot,
+        default_uplink=replace(
+            snapshot.default_uplink,
+            selected_interface=None,
+            routes=(),
+        ),
+        firewall=replace(
+            snapshot.firewall,
+            backends=tuple(
+                replace(
+                    backend,
+                    tool_present=False,
+                    functional_active=None,
+                    variant=None,
+                )
+                for backend in snapshot.firewall.backends
+            ),
+            selected_backend="unknown",
+            rationale="no_firewall_detected",
+        ),
+        probe_errors=(
+            host_facts.ProbeError(
+                probe_id="network.default_uplink",
+                kind="missing",
+                message="required tool is unavailable: ip",
+                exit_status=None,
+            ),
+            host_facts.ProbeError(
+                probe_id="firewall.firewalld.functional",
+                kind="missing",
+                message="required tool is unavailable: firewall-cmd",
+                exit_status=None,
+            ),
+        ),
+    )
+    _patch_snapshot_collector_dependencies(monkeypatch)
+
+    report = preflight_report.collect_preflight_report(
+        {"enable_internet": True},
+        host_facts_snapshot=snapshot,
+    )
+
+    issue_codes = {item["code"] for item in report["issues"]}
+    assert report["overall_readiness"] == "warning"
+    assert report["network"]["active_uplink_interface"] is None
+    assert report["firewall"] == {
+        "backend": "unknown",
+        "status": "not_detected",
+        "rationale": "no_firewall_detected",
+    }
+    assert "default_uplink_not_detected" in issue_codes
+    assert "firewall_backend_not_detected" in issue_codes
+    assert {item["probe"] for item in report["evidence"]["probe_failures"]} == {
+        "network.default_uplink",
+        "firewall.firewalld.functional",
+    }
+
+
+@pytest.mark.parametrize("failure_mode", ("malformed_phy", "missing_iw"))
+def test_unknown_snapshot_iw_facts_never_become_confident_pass(
+    monkeypatch,
+    failure_mode,
+):
+    snapshot = _host_facts_snapshot()
+    if failure_mode == "malformed_phy":
+        unknown_phy = replace(
+            snapshot.iw_phys[0],
+            interface_modes_known=False,
+            supported_interface_modes=(),
+            supports_ap=None,
+            supports_2ghz=None,
+            supports_5ghz=None,
+            supports_6ghz=None,
+            supports_80mhz=None,
+            supports_wifi6=None,
+            supports_ap_managed_concurrency=None,
+            frequencies=(),
+        )
+        unknown_adapter = replace(
+            snapshot.adapters[0],
+            supports_ap=None,
+            supports_2ghz=None,
+            supports_5ghz=None,
+            supports_6ghz=None,
+            supports_80mhz=None,
+            supports_wifi6=None,
+        )
+        snapshot = replace(
+            snapshot,
+            iw_phys=(unknown_phy,),
+            adapters=(unknown_adapter,),
+            probe_errors=(
+                host_facts.ProbeError(
+                    probe_id="iw.phy.phy1",
+                    kind="parse",
+                    message="supported interface mode facts were not found",
+                    exit_status=0,
+                ),
+            ),
+        )
+    else:
+        snapshot = replace(
+            snapshot,
+            iw_dev=replace(snapshot.iw_dev, interfaces=()),
+            iw_phys=(),
+            adapters=(),
+            probe_errors=(
+                host_facts.ProbeError(
+                    probe_id="iw.dev",
+                    kind="missing",
+                    message="required tool is unavailable: iw",
+                    exit_status=None,
+                ),
+            ),
+        )
+    _patch_snapshot_collector_dependencies(monkeypatch)
+
+    report = preflight_report.collect_preflight_report(
+        {"enable_internet": True},
+        host_facts_snapshot=snapshot,
+    )
+
+    issue_codes = {item["code"] for item in report["issues"]}
+    selected = report["wifi"]["selected_adapter_capabilities"]
+    assert report["overall_readiness"] == "blocked"
+    assert selected["ap_mode"] is None
+    assert selected["supports_5ghz"] is None
+    assert selected["supports_80mhz"] is None
+    assert "no_ap_capable_adapter" in issue_codes
+    assert "ap_mode_unknown" in issue_codes
+    assert report["evidence"]["probe_failures"][0]["probe"].startswith("iw.")
+    if failure_mode == "missing_iw":
+        assert "adapter_inventory_unavailable" in issue_codes
+    else:
+        assert "probe_unavailable" in issue_codes
 
 
 def test_runtime_binary_probe_uses_public_read_only_inspection(monkeypatch):


### PR DESCRIPTION
Implements HostFactsSnapshot PR 2 by making diagnostics preflight consume a single operation-scoped HostFactsSnapshot while preserving the existing `/v1/diagnostics/preflight` response shape.

What changed:
- Preflight now builds or accepts an injected HostFactsSnapshot.
- Preflight consumes snapshot-backed platform, firewall, NetworkManager/iwd, uplink, regulatory, adapter-capability, and concurrency facts.
- Existing inventory/readiness scoring and recommendation policy are retained.
- Snapshot probe failures are surfaced conservatively in `evidence.probe_failures`.
- Unknown or partial facts remain conservative instead of becoming confident pass results.

Compatibility:
- `/v1/diagnostics/preflight` route unchanged.
- API auth behavior unchanged.
- Response keys unchanged.
- Schema version unchanged.
- Issue codes, severities, context fields, actions, evidence layout, and result-code behavior preserved.
- Known-good legacy and snapshot-backed reports compare exactly equal in tests.

Safety:
- Preflight only.
- No lifecycle migration.
- No active-uplink lifecycle guard change.
- No adapter inventory/readiness/scoring/recommendation behavior change.
- No API route or UI change.
- No installer/uninstaller change.
- No firewall mutation or engine behavior change.
- No support-bundle, auth/token, or CLI behavior change.
- Snapshot collection remains read-only.
- No `shell=True`.
- Tests avoid real host/networking commands.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `569 passed, 4 subtests passed`