### PR TITLE
feat: use host facts snapshot in lifecycle

### DIFF
--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -26,6 +26,8 @@ from vr_hotspotd.engine.hostapd_bridge_cmd import build_cmd_bridge
 from vr_hotspotd.engine.supervisor import start_engine, stop_engine, is_running, get_tails
 from vr_hotspotd.engine.channel_scan import select_best_channel
 from vr_hotspotd.engine.tx_power import auto_adjust_tx_power, set_tx_power, get_tx_power
+from vr_hotspotd.host_facts import HostFactsSnapshot
+from vr_hotspotd.host_facts_builder import build_host_facts_snapshot
 from vr_hotspotd import (
     host_probes,
     network_tuning,
@@ -204,6 +206,7 @@ _COUNTRY_CODE_RE = re.compile(r"^[A-Z]{2}$")
 _CMD_TIMEOUT_S = 2.5
 _NM_IWD_CONF_DIR = Path("/etc/NetworkManager/conf.d")
 _IWD_ASSOCIATION_ERROR = "ap_adapter_still_associated_iwd_autoconnect"
+_DEFAULT_UPLINK_UNKNOWN_ERROR = "default_uplink_unknown"
 
 
 def ensure_hostapd_ctrl_interface_dir(conf_path: str) -> None:
@@ -1077,6 +1080,53 @@ def _prepare_ap_interface(
     return warnings
 
 
+def _snapshot_default_uplink_is_known(snapshot: HostFactsSnapshot) -> bool:
+    """Return whether the snapshot conclusively identified or ruled out an uplink."""
+
+    facts = snapshot.default_uplink
+    probe_id = facts.source_probe_id
+    if any(error.probe_id == probe_id for error in snapshot.probe_errors):
+        return False
+    if facts.selected_interface:
+        return True
+    if facts.routes:
+        # A default route without a parseable interface is not a known-safe
+        # absence; lifecycle cannot prove that the AP role is separate.
+        return False
+    return any(
+        record.probe_id == probe_id
+        and record.exit_status == 0
+        and not record.timed_out
+        and not record.missing
+        and not record.permission_denied
+        and not record.output_truncated
+        for record in snapshot.probe_records
+    )
+
+
+def _snapshot_uplink_guard_error(
+    snapshot: HostFactsSnapshot,
+    ap_ifname: Optional[str],
+) -> Optional[str]:
+    """Evaluate AP/uplink role safety from one immutable operation snapshot."""
+
+    active_uplink = snapshot.default_uplink.selected_interface
+    if ap_ifname and active_uplink and ap_ifname == active_uplink:
+        return ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    if not _snapshot_default_uplink_is_known(snapshot):
+        return _DEFAULT_UPLINK_UNKNOWN_ERROR
+    return None
+
+
+def _assert_snapshot_ap_adapter_is_safe(
+    snapshot: HostFactsSnapshot,
+    ap_ifname: Optional[str],
+) -> None:
+    error = _snapshot_uplink_guard_error(snapshot, ap_ifname)
+    if error:
+        raise RuntimeError(error)
+
+
 def _maybe_reselect_ap_after_prestart_failure(
     *,
     ap_ifname: str,
@@ -1084,12 +1134,14 @@ def _maybe_reselect_ap_after_prestart_failure(
     band_pref: str,
     inv: Dict[str, Any],
     adapter: Optional[Dict[str, Any]],
+    host_facts_snapshot: HostFactsSnapshot,
     platform_is_pop: bool,
     prep_warnings: List[str],
 ) -> Tuple[str, Dict[str, Any], Optional[Dict[str, Any]], List[str]]:
     """
-    On Pop!_OS, driver reload can cause USB wlan ifnames to change/disappear.
-    Re-discover adapters and select the current AP-capable iface.
+    On Pop!_OS, driver reload can cause USB wlan ifnames to disappear. Only
+    adapters from the operation snapshot remain eligible after mutation; a new
+    interface name requires a new start operation and a new snapshot.
     """
     warnings: List[str] = []
     if not platform_is_pop or not ap_ifname:
@@ -1136,6 +1188,7 @@ def _maybe_reselect_ap_after_prestart_failure(
                 continue
             if require_bus and str(item.get("bus") or "").strip().lower() != require_bus:
                 continue
+            _assert_snapshot_ap_adapter_is_safe(host_facts_snapshot, cand)
             return cand, item
         return None, None
 
@@ -1144,12 +1197,9 @@ def _maybe_reselect_ap_after_prestart_failure(
     wait_usb = old_bus == "usb"
     scans = 12 if wait_usb else 1
     for _ in range(scans):
-        try:
-            inv_refreshed = get_adapters()
-        except Exception:
-            inv_refreshed = inv
-        inv_err = inv_refreshed.get("error") if isinstance(inv_refreshed, dict) else None
-        if inv_err and not (inv_refreshed or {}).get("adapters"):
+        inv_snapshot = inv
+        inv_err = inv_snapshot.get("error") if isinstance(inv_snapshot, dict) else None
+        if inv_err and not (inv_snapshot or {}).get("adapters"):
             if wait_usb:
                 time.sleep(0.5)
                 continue
@@ -1157,11 +1207,11 @@ def _maybe_reselect_ap_after_prestart_failure(
             return ap_ifname, inv, adapter, warnings
 
         require_bus = old_bus if wait_usb else None
-        candidate, new_adapter = _pick_candidate(inv_refreshed, require_bus=require_bus)
+        candidate, new_adapter = _pick_candidate(inv_snapshot, require_bus=require_bus)
         if candidate and new_adapter:
             if candidate != ap_ifname:
                 warnings.append(f"ap_adapter_reselected_after_reload:{ap_ifname}->{candidate}")
-            return candidate, inv_refreshed, new_adapter, warnings
+            return candidate, inv_snapshot, new_adapter, warnings
 
         if wait_usb:
             time.sleep(0.5)
@@ -1170,17 +1220,6 @@ def _maybe_reselect_ap_after_prestart_failure(
     if wait_usb:
         warnings.append("ap_adapter_reselect_usb_missing_after_reload")
         return ap_ifname, inv, adapter, warnings
-
-    try:
-        inv_refreshed = get_adapters()
-        candidate = _normalize_ap_adapter(ap_ifname, inv_refreshed)
-        if not candidate:
-            return ap_ifname, inv, adapter, warnings
-        new_adapter = _get_adapter(inv_refreshed, candidate)
-        if new_adapter and new_adapter.get("supports_ap"):
-            return candidate, inv_refreshed, new_adapter, warnings
-    except Exception as exc:
-        warnings.append(f"ap_adapter_reselect_failed:{exc}")
     return ap_ifname, inv, adapter, warnings
 
 
@@ -1799,6 +1838,7 @@ def _start_hotspot_5ghz_strict(
     *,
     cfg: Dict[str, Any],
     inv: Dict[str, Any],
+    host_facts_snapshot: HostFactsSnapshot,
     ap_ifname: str,
     target_phy: Optional[str],
     ssid: str,
@@ -1829,12 +1869,11 @@ def _start_hotspot_5ghz_strict(
     iface_up_grace_s: float = 0.0,
     ap_ready_nohint_retry_s: float = 0.0,
     pop_timeout_retry_no_virt: bool = False,
-    active_uplink_interface: Optional[str] = None,
 ) -> LifecycleResult:
     attempts: List[Dict[str, Any]] = []
+    active_uplink_interface = host_facts_snapshot.default_uplink.selected_interface
 
-    def _active_uplink_reselection_failure() -> LifecycleResult:
-        last_error = ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
+    def _uplink_safety_failure(last_error: str) -> LifecycleResult:
         warnings = list(start_warnings)
         warnings.extend(_safe_revert_tuning(tuning_state))
         state = update_state(
@@ -2012,12 +2051,6 @@ def _start_hotspot_5ghz_strict(
     res_final = None
     selected_candidate: Optional[Dict[str, Any]] = None
 
-    # Defensive guard: if caller missed passing the Pop!_OS flag, detect here
-    # so iface-busy retries still prefer no-virt mode.
-    if (not pop_timeout_retry_no_virt) and os_release.is_pop_os():
-        pop_timeout_retry_no_virt = True
-        start_warnings.append("platform_pop_retry_no_virt_autodetected")
-
     def _expected_ifname(no_virt: bool, force_hostapd_nat: bool = False) -> Optional[str]:
         if use_hostapd_nat or force_hostapd_nat or bridge_mode:
             return ap_ifname if no_virt else _virt_ap_ifname(ap_ifname)
@@ -2122,17 +2155,28 @@ def _start_hotspot_5ghz_strict(
         if prestart_missing_reselect:
             start_warnings.append("ap_iface_missing_prestart")
             old_ifname = ap_ifname
-            ap_ifname, inv, adapter_now, reselect_warnings = _maybe_reselect_ap_after_prestart_failure(
-                ap_ifname=ap_ifname,
-                preferred_ifname=cfg.get("ap_adapter") if isinstance(cfg.get("ap_adapter"), str) else None,
-                band_pref="5ghz",
-                inv=inv,
-                adapter=_get_adapter(inv, old_ifname),
-                platform_is_pop=True,
-                prep_warnings=["ap_iface_not_up_prestart"],
-            )
-            if active_uplink_interface and ap_ifname == active_uplink_interface:
-                return _active_uplink_reselection_failure()
+            try:
+                ap_ifname, inv, adapter_now, reselect_warnings = _maybe_reselect_ap_after_prestart_failure(
+                    ap_ifname=ap_ifname,
+                    preferred_ifname=cfg.get("ap_adapter") if isinstance(cfg.get("ap_adapter"), str) else None,
+                    band_pref="5ghz",
+                    inv=inv,
+                    adapter=_get_adapter(inv, old_ifname),
+                    host_facts_snapshot=host_facts_snapshot,
+                    platform_is_pop=True,
+                    prep_warnings=["ap_iface_not_up_prestart"],
+                )
+            except RuntimeError as exc:
+                error = str(exc)
+                if error in (
+                    ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+                    _DEFAULT_UPLINK_UNKNOWN_ERROR,
+                ):
+                    return _uplink_safety_failure(error)
+                raise
+            guard_error = _snapshot_uplink_guard_error(host_facts_snapshot, ap_ifname)
+            if guard_error:
+                return _uplink_safety_failure(guard_error)
             if reselect_warnings:
                 start_warnings.extend(reselect_warnings)
             if ap_ifname != old_ifname:
@@ -2252,17 +2296,28 @@ def _start_hotspot_5ghz_strict(
                     start_warnings.append("ap_parent_iface_missing_reselect")
                     _cleanup_attempt()
                     old_ifname = ap_ifname
-                    ap_ifname, inv, adapter_now, reselect_warnings = _maybe_reselect_ap_after_prestart_failure(
-                        ap_ifname=ap_ifname,
-                        preferred_ifname=cfg.get("ap_adapter") if isinstance(cfg.get("ap_adapter"), str) else None,
-                        band_pref="5ghz",
-                        inv=inv,
-                        adapter=_get_adapter(inv, old_ifname),
-                        platform_is_pop=True,
-                        prep_warnings=["ap_iface_not_up_post_driver_reload"],
-                    )
-                    if active_uplink_interface and ap_ifname == active_uplink_interface:
-                        return _active_uplink_reselection_failure()
+                    try:
+                        ap_ifname, inv, adapter_now, reselect_warnings = _maybe_reselect_ap_after_prestart_failure(
+                            ap_ifname=ap_ifname,
+                            preferred_ifname=cfg.get("ap_adapter") if isinstance(cfg.get("ap_adapter"), str) else None,
+                            band_pref="5ghz",
+                            inv=inv,
+                            adapter=_get_adapter(inv, old_ifname),
+                            host_facts_snapshot=host_facts_snapshot,
+                            platform_is_pop=True,
+                            prep_warnings=["ap_iface_not_up_post_driver_reload"],
+                        )
+                    except RuntimeError as exc:
+                        error = str(exc)
+                        if error in (
+                            ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+                            _DEFAULT_UPLINK_UNKNOWN_ERROR,
+                        ):
+                            return _uplink_safety_failure(error)
+                        raise
+                    guard_error = _snapshot_uplink_guard_error(host_facts_snapshot, ap_ifname)
+                    if guard_error:
+                        return _uplink_safety_failure(guard_error)
                     if reselect_warnings:
                         start_warnings.extend(reselect_warnings)
                     # Retry once more after parent-iface recovery even when the
@@ -3513,7 +3568,13 @@ def repair(correlation_id: str = "repair"):
         return _repair_impl(correlation_id=correlation_id)
 
 
-def _repair_impl(correlation_id: str = "repair"):
+def _repair_impl(
+    correlation_id: str = "repair",
+    *,
+    host_facts_snapshot: Optional[HostFactsSnapshot] = None,
+    inventory: Optional[Dict[str, Any]] = None,
+    platform_is_pop: Optional[bool] = None,
+):
     cfg = load_config()
     fw_cfg = _build_firewalld_cfg(cfg)
 
@@ -3526,7 +3587,12 @@ def _repair_impl(correlation_id: str = "repair"):
     removed_conf_dirs: List[str] = []
 
     try:
-        inv = get_adapters()
+        if isinstance(inventory, dict):
+            inv = inventory
+        elif host_facts_snapshot is not None:
+            inv = get_adapters(host_facts_snapshot=host_facts_snapshot)
+        else:
+            inv = get_adapters()
         preferred = cfg.get("ap_adapter")
         if preferred and isinstance(preferred, str) and preferred.strip():
             ap_ifname = _normalize_ap_adapter(preferred.strip(), inv)
@@ -3543,7 +3609,8 @@ def _repair_impl(correlation_id: str = "repair"):
     try:
         # Pop!_OS USB adapters can re-enumerate PHYs; stale virtual AP ifaces on
         # old PHYs can poison subsequent starts, so clean across all PHYs there.
-        cleanup_phy = None if os_release.is_pop_os() else target_phy
+        is_pop = os_release.is_pop_os() if platform_is_pop is None else platform_is_pop
+        cleanup_phy = None if is_pop else target_phy
         removed_ifaces = _cleanup_virtual_ap_ifaces(target_phy=cleanup_phy)
     except Exception:
         removed_ifaces = []
@@ -3590,6 +3657,25 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
     state = load_state()
     if state.get("phase") in ("starting", "running") and is_running():
         return LifecycleResult("already_running", state)
+
+    try:
+        host_facts_snapshot = build_host_facts_snapshot(
+            operation_kind="lifecycle_start",
+        )
+        if not isinstance(host_facts_snapshot, HostFactsSnapshot):
+            raise TypeError("snapshot builder returned an unexpected value")
+    except Exception:
+        err = "host_facts_snapshot_unavailable"
+        state = update_state(
+            phase="error",
+            running=False,
+            ap_interface=None,
+            last_op="start",
+            last_error=err,
+            last_correlation_id=correlation_id,
+            engine={"last_error": err, "ap_logs_tail": []},
+        )
+        return LifecycleResult("start_failed", state)
 
     state = update_state(
         phase="starting",
@@ -3709,7 +3795,7 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
     nm_remediation_error: Optional[str] = None
     prestart_warnings: List[str] = []
     try:
-        inv = get_adapters()
+        inv = get_adapters(host_facts_snapshot=host_facts_snapshot)
         inv_error = inv.get("error")
         if inv_error and not inv.get("adapters"):
             raise RuntimeError(inv_error)
@@ -3745,14 +3831,18 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
         if not a or not a.get("supports_ap"):
             raise RuntimeError("no_ap_capable_adapter_found")
 
-        active_uplink_interface = host_probes.probe_default_uplink()
-        if active_uplink_interface and ap_ifname == active_uplink_interface:
-            raise RuntimeError(ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK)
+        active_uplink_interface = host_facts_snapshot.default_uplink.selected_interface
+        _assert_snapshot_ap_adapter_is_safe(host_facts_snapshot, ap_ifname)
 
         # All host mutation stays behind the active-uplink role guard. Repair
         # can stop engines, revert tuning/firewall state, and remove virtual
         # interfaces, so it must not run until the selected AP role is safe.
-        _repair_impl(correlation_id=correlation_id)
+        _repair_impl(
+            correlation_id=correlation_id,
+            host_facts_snapshot=host_facts_snapshot,
+            inventory=inv,
+            platform_is_pop=platform_is_pop,
+        )
         state = update_state(
             phase="starting",
             last_op="start",
@@ -3858,11 +3948,11 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
                 band_pref=bp,
                 inv=inv,
                 adapter=a,
+                host_facts_snapshot=host_facts_snapshot,
                 platform_is_pop=platform_is_pop,
                 prep_warnings=prep_warnings,
             )
-            if active_uplink_interface and ap_ifname == active_uplink_interface:
-                raise RuntimeError(ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK)
+            _assert_snapshot_ap_adapter_is_safe(host_facts_snapshot, ap_ifname)
             if reselect_warnings:
                 prestart_warnings.extend(reselect_warnings)
             if ap_ifname != old_ifname:
@@ -3912,8 +4002,12 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
             ERROR_NM_INTERFACE_MANAGED,
             _IWD_ASSOCIATION_ERROR,
             ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+            _DEFAULT_UPLINK_UNKNOWN_ERROR,
         ):
-            if err == ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK:
+            if err in (
+                ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK,
+                _DEFAULT_UPLINK_UNKNOWN_ERROR,
+            ):
                 context = {
                     "ap_adapter": ap_ifname,
                     "active_uplink_interface": active_uplink_interface,
@@ -4071,7 +4165,7 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
             iface_up_grace_s=iface_up_grace_s,
             ap_ready_nohint_retry_s=ap_ready_nohint_retry_s,
             pop_timeout_retry_no_virt=platform_is_pop,
-            active_uplink_interface=active_uplink_interface,
+            host_facts_snapshot=host_facts_snapshot,
         )
 
     # Attempt 1: requested band

--- a/tests/host_facts_snapshot_factory.py
+++ b/tests/host_facts_snapshot_factory.py
@@ -1,14 +1,21 @@
+from typing import Optional
+
 from vr_hotspotd import host_facts
 
 
-def make_host_facts_snapshot() -> host_facts.HostFactsSnapshot:
+def make_host_facts_snapshot(
+    *,
+    snapshot_id: str = "adapter-snapshot-test-1",
+    operation_kind: str = "adapter-test",
+    default_uplink_interface: Optional[str] = "enp4s0",
+) -> host_facts.HostFactsSnapshot:
     """Return one internally consistent, known-good adapter snapshot fixture."""
 
     return host_facts.HostFactsSnapshot(
         schema_version=1,
         metadata=host_facts.SnapshotMetadata(
-            snapshot_id="adapter-snapshot-test-1",
-            operation_kind="adapter-test",
+            snapshot_id=snapshot_id,
+            operation_kind=operation_kind,
             source="test",
             started_at_utc="2026-07-22T12:00:00.000Z",
             completed_at_utc="2026-07-22T12:00:00.050Z",
@@ -31,15 +38,17 @@ def make_host_facts_snapshot() -> host_facts.HostFactsSnapshot:
             source_probe_id="platform.os_release",
         ),
         default_uplink=host_facts.DefaultUplinkFacts(
-            selected_interface="enp4s0",
+            selected_interface=default_uplink_interface,
             routes=(
                 host_facts.DefaultRouteFact(
-                    interface="enp4s0",
+                    interface=default_uplink_interface,
                     gateway="192.0.2.1",
                     metric=100,
                     protocol="dhcp",
                 ),
-            ),
+            )
+            if default_uplink_interface
+            else (),
             source_probe_id="network.default_uplink",
         ),
         iw_dev=host_facts.IwDevFacts(
@@ -183,6 +192,19 @@ def make_host_facts_snapshot() -> host_facts.HostFactsSnapshot:
                 ),
             ),
         ),
-        probe_records=(),
+        probe_records=(
+            host_facts.ProbeRecord(
+                probe_id="network.default_uplink",
+                source_kind="command",
+                source=("/usr/sbin/ip", "route", "show", "default"),
+                started_offset_ms=10,
+                completed_offset_ms=11,
+                exit_status=0,
+                timed_out=False,
+                missing=False,
+                permission_denied=False,
+                output_truncated=False,
+            ),
+        ),
         probe_errors=(),
     )

--- a/tests/test_80mhz_enforcement.py
+++ b/tests/test_80mhz_enforcement.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
+
 
 # Add backend to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
@@ -13,6 +15,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../b
 # Ensure fresh start
 if "vr_hotspotd.lifecycle" in sys.modules:
     del sys.modules["vr_hotspotd.lifecycle"]
+
+
+_HOST_FACTS_SNAPSHOT = make_host_facts_snapshot(operation_kind="lifecycle_start")
+
+
+@pytest.fixture(autouse=True)
+def _mock_lifecycle_host_facts_snapshot(monkeypatch):
+    from vr_hotspotd import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: _HOST_FACTS_SNAPSHOT,
+    )
 
 
 @pytest.mark.usefixtures("mock_missing_system_commands")

--- a/tests/test_active_uplink_start_guard.py
+++ b/tests/test_active_uplink_start_guard.py
@@ -1,10 +1,12 @@
 from copy import deepcopy
+from dataclasses import replace
 
 import pytest
 
-from vr_hotspotd import lifecycle
+from vr_hotspotd import host_facts, lifecycle
 from vr_hotspotd.policy import ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
 from vr_hotspotd.state import DEFAULT_STATE
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
 
 
 def _config(*, ap_adapter=""):
@@ -46,9 +48,15 @@ def _stub_read_only_start_environment(
     *,
     config,
     active_uplink_interface,
+    snapshot=None,
 ):
     state = deepcopy(DEFAULT_STATE)
     events = []
+    operation_snapshot = snapshot or make_host_facts_snapshot(
+        snapshot_id="lifecycle-start-snapshot",
+        operation_kind="lifecycle_start",
+        default_uplink_interface=active_uplink_interface,
+    )
 
     def load_state():
         return state
@@ -63,23 +71,28 @@ def _stub_read_only_start_environment(
                 state[key] = value
         return state
 
-    def get_adapters():
-        events.append("inventory")
-        return _inventory()
+    def build_snapshot(*, operation_kind):
+        events.append("snapshot")
+        assert operation_kind == "lifecycle_start"
+        return operation_snapshot
 
-    def probe_default_uplink():
-        events.append("active_uplink")
-        return active_uplink_interface
+    def get_adapters(*, host_facts_snapshot):
+        events.append("inventory")
+        assert host_facts_snapshot is operation_snapshot
+        return _inventory()
 
     monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
     monkeypatch.setattr(lifecycle, "load_state", load_state)
     monkeypatch.setattr(lifecycle, "update_state", update_state)
     monkeypatch.setattr(lifecycle, "load_config", lambda: dict(config))
+    monkeypatch.setattr(lifecycle, "build_host_facts_snapshot", build_snapshot)
     monkeypatch.setattr(lifecycle, "get_adapters", get_adapters)
     monkeypatch.setattr(
         lifecycle.host_probes,
         "probe_default_uplink",
-        probe_default_uplink,
+        lambda: (_ for _ in ()).throw(
+            AssertionError("lifecycle re-probed the default uplink")
+        ),
     )
     monkeypatch.setattr(
         lifecycle.wifi_probe,
@@ -96,7 +109,7 @@ def _stub_read_only_start_environment(
     monkeypatch.setattr(lifecycle.os_release, "is_pop_os", lambda _info=None: False)
     monkeypatch.setattr(lifecycle.os_release, "is_bazzite", lambda _info=None: False)
 
-    return state, events
+    return state, events, operation_snapshot
 
 
 def _forbid_mutations(monkeypatch):
@@ -148,7 +161,7 @@ def test_active_uplink_conflict_blocks_before_any_mutation(
     active_uplink_interface,
     selected_adapter,
 ):
-    state, events = _stub_read_only_start_environment(
+    state, events, _snapshot = _stub_read_only_start_environment(
         monkeypatch,
         config=_config(ap_adapter=configured_adapter),
         active_uplink_interface=active_uplink_interface,
@@ -172,14 +185,14 @@ def test_active_uplink_conflict_blocks_before_any_mutation(
             "active_uplink_interface": active_uplink_interface,
         },
     }
-    assert events == ["inventory", "active_uplink"]
+    assert events == ["snapshot", "inventory"]
     assert mutation_calls == []
 
 
 def test_active_uplink_conflict_after_reselection_blocks_before_replacement_mutation(
     monkeypatch,
 ):
-    state, events = _stub_read_only_start_environment(
+    state, events, snapshot = _stub_read_only_start_environment(
         monkeypatch,
         config=_config(ap_adapter="wlan0"),
         active_uplink_interface="wlan1",
@@ -214,6 +227,7 @@ def test_active_uplink_conflict_after_reselection_blocks_before_replacement_muta
 
     def reselect(**kwargs):
         calls.append(("reselect", kwargs["ap_ifname"]))
+        assert kwargs["host_facts_snapshot"] is snapshot
         return (
             "wlan1",
             inventory,
@@ -281,7 +295,7 @@ def test_active_uplink_conflict_after_reselection_blocks_before_replacement_muta
             "active_uplink_interface": "wlan1",
         },
     }
-    assert events == ["inventory", "active_uplink"]
+    assert events == ["snapshot", "inventory"]
     assert calls == [
         ("repair", None),
         ("iwd_reservation", "wlan0"),
@@ -300,14 +314,16 @@ def test_non_conflicting_uplink_is_allowed_past_guard(
     monkeypatch,
     active_uplink_interface,
 ):
-    state, events = _stub_read_only_start_environment(
+    state, events, snapshot = _stub_read_only_start_environment(
         monkeypatch,
         config=_config(),
         active_uplink_interface=active_uplink_interface,
     )
     mutation_calls = []
 
-    def repair(*_args, **_kwargs):
+    def repair(*_args, **kwargs):
+        assert kwargs["host_facts_snapshot"] is snapshot
+        assert kwargs["inventory"] == _inventory()
         mutation_calls.append("repair")
         return state
 
@@ -323,5 +339,46 @@ def test_non_conflicting_uplink_is_allowed_past_guard(
     assert result.code == "start_failed"
     assert state["last_error"] == "stop_after_active_uplink_guard"
     assert state["last_error"] != ERROR_AP_ADAPTER_IS_ACTIVE_UPLINK
-    assert events == ["inventory", "active_uplink"]
+    assert events == ["snapshot", "inventory"]
     assert mutation_calls == ["repair", "iwd_reservation"]
+
+
+def test_unknown_snapshot_default_uplink_blocks_before_any_mutation(monkeypatch):
+    snapshot = make_host_facts_snapshot(
+        snapshot_id="unknown-uplink-snapshot",
+        operation_kind="lifecycle_start",
+        default_uplink_interface=None,
+    )
+    snapshot = replace(
+        snapshot,
+        probe_errors=(
+            host_facts.ProbeError(
+                probe_id="network.default_uplink",
+                kind="timeout",
+                message="read-only command timed out",
+                exit_status=124,
+            ),
+        ),
+    )
+    state, events, _snapshot = _stub_read_only_start_environment(
+        monkeypatch,
+        config=_config(ap_adapter="wlan0"),
+        active_uplink_interface=None,
+        snapshot=snapshot,
+    )
+    mutation_calls = _forbid_mutations(monkeypatch)
+
+    result = lifecycle._start_hotspot_impl(correlation_id="unknown-uplink-test")
+
+    assert result.code == "start_failed"
+    assert state["last_error"] == "default_uplink_unknown"
+    assert state["last_error_detail"] == {
+        "code": "default_uplink_unknown",
+        "remediation": "Check logs for details.",
+        "context": {
+            "ap_adapter": "wlan0",
+            "active_uplink_interface": None,
+        },
+    }
+    assert events == ["snapshot", "inventory"]
+    assert mutation_calls == []

--- a/tests/test_basic_mode_enforcement.py
+++ b/tests/test_basic_mode_enforcement.py
@@ -9,8 +9,24 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
+
 # Add backend to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
+
+
+_HOST_FACTS_SNAPSHOT = make_host_facts_snapshot(operation_kind="lifecycle_start")
+
+
+@pytest.fixture(autouse=True)
+def _mock_lifecycle_host_facts_snapshot(monkeypatch):
+    from vr_hotspotd import lifecycle
+
+    monkeypatch.setattr(
+        lifecycle,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: _HOST_FACTS_SNAPSHOT,
+    )
 
 
 @pytest.mark.usefixtures("mock_missing_system_commands")
@@ -1160,6 +1176,7 @@ class TestPostStartWidthCheck(unittest.TestCase):
             res = lifecycle._start_hotspot_5ghz_strict(
                 cfg={"watchdog_enable": False},
                 inv={"adapters": []},
+                host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
                 ap_ifname="wlan1",
                 target_phy="phy1",
                 ssid="VR-Hotspot",
@@ -1290,6 +1307,7 @@ class TestPostStartWidthCheck(unittest.TestCase):
             res = lifecycle._start_hotspot_5ghz_strict(
                 cfg={"watchdog_enable": False},
                 inv={"adapters": []},
+                host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
                 ap_ifname="wlan1",
                 target_phy="phy1",
                 ssid="VR-Hotspot",
@@ -1418,6 +1436,7 @@ class TestPostStartWidthCheck(unittest.TestCase):
             res = lifecycle._start_hotspot_5ghz_strict(
                 cfg={"watchdog_enable": False},
                 inv={"adapters": []},
+                host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
                 ap_ifname="wlan1",
                 target_phy="phy1",
                 ssid="VR-Hotspot",

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import vr_hotspotd.lifecycle as lifecycle
 from vr_hotspotd.state import DEFAULT_STATE
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
 
 
 def _state_helpers():
@@ -31,7 +32,14 @@ def _stubbed_env(monkeypatch, cfg, ap_ready_returns, fallback_candidates=None):
     monkeypatch.setattr(lifecycle, "update_state", update_state)
     monkeypatch.setattr(lifecycle, "load_config", lambda: cfg)
     monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
-    monkeypatch.setattr(lifecycle, "_repair_impl", lambda correlation_id="repair": state)
+    monkeypatch.setattr(
+        lifecycle,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: make_host_facts_snapshot(
+            operation_kind=operation_kind,
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_repair_impl", lambda **_kwargs: state)
     monkeypatch.setattr(lifecycle, "_maybe_set_regdom", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(lifecycle, "_iface_is_up", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(lifecycle, "_iw_dev_info", lambda *_args, **_kwargs: "")
@@ -81,7 +89,7 @@ def _stubbed_env(monkeypatch, cfg, ap_ready_returns, fallback_candidates=None):
     monkeypatch.setattr(
         lifecycle,
         "get_adapters",
-        lambda: {
+        lambda *, host_facts_snapshot: {
             "recommended": "wlan0",
             "adapters": [
                 {

--- a/tests/test_iwd_ap_reservation.py
+++ b/tests/test_iwd_ap_reservation.py
@@ -4,6 +4,8 @@ import sys
 
 import pytest
 
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
+
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
 
@@ -120,7 +122,14 @@ def test_steamos_iwd_still_associated_fails_with_clear_error(
     monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
     monkeypatch.setattr(lifecycle, "load_state", lambda: {"phase": "stopped"})
     monkeypatch.setattr(lifecycle, "is_running", lambda: False)
-    monkeypatch.setattr(lifecycle, "_repair_impl", lambda correlation_id="start": {})
+    monkeypatch.setattr(
+        lifecycle,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: make_host_facts_snapshot(
+            operation_kind=operation_kind,
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_repair_impl", lambda **_kwargs: {})
     monkeypatch.setattr(lifecycle, "update_state", lambda **kwargs: states.append(kwargs) or kwargs)
     monkeypatch.setattr(
         lifecycle,
@@ -141,7 +150,7 @@ def test_steamos_iwd_still_associated_fails_with_clear_error(
     monkeypatch.setattr(
         lifecycle,
         "get_adapters",
-        lambda: {
+        lambda *, host_facts_snapshot: {
             "recommended": "wlan1",
             "adapters": [
                 {

--- a/tests/test_passphrase_autoprovision.py
+++ b/tests/test_passphrase_autoprovision.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
+
 
 # Add backend to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
@@ -17,14 +19,21 @@ def _common_start_mocks(monkeypatch, cfg):
         return dict(state)
 
     monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
-    monkeypatch.setattr(lifecycle, "_repair_impl", lambda correlation_id="start": None)
+    monkeypatch.setattr(
+        lifecycle,
+        "build_host_facts_snapshot",
+        lambda *, operation_kind: make_host_facts_snapshot(
+            operation_kind=operation_kind,
+        ),
+    )
+    monkeypatch.setattr(lifecycle, "_repair_impl", lambda **_kwargs: None)
     monkeypatch.setattr(lifecycle, "load_state", lambda: {"phase": "stopped"})
     monkeypatch.setattr(lifecycle, "update_state", fake_update_state)
     monkeypatch.setattr(lifecycle, "load_config", lambda: dict(cfg))
     monkeypatch.setattr(
         lifecycle,
         "get_adapters",
-        lambda: {
+        lambda *, host_facts_snapshot: {
             "adapters": [
                 {
                     "ifname": "wlan1",

--- a/tests/test_pop_iface_prep_and_timeouts.py
+++ b/tests/test_pop_iface_prep_and_timeouts.py
@@ -5,8 +5,13 @@ from types import SimpleNamespace
 
 import pytest
 
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
+
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../backend")))
+
+
+_HOST_FACTS_SNAPSHOT = make_host_facts_snapshot(operation_kind="lifecycle_start")
 
 
 def test_prepare_ap_interface_force_disconnect_sets_unmanaged(
@@ -210,21 +215,24 @@ def test_prepare_ap_interface_does_not_reload_driver_by_default(monkeypatch):
     assert reload_called["n"] == 0
 
 
-def test_reselect_adapter_after_reload_when_iface_missing(monkeypatch):
+def test_reselect_does_not_adopt_unobserved_reenumerated_iface(monkeypatch):
     import vr_hotspotd.lifecycle as lifecycle
 
     inv_initial = {
-        "adapters": [{"ifname": "wlxOLD", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True}],
+        "adapters": [{"ifname": "wlxOLD", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True, "bus": "usb"}],
         "recommended": "wlxOLD",
     }
-    inv_refreshed = {
-        "adapters": [{"ifname": "wlxNEW", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True}],
-        "recommended": "wlxNEW",
-    }
-
-    monkeypatch.setattr(lifecycle, "get_adapters", lambda: inv_refreshed)
+    monkeypatch.setattr(
+        lifecycle,
+        "get_adapters",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("reselection re-probed adapter inventory")
+        ),
+    )
+    monkeypatch.setattr(lifecycle.time, "sleep", lambda _s: None)
 
     def fake_exists(path: str) -> bool:
+        path = str(path)
         if path.endswith("/sys/class/net/wlxOLD"):
             return False
         if path.endswith("/sys/class/net/wlxNEW"):
@@ -239,14 +247,15 @@ def test_reselect_adapter_after_reload_when_iface_missing(monkeypatch):
         band_pref="5ghz",
         inv=inv_initial,
         adapter=inv_initial["adapters"][0],
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         platform_is_pop=True,
         prep_warnings=["ap_iface_not_up_post_driver_reload"],
     )
 
-    assert ap_ifname == "wlxNEW"
-    assert inv_out["recommended"] == "wlxNEW"
-    assert adapter_out and adapter_out.get("ifname") == "wlxNEW"
-    assert "ap_adapter_reselected_after_reload:wlxOLD->wlxNEW" in warnings
+    assert ap_ifname == "wlxOLD"
+    assert inv_out is inv_initial
+    assert adapter_out and adapter_out.get("ifname") == "wlxOLD"
+    assert "ap_adapter_reselect_usb_missing_after_reload" in warnings
 
 
 def test_reselect_adapter_noop_when_not_pop(monkeypatch):
@@ -263,6 +272,7 @@ def test_reselect_adapter_noop_when_not_pop(monkeypatch):
         band_pref="5ghz",
         inv=inv_initial,
         adapter=inv_initial["adapters"][0],
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         platform_is_pop=False,
         prep_warnings=["ap_iface_not_up_post_driver_reload"],
     )
@@ -277,18 +287,24 @@ def test_reselect_adapter_keeps_usb_when_only_pci_available(monkeypatch):
     import vr_hotspotd.lifecycle as lifecycle
 
     inv_initial = {
-        "adapters": [{"ifname": "wlxUSBOLD", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True, "bus": "usb"}],
-        "recommended": "wlxUSBOLD",
-    }
-    inv_pci_only = {
-        "adapters": [{"ifname": "wlp8s0", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True, "bus": "pci"}],
+        "adapters": [
+            {"ifname": "wlxUSBOLD", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True, "bus": "usb"},
+            {"ifname": "wlp8s0", "supports_ap": True, "supports_5ghz": True, "supports_80mhz": True, "bus": "pci"},
+        ],
         "recommended": "wlp8s0",
     }
 
-    monkeypatch.setattr(lifecycle, "get_adapters", lambda: inv_pci_only)
+    monkeypatch.setattr(
+        lifecycle,
+        "get_adapters",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("reselection re-probed adapter inventory")
+        ),
+    )
     monkeypatch.setattr(lifecycle.time, "sleep", lambda _s: None)
 
     def fake_exists(path: str) -> bool:
+        path = str(path)
         if path.endswith("/sys/class/net/wlxUSBOLD"):
             return False
         if path.endswith("/sys/class/net/wlp8s0"):
@@ -303,15 +319,70 @@ def test_reselect_adapter_keeps_usb_when_only_pci_available(monkeypatch):
         band_pref="5ghz",
         inv=inv_initial,
         adapter=inv_initial["adapters"][0],
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         platform_is_pop=True,
         prep_warnings=["ap_iface_not_up_post_driver_reload"],
     )
 
     assert ap_ifname == "wlxUSBOLD"
-    assert inv_out["recommended"] == "wlxUSBOLD"
+    assert inv_out is inv_initial
+    assert inv_out["recommended"] == "wlp8s0"
     assert adapter_out and adapter_out.get("ifname") == "wlxUSBOLD"
     assert "ap_adapter_reselect_usb_missing_after_reload" in warnings
     assert not any("->wlp8s0" in w for w in warnings)
+
+
+def test_reselect_adapter_rejects_snapshot_active_uplink(monkeypatch):
+    import vr_hotspotd.lifecycle as lifecycle
+
+    snapshot = make_host_facts_snapshot(
+        operation_kind="lifecycle_start",
+        default_uplink_interface="wlxUPLINK",
+    )
+    inv = {
+        "adapters": [
+            {
+                "ifname": "wlxOLD",
+                "supports_ap": True,
+                "supports_5ghz": True,
+                "supports_80mhz": True,
+                "bus": "usb",
+            },
+            {
+                "ifname": "wlxUPLINK",
+                "supports_ap": True,
+                "supports_5ghz": True,
+                "supports_80mhz": True,
+                "bus": "usb",
+            },
+        ],
+        "recommended": "wlxUPLINK",
+    }
+    monkeypatch.setattr(lifecycle.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        lifecycle.os.path,
+        "exists",
+        lambda path: str(path).endswith("/sys/class/net/wlxUPLINK"),
+    )
+    monkeypatch.setattr(
+        lifecycle,
+        "get_adapters",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("reselection re-probed adapter inventory")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="^ap_adapter_is_active_uplink$"):
+        lifecycle._maybe_reselect_ap_after_prestart_failure(
+            ap_ifname="wlxOLD",
+            preferred_ifname="wlxOLD",
+            band_pref="5ghz",
+            inv=inv,
+            adapter=inv["adapters"][0],
+            host_facts_snapshot=snapshot,
+            platform_is_pop=True,
+            prep_warnings=["ap_iface_not_up_post_driver_reload"],
+        )
 
 
 def test_virtual_iface_missing_signal_detects_x0_cannot_find_device():
@@ -400,9 +471,16 @@ def test_parent_iface_missing_signal_detects_cannot_find_parent_iface():
     assert lifecycle._lines_have_parent_iface_missing_signal(lines, "wlx7419f816af4c") is True
 
 
-def test_start_5ghz_strict_reselects_iface_after_no_virt_parent_missing(
+@pytest.mark.parametrize(
+    ("active_uplink_interface", "expected_code"),
+    (("enp4s0", "started"), ("wlxNEW", "ap_adapter_is_active_uplink")),
+    ids=("safe_reselection", "active_uplink_reselection"),
+)
+def test_start_5ghz_strict_reselection_uses_snapshot_uplink_guard(
     monkeypatch,
     mock_missing_system_commands,
+    active_uplink_interface,
+    expected_code,
 ):
     import vr_hotspotd.lifecycle as lifecycle
 
@@ -487,6 +565,20 @@ def test_start_5ghz_strict_reselects_iface_after_no_virt_parent_missing(
     def fake_build_cmd_nat(**kwargs):
         return [f"if={kwargs.get('ap_ifname')}", f"no_virt={kwargs.get('no_virt')}"]
 
+    operation_snapshot = make_host_facts_snapshot(
+        operation_kind="lifecycle_start",
+        default_uplink_interface=active_uplink_interface,
+    )
+
+    def fake_reselect(**kwargs):
+        assert kwargs["host_facts_snapshot"] is operation_snapshot
+        return (
+            "wlxNEW",
+            inv,
+            inv["adapters"][1],
+            ["ap_adapter_reselected_after_reload:wlxOLD->wlxNEW"],
+        )
+
     monkeypatch.setattr(lifecycle.wifi_probe, "probe", lambda *_args, **_kwargs: probe_payload)
     monkeypatch.setattr(lifecycle, "_attempt_start_candidate", fake_attempt_start_candidate)
     monkeypatch.setattr(lifecycle, "build_cmd_nat", fake_build_cmd_nat)
@@ -499,12 +591,17 @@ def test_start_5ghz_strict_reselects_iface_after_no_virt_parent_missing(
     monkeypatch.setattr(lifecycle.system_tuning, "apply_runtime", lambda *_args, **_kwargs: ({}, []))
     monkeypatch.setattr(lifecycle.network_tuning, "apply", lambda *_args, **_kwargs: ({}, []))
     monkeypatch.setattr(lifecycle, "_watchdog_enabled", lambda _cfg: False)
-    monkeypatch.setattr(lifecycle, "_maybe_reselect_ap_after_prestart_failure", lambda **_kwargs: ("wlxNEW", inv, inv["adapters"][1], ["ap_adapter_reselected_after_reload:wlxOLD->wlxNEW"]))
+    monkeypatch.setattr(
+        lifecycle,
+        "_maybe_reselect_ap_after_prestart_failure",
+        fake_reselect,
+    )
     monkeypatch.setattr(lifecycle.os.path, "exists", lambda p: not p.endswith("/sys/class/net/wlxOLD"))
 
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=operation_snapshot,
         ap_ifname="wlxOLD",
         target_phy="phy9",
         ssid="VR-Hotspot",
@@ -535,9 +632,14 @@ def test_start_5ghz_strict_reselects_iface_after_no_virt_parent_missing(
         pop_timeout_retry_no_virt=True,
     )
 
-    assert res.code == "started"
+    assert res.code == expected_code
     assert "ap_parent_iface_missing_reselect" in state.get("warnings", [])
-    assert "ap_adapter_reselected_after_reload:wlxOLD->wlxNEW" in state.get("warnings", [])
+    if expected_code == "started":
+        assert call_n["n"] == 3
+        assert "ap_adapter_reselected_after_reload:wlxOLD->wlxNEW" in state.get("warnings", [])
+    else:
+        assert call_n["n"] == 2
+        assert state["last_error"] == "ap_adapter_is_active_uplink"
 
 
 def test_start_5ghz_strict_retries_after_parent_missing_even_when_iface_name_unchanged(
@@ -647,6 +749,7 @@ def test_start_5ghz_strict_retries_after_parent_missing_even_when_iface_name_unc
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         ap_ifname="wlxOLD",
         target_phy="phy9",
         ssid="VR-Hotspot",
@@ -781,6 +884,7 @@ def test_start_5ghz_strict_pop_degrades_probe_errors_and_uses_default_candidates
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         ap_ifname="wlx7419f816af4c",
         target_phy="phy9",
         ssid="VR-Hotspot",
@@ -856,6 +960,7 @@ def test_start_5ghz_strict_non_pop_keeps_probe_errors_fatal(monkeypatch):
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         ap_ifname="wlx7419f816af4c",
         target_phy="phy9",
         ssid="VR-Hotspot",
@@ -985,6 +1090,7 @@ def test_start_5ghz_strict_retries_no_virt_when_virtual_iface_missing(
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         ap_ifname="wlx7419f816af4c",
         target_phy="phy9",
         ssid="VR-Hotspot",
@@ -1113,6 +1219,7 @@ def test_start_5ghz_strict_pop_timeout_retry_handles_hostapd_early_exit(
     res = lifecycle._start_hotspot_5ghz_strict(
         cfg={"watchdog_enable": False},
         inv=inv,
+        host_facts_snapshot=_HOST_FACTS_SNAPSHOT,
         ap_ifname="wlx7419f816af4c",
         target_phy="phy9",
         ssid="VR-Hotspot",

--- a/tests/test_wifi6_gating.py
+++ b/tests/test_wifi6_gating.py
@@ -8,6 +8,7 @@ import pytest
 
 import vr_hotspotd.lifecycle as lifecycle
 from vr_hotspotd.state import DEFAULT_STATE
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
 
 
 def _state_helpers():
@@ -52,7 +53,16 @@ def _stubbed_env(cfg, supports_wifi6):
         stack.enter_context(patch.object(lifecycle, "update_state", update_state))
         stack.enter_context(patch.object(lifecycle, "load_config", lambda: cfg))
         stack.enter_context(patch.object(lifecycle, "ensure_config_file", lambda: None))
-        stack.enter_context(patch.object(lifecycle, "_repair_impl", lambda correlation_id="repair": state))
+        stack.enter_context(
+            patch.object(
+                lifecycle,
+                "build_host_facts_snapshot",
+                lambda *, operation_kind: make_host_facts_snapshot(
+                    operation_kind=operation_kind,
+                ),
+            )
+        )
+        stack.enter_context(patch.object(lifecycle, "_repair_impl", lambda **_kwargs: state))
         stack.enter_context(patch.object(lifecycle, "_maybe_set_regdom", lambda *_args, **_kwargs: None))
         stack.enter_context(
             patch.object(
@@ -97,7 +107,7 @@ def _stubbed_env(cfg, supports_wifi6):
             patch.object(
                 lifecycle,
                 "get_adapters",
-                lambda: {
+                lambda *, host_facts_snapshot: {
                     "recommended": "wlan0",
                     "adapters": [
                         {


### PR DESCRIPTION
Implements HostFactsSnapshot PR 4 by making lifecycle start selection consume one operation-scoped HostFactsSnapshot.

What changed:
- `_start_hotspot_impl()` builds exactly one lifecycle start snapshot after the already-running fast path and before host-network mutation.
- Adapter inventory for lifecycle selection now uses `get_adapters(host_facts_snapshot=...)`.
- Start-time repair receives the same snapshot and projected inventory.
- The active-uplink guard now uses `snapshot.default_uplink` instead of a separate live default-route probe.
- Retry, fallback, strict 5 GHz retry, and Pop!_OS reselection paths re-check the same snapshot-based active-uplink guard.
- Pop!_OS recovery can verify whether an originally captured interface exists, but cannot re-inventory or adopt a new interface name mid-operation.

Safety:
- Selected AP adapter matching the snapshot active uplink blocks before repair or host mutation.
- Unknown default uplink fails closed/conservatively where safety requires.
- Successful empty route result remains a known absence.
- Failed, timed-out, missing, permission-denied, truncated, non-successful, or malformed default-route evidence cannot become a confident safe pass.
- Post-start network tuning and child-engine route discovery cannot revise lifecycle selection or bypass active-uplink safety.
- Snapshot collection remains read-only.
- No mutating host commands moved into snapshot collection.
- No `shell=True`.

Compatibility:
- Existing recommendation, capability, readiness/scoring, configured selection, and USB preference semantics are preserved.
- Existing 40 MHz fallback remains compatible.
- Existing virtual/no-virtual paths remain compatible.
- Existing retained-adapter retries remain compatible.
- Existing watchdog-triggered fresh starts remain compatible.
- API routes and response shapes unchanged.
- UI unchanged.
- Installer/uninstaller unchanged.
- Preflight response behavior unchanged.
- Adapter API response behavior unchanged.
- Firewall mutation behavior unchanged except existing lifecycle calls.
- Engine command behavior unchanged.
- Passphrase handling unchanged.
- Support bundle behavior unchanged.
- Auth/token behavior unchanged.
- CLI behavior unchanged.

Tests:
- Covers exactly one lifecycle snapshot before mutation.
- Covers selection using snapshot-backed inventory/readiness.
- Covers active-uplink guard using the same snapshot as selection.
- Covers active-uplink conflict blocking before mutation.
- Covers unknown uplink fail-closed behavior.
- Covers retry/fallback/reselection guard enforcement.
- Covers Pop!_OS recovery not selecting the active uplink.
- Covers 5 GHz fallback compatibility.
- Covers virtual/no-virtual compatibility.
- Covers watchdog compatibility.
- Tests avoid real host/networking commands.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `590 passed, 4 subtests passed`
