### PR TITLE
refactor: avoid duplicate host facts probes

### DIFF
--- a/backend/vr_hotspotd/diagnostics/platform.py
+++ b/backend/vr_hotspotd/diagnostics/platform.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from vr_hotspotd import host_probes
+from vr_hotspotd.host_facts import HostFactsSnapshot
 
 try:
     from vr_hotspotd import os_release as os_release_mod
@@ -70,7 +71,26 @@ def _split_like(value: Optional[Any]) -> List[str]:
     return host_probes.split_tokens(value)
 
 
-def _probe_os() -> Dict[str, Any]:
+def _snapshot_probe_failed(snapshot: HostFactsSnapshot, probe_id: str) -> bool:
+    return any(error.probe_id == probe_id for error in snapshot.probe_errors)
+
+
+def _probe_os(
+    host_facts_snapshot: Optional[HostFactsSnapshot] = None,
+) -> Dict[str, Any]:
+    if host_facts_snapshot is not None and not _snapshot_probe_failed(
+        host_facts_snapshot,
+        "platform.os_release",
+    ):
+        facts = host_facts_snapshot.platform
+        return {
+            "pretty_name": facts.os_name or "",
+            "id": facts.os_id or "",
+            "version_id": facts.version_id or "",
+            "variant_id": facts.variant_id or "",
+            "id_like": list(facts.id_like),
+        }
+
     info = _read_os_release()
     return {
         "pretty_name": info.get("pretty_name") or info.get("name") or "",
@@ -168,32 +188,99 @@ def _probe_session() -> Dict[str, Any]:
     }
 
 
-def _probe_integration() -> Dict[str, Any]:
+def _probe_integration(
+    host_facts_snapshot: Optional[HostFactsSnapshot] = None,
+) -> Dict[str, Any]:
     systemctl_present = shutil.which("systemctl") is not None
     systemd = {
         "present": systemctl_present,
         "active": _systemctl_is_active("systemd-journald") if systemctl_present else False,
     }
 
-    nmcli = shutil.which("nmcli") is not None
-    network_manager = {
-        "present": nmcli or shutil.which("NetworkManager") is not None,
-        "active": _systemctl_is_active("NetworkManager") if systemctl_present else False,
-        "nmcli": nmcli,
-    }
+    snapshot_tools_complete = host_facts_snapshot is not None and not any(
+        _snapshot_probe_failed(host_facts_snapshot, f"tool.{name}")
+        for name in (
+            "nmcli",
+            "NetworkManager",
+            "firewall-cmd",
+            "ufw",
+            "nft",
+            "iptables",
+        )
+    )
+    if not snapshot_tools_complete:
+        nmcli = shutil.which("nmcli") is not None
+        network_manager = {
+            "present": nmcli or shutil.which("NetworkManager") is not None,
+            "active": _systemctl_is_active("NetworkManager") if systemctl_present else False,
+            "nmcli": nmcli,
+        }
 
-    firewall = {
-        "firewalld": {
-            "present": shutil.which("firewall-cmd") is not None,
-            "active": _systemctl_is_active("firewalld") if systemctl_present else False,
-        },
-        "ufw": {
-            "present": shutil.which("ufw") is not None,
-            "active": _systemctl_is_active("ufw") if systemctl_present else False,
-        },
-        "nft": {"present": shutil.which("nft") is not None},
-        "iptables": {"present": shutil.which("iptables") is not None},
-    }
+        firewall = {
+            "firewalld": {
+                "present": shutil.which("firewall-cmd") is not None,
+                "active": _systemctl_is_active("firewalld") if systemctl_present else False,
+            },
+            "ufw": {
+                "present": shutil.which("ufw") is not None,
+                "active": _systemctl_is_active("ufw") if systemctl_present else False,
+            },
+            "nft": {"present": shutil.which("nft") is not None},
+            "iptables": {"present": shutil.which("iptables") is not None},
+        }
+    else:
+        nm_facts = host_facts_snapshot.network_manager
+        nm_active = nm_facts.service_active is True
+        if _snapshot_probe_failed(
+            host_facts_snapshot,
+            "network_manager.service",
+        ):
+            nm_active = (
+                _systemctl_is_active("NetworkManager") if systemctl_present else False
+            )
+        network_manager = {
+            "present": bool(nm_facts.nmcli_present or nm_facts.binary_present),
+            "active": nm_active,
+            "nmcli": nm_facts.nmcli_present,
+        }
+
+        firewall_by_name = {
+            item.name: item for item in host_facts_snapshot.firewall.backends
+        }
+        firewalld = firewall_by_name.get("firewalld")
+        ufw = firewall_by_name.get("ufw")
+        nft = firewall_by_name.get("nftables")
+        iptables = firewall_by_name.get("iptables")
+        firewalld_active = bool(
+            firewalld and firewalld.service_active is True
+        )
+        if _snapshot_probe_failed(
+            host_facts_snapshot,
+            "firewall.firewalld.service",
+        ):
+            firewalld_active = (
+                _systemctl_is_active("firewalld") if systemctl_present else False
+            )
+        ufw_active = bool(ufw and ufw.service_active is True)
+        if _snapshot_probe_failed(
+            host_facts_snapshot,
+            "firewall.ufw.service",
+        ):
+            ufw_active = _systemctl_is_active("ufw") if systemctl_present else False
+        firewall = {
+            "firewalld": {
+                "present": bool(firewalld and firewalld.tool_present),
+                "active": firewalld_active,
+            },
+            "ufw": {
+                "present": bool(ufw and ufw.tool_present),
+                "active": ufw_active,
+            },
+            "nft": {"present": bool(nft and nft.tool_present)},
+            "iptables": {
+                "present": bool(iptables and iptables.tool_present),
+            },
+        }
 
     return {
         "systemd": systemd,
@@ -227,16 +314,19 @@ def _generate_notes(immutability: Dict[str, Any], integration: Dict[str, Any]) -
     return notes
 
 
-def collect_platform_matrix() -> Dict[str, Any]:
+def collect_platform_matrix(
+    *,
+    host_facts_snapshot: Optional[HostFactsSnapshot] = None,
+) -> Dict[str, Any]:
     """
     Collect platform capability matrix.
 
     Returns a dict safe for JSON serialization with OS, integration, and
     environment information. All probes are best-effort and fail gracefully.
     """
-    os_info = _probe_os()
+    os_info = _probe_os(host_facts_snapshot)
     immutability = _probe_immutability()
-    integration = _probe_integration()
+    integration = _probe_integration(host_facts_snapshot)
     session = _probe_session()
     notes = _generate_notes(immutability, integration)
 

--- a/backend/vr_hotspotd/diagnostics/preflight_report.py
+++ b/backend/vr_hotspotd/diagnostics/preflight_report.py
@@ -523,6 +523,17 @@ def _snapshot_concurrency(snapshot: HostFactsSnapshot) -> Dict[str, Optional[boo
     }
 
 
+def _snapshot_has_complete_adapter_projection(snapshot: HostFactsSnapshot) -> bool:
+    """Return whether snapshot-owned inputs can replace legacy inventory reads."""
+
+    return not any(
+        error.probe_id in ("iw.dev", "iw.regulatory")
+        or error.probe_id.startswith("iw.phy.")
+        or error.probe_id.startswith("sysfs.adapter.")
+        for error in snapshot.probe_errors
+    )
+
+
 def build_preflight_report(
     *,
     platform_matrix: Mapping[str, Any],
@@ -1024,7 +1035,11 @@ def collect_preflight_report(
 
     platform_matrix_base = _safe_collect(
         "platform",
-        collect_platform_matrix,
+        (
+            lambda: collect_platform_matrix(host_facts_snapshot=snapshot)
+            if snapshot is not None
+            else collect_platform_matrix()
+        ),
         {},
         failures,
     )
@@ -1080,7 +1095,12 @@ def collect_preflight_report(
     )
     policy_inventory = _safe_collect(
         "adapter_inventory",
-        get_adapters,
+        (
+            lambda: get_adapters(host_facts_snapshot=snapshot)
+            if snapshot is not None
+            and _snapshot_has_complete_adapter_projection(snapshot)
+            else get_adapters()
+        ),
         {"error": "probe_failed", "adapters": [], "recommended": None},
         failures,
     )

--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -1104,6 +1104,47 @@ def _snapshot_default_uplink_is_known(snapshot: HostFactsSnapshot) -> bool:
     )
 
 
+def _snapshot_os_release(snapshot: HostFactsSnapshot) -> Dict[str, str]:
+    """Return the already-captured os-release mapping for lifecycle policy."""
+
+    info = {item.key: item.value for item in snapshot.platform.os_release}
+    complete = bool(info) and not any(
+        error.probe_id == snapshot.platform.source_probe_id
+        for error in snapshot.probe_errors
+    )
+    return info if complete else os_release.read_os_release()
+
+
+def _snapshot_firewall_backend(snapshot: HostFactsSnapshot) -> str:
+    """Use snapshot selection unless a functional backend fact is incomplete."""
+
+    by_name = {item.name: item for item in snapshot.firewall.backends}
+    functional_incomplete = any(
+        error.probe_id == probe_id
+        and by_name.get(backend_name) is not None
+        and by_name[backend_name].tool_present
+        for backend_name, probe_id in (
+            ("firewalld", "firewall.firewalld.functional"),
+            ("ufw", "firewall.ufw.functional"),
+        )
+        for error in snapshot.probe_errors
+    )
+    tool_resolution_incomplete = any(
+        error.probe_id
+        in {
+            "tool.firewall-cmd",
+            "tool.ufw",
+            "tool.nft",
+            "tool.iptables",
+        }
+        for error in snapshot.probe_errors
+    )
+    if functional_incomplete or tool_resolution_incomplete:
+        firewall_probe = wifi_probe.detect_firewall_backends()
+        return firewall_probe.get("selected_backend") or "unknown"
+    return snapshot.firewall.selected_backend or "unknown"
+
+
 def _snapshot_uplink_guard_error(
     snapshot: HostFactsSnapshot,
     ap_ifname: Optional[str],
@@ -1915,6 +1956,7 @@ def _start_hotspot_5ghz_strict(
         country=country if isinstance(country, str) else None,
         allow_dfs=allow_dfs_channels,
         preferred_primary_channel=preferred_primary_channel,
+        include_host_context=False,
     )
     wifi = probe.get("wifi") if isinstance(probe, dict) else {}
     wifi_errors = wifi.get("errors") if isinstance(wifi, dict) else []
@@ -3693,9 +3735,8 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
     cfg = _apply_start_overrides(cfg, overrides)
     allow_fallback_40mhz = bool(cfg.get("allow_fallback_40mhz", False))
     allow_dfs_channels = bool(cfg.get("allow_dfs_channels", False))
-    firewall_probe = wifi_probe.detect_firewall_backends()
-    firewall_backend = firewall_probe.get("selected_backend") or "unknown"
-    platform_info = os_release.read_os_release()
+    firewall_backend = _snapshot_firewall_backend(host_facts_snapshot)
+    platform_info = _snapshot_os_release(host_facts_snapshot)
     platform_warnings: List[str] = []
     try:
         cfg, platform_warnings = os_release.apply_platform_overrides(cfg, platform_info)

--- a/backend/vr_hotspotd/wifi_probe.py
+++ b/backend/vr_hotspotd/wifi_probe.py
@@ -391,7 +391,19 @@ def probe(
     country: Optional[str] = None,
     allow_dfs: bool = False,
     preferred_primary_channel: Optional[int] = None,
+    include_host_context: bool = True,
 ) -> Dict[str, Any]:
+    if not include_host_context:
+        return {
+            "wifi": probe_5ghz_80(
+                ap_ifname,
+                inventory=inventory,
+                country=country,
+                allow_dfs=allow_dfs,
+                preferred_primary_channel=preferred_primary_channel,
+            ),
+        }
+
     return {
         "os": detect_os_flavor(),
         "firewall": detect_firewall_backends(),

--- a/tests/test_active_uplink_start_guard.py
+++ b/tests/test_active_uplink_start_guard.py
@@ -97,9 +97,17 @@ def _stub_read_only_start_environment(
     monkeypatch.setattr(
         lifecycle.wifi_probe,
         "detect_firewall_backends",
-        lambda: {"selected_backend": "nftables"},
+        lambda: (_ for _ in ()).throw(
+            AssertionError("lifecycle re-probed snapshot firewall facts")
+        ),
     )
-    monkeypatch.setattr(lifecycle.os_release, "read_os_release", lambda: {"id": "ubuntu"})
+    monkeypatch.setattr(
+        lifecycle.os_release,
+        "read_os_release",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("lifecycle re-read snapshot os-release facts")
+        ),
+    )
     monkeypatch.setattr(
         lifecycle.os_release,
         "apply_platform_overrides",
@@ -382,3 +390,48 @@ def test_unknown_snapshot_default_uplink_blocks_before_any_mutation(monkeypatch)
     }
     assert events == ["snapshot", "inventory"]
     assert mutation_calls == []
+
+
+def test_incomplete_snapshot_facts_keep_lifecycle_probe_fallbacks(monkeypatch):
+    snapshot = make_host_facts_snapshot(operation_kind="lifecycle_start")
+    firewalld = replace(
+        snapshot.firewall.backends[0],
+        tool_present=True,
+        functional_active=None,
+    )
+    snapshot = replace(
+        snapshot,
+        firewall=replace(
+            snapshot.firewall,
+            backends=(firewalld, *snapshot.firewall.backends[1:]),
+        ),
+        probe_errors=(
+            host_facts.ProbeError(
+                probe_id="platform.os_release",
+                kind="io",
+                message="partial os-release read",
+                exit_status=None,
+            ),
+            host_facts.ProbeError(
+                probe_id="firewall.firewalld.functional",
+                kind="timeout",
+                message="firewall status timed out",
+                exit_status=124,
+            ),
+        ),
+    )
+    calls = []
+    monkeypatch.setattr(
+        lifecycle.os_release,
+        "read_os_release",
+        lambda: calls.append("os_release") or {"id": "ubuntu"},
+    )
+    monkeypatch.setattr(
+        lifecycle.wifi_probe,
+        "detect_firewall_backends",
+        lambda: calls.append("firewall") or {"selected_backend": "firewalld"},
+    )
+
+    assert lifecycle._snapshot_os_release(snapshot) == {"id": "ubuntu"}
+    assert lifecycle._snapshot_firewall_backend(snapshot) == "firewalld"
+    assert calls == ["os_release", "firewall"]

--- a/tests/test_host_probes.py
+++ b/tests/test_host_probes.py
@@ -566,3 +566,55 @@ def test_default_uplink_execution_error_policies_are_unchanged(monkeypatch):
     with pytest.raises(FileNotFoundError) as exc:
         hostapd_nat_engine._default_uplink_iface()
     assert exc.value is failure
+
+
+def test_network_tuning_keeps_live_post_start_uplink_discovery(monkeypatch):
+    discovered = iter(("enp4s0", "wwan0"))
+    route_calls = []
+    nat_calls = []
+
+    def discover_uplink():
+        uplink = next(discovered)
+        route_calls.append(uplink)
+        return uplink
+
+    def apply_nat(
+        _cfg,
+        *,
+        ap_ifname,
+        uplink_ifname,
+        enable_internet,
+        firewalld_cfg,
+    ):
+        nat_calls.append(
+            (ap_ifname, uplink_ifname, enable_internet, firewalld_cfg)
+        )
+        return {}, []
+
+    monkeypatch.setattr(network_tuning, "_default_uplink_iface", discover_uplink)
+    monkeypatch.setattr(
+        network_tuning.qos,
+        "apply",
+        lambda *_args, **_kwargs: ({}, []),
+    )
+    monkeypatch.setattr(network_tuning.nat_accel, "apply", apply_nat)
+
+    first_state, first_warnings = network_tuning.apply(
+        {},
+        ap_ifname="wlan1",
+        enable_internet=True,
+    )
+    second_state, second_warnings = network_tuning.apply(
+        {},
+        ap_ifname="wlan1",
+        enable_internet=True,
+    )
+
+    assert route_calls == ["enp4s0", "wwan0"]
+    assert first_state == {"uplink_ifname": "enp4s0"}
+    assert second_state == {"uplink_ifname": "wwan0"}
+    assert first_warnings == second_warnings == []
+    assert nat_calls == [
+        ("wlan1", "enp4s0", True, None),
+        ("wlan1", "wwan0", True, None),
+    ]

--- a/tests/test_platform_probes.py
+++ b/tests/test_platform_probes.py
@@ -1,4 +1,5 @@
 from vr_hotspotd.diagnostics import platform
+from tests.host_facts_snapshot_factory import make_host_facts_snapshot
 
 
 def test_platform_os_probe_preserves_public_matrix_shape(monkeypatch):
@@ -61,6 +62,70 @@ def test_platform_integration_probe_preserves_presence_and_service_semantics(
             "iptables": {"present": False},
         },
     }
+
+
+def test_platform_snapshot_bypasses_duplicate_os_and_service_probes(monkeypatch):
+    snapshot = make_host_facts_snapshot(operation_kind="diagnostics_preflight")
+    which_calls = []
+    service_calls = []
+
+    monkeypatch.setattr(
+        platform,
+        "_read_os_release",
+        lambda: (_ for _ in ()).throw(AssertionError("os-release was re-read")),
+    )
+
+    def which(name):
+        which_calls.append(name)
+        if name == "systemctl":
+            return "/usr/bin/systemctl"
+        if name in {
+            "nmcli",
+            "NetworkManager",
+            "firewall-cmd",
+            "ufw",
+            "nft",
+            "iptables",
+        }:
+            raise AssertionError(f"snapshot-owned tool presence was re-probed: {name}")
+        return None
+
+    def systemctl_is_active(service):
+        service_calls.append(service)
+        if service != "systemd-journald":
+            raise AssertionError(f"snapshot-owned service was re-probed: {service}")
+        return True
+
+    monkeypatch.setattr(platform.shutil, "which", which)
+    monkeypatch.setattr(platform, "_systemctl_is_active", systemctl_is_active)
+    monkeypatch.setattr(platform, "_path_is_writable", lambda _path: True)
+
+    result = platform.collect_platform_matrix(host_facts_snapshot=snapshot)
+
+    assert result["os"] == {
+        "pretty_name": "Ubuntu",
+        "id": "ubuntu",
+        "version_id": "24.04",
+        "variant_id": "",
+        "id_like": ["debian"],
+    }
+    assert result["integration"] == {
+        "systemd": {"present": True, "active": True},
+        "network_manager": {
+            "present": True,
+            "active": True,
+            "nmcli": True,
+        },
+        "firewall": {
+            "firewalld": {"present": False, "active": False},
+            "ufw": {"present": False, "active": False},
+            "nft": {"present": True},
+            "iptables": {"present": True},
+        },
+    }
+    assert result["notes"] == ["network_manager_active"]
+    assert service_calls == ["systemd-journald"]
+    assert which_calls == ["rpm-ostree", "steamos-readonly", "mount", "systemctl"]
 
 
 def test_platform_immutability_keeps_rpm_ostree_priority(monkeypatch):

--- a/tests/test_pop_iface_prep_and_timeouts.py
+++ b/tests/test_pop_iface_prep_and_timeouts.py
@@ -579,7 +579,11 @@ def test_start_5ghz_strict_reselection_uses_snapshot_uplink_guard(
             ["ap_adapter_reselected_after_reload:wlxOLD->wlxNEW"],
         )
 
-    monkeypatch.setattr(lifecycle.wifi_probe, "probe", lambda *_args, **_kwargs: probe_payload)
+    def fake_wifi_probe(*_args, **kwargs):
+        assert kwargs["include_host_context"] is False
+        return probe_payload
+
+    monkeypatch.setattr(lifecycle.wifi_probe, "probe", fake_wifi_probe)
     monkeypatch.setattr(lifecycle, "_attempt_start_candidate", fake_attempt_start_candidate)
     monkeypatch.setattr(lifecycle, "build_cmd_nat", fake_build_cmd_nat)
     monkeypatch.setattr(lifecycle, "_prepare_ap_interface", lambda *_args, **_kwargs: [])

--- a/tests/test_preflight_report.py
+++ b/tests/test_preflight_report.py
@@ -276,9 +276,17 @@ def _host_facts_snapshot():
 
 
 def _patch_snapshot_collector_dependencies(monkeypatch, *, preflight_callback=None):
-    monkeypatch.setattr(preflight_report, "collect_platform_matrix", lambda: PLATFORM)
+    monkeypatch.setattr(
+        preflight_report,
+        "collect_platform_matrix",
+        lambda *, host_facts_snapshot=None: PLATFORM,
+    )
     monkeypatch.setattr(preflight_report, "_collect_runtime_binaries", lambda: BINARIES)
-    monkeypatch.setattr(preflight_report, "get_adapters", lambda: INVENTORY)
+    monkeypatch.setattr(
+        preflight_report,
+        "get_adapters",
+        lambda *, host_facts_snapshot=None: INVENTORY,
+    )
     monkeypatch.setattr(
         preflight_report,
         "build_readiness_model",
@@ -586,21 +594,23 @@ def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
         ),
     )
 
-    monkeypatch.setattr(
-        preflight_report,
-        "collect_platform_matrix",
-        lambda: calls.append("platform") or PLATFORM,
-    )
+    def collect_platform(*, host_facts_snapshot=None):
+        assert host_facts_snapshot is snapshot
+        calls.append(("platform", host_facts_snapshot.metadata.snapshot_id))
+        return PLATFORM
+
+    monkeypatch.setattr(preflight_report, "collect_platform_matrix", collect_platform)
     monkeypatch.setattr(
         preflight_report,
         "_collect_runtime_binaries",
         lambda: calls.append("binaries") or BINARIES,
     )
-    monkeypatch.setattr(
-        preflight_report,
-        "get_adapters",
-        lambda: calls.append("inventory") or INVENTORY,
-    )
+    def collect_inventory(*, host_facts_snapshot=None):
+        assert host_facts_snapshot is snapshot
+        calls.append(("inventory", host_facts_snapshot.metadata.snapshot_id))
+        return INVENTORY
+
+    monkeypatch.setattr(preflight_report, "get_adapters", collect_inventory)
     monkeypatch.setattr(
         preflight_report,
         "build_readiness_model",
@@ -655,6 +665,8 @@ def test_collector_uses_mocked_read_only_probe_results(monkeypatch):
     )
 
     assert report["overall_readiness"] == "ready"
+    assert ("platform", "preflight-snapshot-1") in calls
+    assert ("inventory", "preflight-snapshot-1") in calls
     assert ("readiness", INVENTORY) in calls
     assert report["network"]["active_uplink_interface"] == "enp4s0"
     assert report["firewall"] == {
@@ -693,6 +705,102 @@ def test_snapshot_backed_collector_preserves_existing_report_projection(monkeypa
 
     assert actual == expected
     assert built_for == ["diagnostics_preflight"]
+
+
+def test_collector_retains_legacy_no_snapshot_probe_paths(monkeypatch):
+    calls = []
+
+    def fail_snapshot(*, operation_kind):
+        assert operation_kind == "diagnostics_preflight"
+        raise RuntimeError("snapshot unavailable")
+
+    def collect_platform():
+        calls.append("platform")
+        return PLATFORM
+
+    def collect_inventory():
+        calls.append("inventory")
+        return INVENTORY
+
+    monkeypatch.setattr(preflight_report, "build_host_facts_snapshot", fail_snapshot)
+    monkeypatch.setattr(preflight_report, "collect_platform_matrix", collect_platform)
+    monkeypatch.setattr(
+        preflight_report,
+        "_collect_runtime_binaries",
+        lambda: calls.append("binaries") or BINARIES,
+    )
+    monkeypatch.setattr(preflight_report, "get_adapters", collect_inventory)
+    monkeypatch.setattr(
+        preflight_report,
+        "build_readiness_model",
+        lambda inventory: calls.append(("readiness", inventory)) or READINESS,
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_firewall_backends",
+        lambda: calls.append("firewall") or FIREWALL,
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_network_manager",
+        lambda: calls.append("network_manager")
+        or {"nmcli": True, "running": True},
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_iwd",
+        lambda: calls.append("iwd")
+        or {
+            "present": False,
+            "active": False,
+            "status": "not_installed",
+            "iwctl": False,
+        },
+    )
+    monkeypatch.setattr(
+        preflight_report.host_probes,
+        "probe_default_uplink",
+        lambda: calls.append("default_uplink") or "enp4s0",
+    )
+    monkeypatch.setattr(
+        preflight_report,
+        "probe_ap_managed_concurrency",
+        lambda phy: calls.append(("concurrency", phy)) or True,
+    )
+    monkeypatch.setattr(
+        preflight_report.preflight,
+        "run",
+        lambda _config, **_kwargs: {"errors": [], "warnings": [], "details": {}},
+    )
+
+    report = preflight_report.collect_preflight_report(
+        {
+            "band_preference": "5ghz",
+            "channel_width": "80",
+            "enable_internet": True,
+        }
+    )
+
+    call_labels = {
+        entry[0] if isinstance(entry, tuple) else entry for entry in calls
+    }
+
+    assert set(report) == set(_build())
+    assert {
+        "platform",
+        "firewall",
+        "network_manager",
+        "iwd",
+        "binaries",
+        "inventory",
+        "default_uplink",
+    }.issubset(call_labels)
+    assert ("readiness", INVENTORY) in calls
+    assert ("concurrency", "phy1") in calls
+    assert any(
+        item["probe"] == "host_facts_snapshot"
+        for item in report["evidence"]["probe_failures"]
+    )
 
 
 def test_partial_snapshot_failure_is_visible_and_prevents_confident_pass(monkeypatch):

--- a/tests/test_wifi_probe_candidates.py
+++ b/tests/test_wifi_probe_candidates.py
@@ -124,3 +124,55 @@ Wiphy phy0
     codes = {err["code"] for err in res["errors"]}
     assert "dfs_required_but_disabled" in codes
     assert "non_dfs_80mhz_channels_unavailable" in codes
+
+
+def test_probe_wifi_only_bypasses_unused_host_context(monkeypatch):
+    wifi_result = {"errors": [], "candidates": [{"primary_channel": 36}]}
+
+    def fail_host_context(*_args, **_kwargs):
+        raise AssertionError("unused host context was probed")
+
+    monkeypatch.setattr(wifi_probe, "detect_os_flavor", fail_host_context)
+    monkeypatch.setattr(wifi_probe, "detect_firewall_backends", fail_host_context)
+    monkeypatch.setattr(wifi_probe, "detect_network_manager", fail_host_context)
+    monkeypatch.setattr(
+        wifi_probe,
+        "probe_5ghz_80",
+        lambda *_args, **_kwargs: wifi_result,
+    )
+
+    assert wifi_probe.probe("wlan1", include_host_context=False) == {
+        "wifi": wifi_result,
+    }
+
+
+def test_probe_default_retains_legacy_host_context_shape(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        wifi_probe,
+        "detect_os_flavor",
+        lambda: calls.append("os") or {"flavor": "ubuntu_debian"},
+    )
+    monkeypatch.setattr(
+        wifi_probe,
+        "detect_firewall_backends",
+        lambda: calls.append("firewall") or {"selected_backend": "nftables"},
+    )
+    monkeypatch.setattr(
+        wifi_probe,
+        "detect_network_manager",
+        lambda: calls.append("network_manager") or {"running": True},
+    )
+    monkeypatch.setattr(
+        wifi_probe,
+        "probe_5ghz_80",
+        lambda *_args, **_kwargs: calls.append("wifi") or {"errors": []},
+    )
+
+    assert wifi_probe.probe("wlan1") == {
+        "os": {"flavor": "ubuntu_debian"},
+        "firewall": {"selected_backend": "nftables"},
+        "network_manager": {"running": True},
+        "wifi": {"errors": []},
+    }
+    assert calls == ["os", "firewall", "network_manager", "wifi"]


### PR DESCRIPTION
Implements HostFactsSnapshot PR 5 by safely bypassing duplicate host probes where complete equivalent snapshot facts are already available.

What changed:
- Preflight reuses complete snapshot platform and adapter facts.
- Preflight avoids duplicate OS-release, NetworkManager/firewall service/tool, `iw dev`, `iw phy`, `iw reg`, and adapter sysfs reads when snapshot facts are complete.
- Lifecycle reuses complete snapshot OS and firewall-selection facts.
- Strict 5 GHz probing skips unused OS/firewall/NetworkManager wrapper probes.
- Legacy fallback paths remain intact when snapshot facts are incomplete, unknown, malformed, or unavailable.
- No new route/uplink facts were threaded.

Preserved behavior:
- No-snapshot platform/inventory/preflight paths still work.
- Full-shape `wifi_probe.probe()` behavior is preserved.
- Shared host-probe wrappers remain compatible.
- Network tuning and engine modules are unchanged.
- Post-start route/NAT discovery remains live at original operational points.
- No stale pre-start snapshot route/uplink fact can replace post-start operational route/NAT discovery.
- Lifecycle selection unchanged.
- Active-uplink safety unchanged.
- Retry/fallback/Pop!_OS behavior unchanged.
- Watchdog behavior unchanged.
- Preflight response behavior unchanged.
- Adapter API response/scoring/recommendation behavior unchanged.
- API/UI/installer/firewall mutation/engine/passphrase/support-bundle/auth/CLI behavior unchanged.

CI fix:
- Includes a Python 3.11 test-only fix for `test_collector_retains_legacy_no_snapshot_probe_paths`.
- Avoids hashing payload-bearing call records that contain dict/list inventory data.
- Production behavior unchanged.

Tests:
- Adds/updates no-reprobe assertions.
- Covers legacy fallback and response-shape parity.
- Covers Wi-Fi wrapper shape parity.
- Covers lifecycle OS/firewall bypass and incomplete-fact fallback.
- Covers Pop!_OS reselection safety.
- Covers repeated live post-start uplink discovery.
- Tests avoid real host/networking commands.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `596 passed, 4 subtests passed`
- GitHub CI passed on Python 3.11, 3.12, and 3.13 after the test-only fix.
