### PR TITLE
Validate network config across fields

### DIFF
--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -13,7 +13,14 @@ from urllib.parse import parse_qs, quote, urlsplit
 
 from vr_hotspotd.adapters.inventory import get_adapters
 from vr_hotspotd.adapters.readiness import build_readiness_model
-from vr_hotspotd.config import load_config, load_config_snapshot, write_config_file
+from vr_hotspotd.config import (
+    ConfigValidationError,
+    INVALID_NETWORK_CONFIG,
+    load_config,
+    load_config_snapshot,
+    validate_network_config,
+    write_config_file,
+)
 from vr_hotspotd.lifecycle import (
     repair,
     start_hotspot,
@@ -732,9 +739,10 @@ class APIHandler(BaseHTTPRequestHandler):
                 elif isinstance(v, (int, float)):
                     s = str(v)
                 else:
-                    if v is not None:
+                    if v is None:
+                        out.pop(k, None)
+                    else:
                         warnings.append(f"invalid_ip:{k}")
-                    out.pop(k, None)
                     continue
                 if not s:
                     out.pop(k, None)
@@ -744,7 +752,7 @@ class APIHandler(BaseHTTPRequestHandler):
                         out[k] = s
                     except Exception:
                         warnings.append(f"invalid_ip:{k}")
-                        out.pop(k, None)
+                        out[k] = s
 
             if k == "dhcp_dns":
                 normalized = None
@@ -801,26 +809,6 @@ class APIHandler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
-        # Validate DHCP range if gateway is provided in this payload.
-        gw = out.get("lan_gateway_ip")
-        dhcp_start = out.get("dhcp_start_ip")
-        dhcp_end = out.get("dhcp_end_ip")
-        if gw and dhcp_start and dhcp_end:
-            try:
-                gw_ip = ipaddress.IPv4Address(gw)
-                start_ip = ipaddress.IPv4Address(dhcp_start)
-                end_ip = ipaddress.IPv4Address(dhcp_end)
-                if (int(start_ip) >= int(end_ip)):
-                    warnings.append("dhcp_range_invalid")
-                    out.pop("dhcp_start_ip", None)
-                    out.pop("dhcp_end_ip", None)
-                elif (gw_ip.packed[:3] != start_ip.packed[:3]) or (gw_ip.packed[:3] != end_ip.packed[:3]):
-                    warnings.append("dhcp_range_not_in_gateway_subnet")
-                    out.pop("dhcp_start_ip", None)
-                    out.pop("dhcp_end_ip", None)
-            except Exception:
-                pass
-
         # Enforce 6 GHz security invariants at config time (removes a common start failure)
         if out.get("band_preference") == "6ghz":
             if out.get("ap_security") != "wpa3_sae":
@@ -828,6 +816,31 @@ class APIHandler(BaseHTTPRequestHandler):
                 warnings.append("auto_set_ap_security_wpa3_sae_for_6ghz")
 
         return out, warnings
+
+    def _network_config_errors(self, updates: Dict[str, Any]) -> list[str]:
+        candidate = load_config_snapshot()
+        candidate.update(updates)
+        return validate_network_config(candidate)
+
+    def _respond_invalid_network_config(
+        self,
+        cid: str,
+        warnings: list[str],
+        validation_errors: list[str],
+    ) -> None:
+        combined_warnings = list(warnings)
+        for error in validation_errors:
+            if error not in combined_warnings:
+                combined_warnings.append(error)
+        self._respond(
+            400,
+            self._envelope(
+                correlation_id=cid,
+                result_code=INVALID_NETWORK_CONFIG,
+                warnings=combined_warnings,
+                data={"validation_errors": validation_errors},
+            ),
+        )
 
     def _redact_cmd_list(self, cmd: Any) -> Any:
         if not isinstance(cmd, list):
@@ -1140,6 +1153,11 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
                 return
 
+        validation_errors = self._network_config_errors(filtered)
+        if validation_errors:
+            self._respond_invalid_network_config(cid, warnings, validation_errors)
+            return
+
         try:
             merged = write_config_file(filtered)
             merged_view = self._config_view(include_secrets=False)
@@ -1155,6 +1173,8 @@ class APIHandler(BaseHTTPRequestHandler):
                     warnings=warnings,
                 ),
             )
+        except ConfigValidationError as e:
+            self._respond_invalid_network_config(cid, warnings, list(e.errors))
         except Exception as e:
             self._respond(
                 500,
@@ -1378,6 +1398,11 @@ class APIHandler(BaseHTTPRequestHandler):
             overrides, w_coerce = self._coerce_config_types(overrides)
             warnings += w_coerce
 
+            validation_errors = self._network_config_errors(overrides)
+            if validation_errors:
+                self._respond_invalid_network_config(cid, warnings, validation_errors)
+                return
+
             # Extract basic_mode flag from request body
             basic_mode = False
             if isinstance(body, dict):
@@ -1426,16 +1451,6 @@ class APIHandler(BaseHTTPRequestHandler):
         if path == "/v1/restart":
             warnings = list(body_warnings)
 
-            try:
-                stop_hotspot(correlation_id=cid + ":stop")
-            except Exception:
-                warnings.append("stop_failed_ignored")
-
-            try:
-                repair(correlation_id=cid + ":repair")
-            except Exception:
-                warnings.append("repair_failed_ignored")
-
             overrides_raw: Optional[Dict[str, Any]] = None
             if isinstance(body.get("overrides"), dict):
                 overrides_raw = body.get("overrides")  # type: ignore[assignment]
@@ -1461,12 +1476,27 @@ class APIHandler(BaseHTTPRequestHandler):
             overrides, w_coerce = self._coerce_config_types(overrides)
             warnings += w_coerce
 
+            validation_errors = self._network_config_errors(overrides)
+            if validation_errors:
+                self._respond_invalid_network_config(cid, warnings, validation_errors)
+                return
+
             # Extract basic_mode flag from request body
             basic_mode = False
             if isinstance(body, dict):
                 bm = body.get("basic_mode")
                 if bm is True or (isinstance(bm, str) and bm.lower() in ("true", "1", "yes")):
                     basic_mode = True
+
+            try:
+                stop_hotspot(correlation_id=cid + ":stop")
+            except Exception:
+                warnings.append("stop_failed_ignored")
+
+            try:
+                repair(correlation_id=cid + ":repair")
+            except Exception:
+                warnings.append("repair_failed_ignored")
 
             res = start_hotspot(correlation_id=cid + ":start", overrides=overrides if overrides else None, basic_mode=basic_mode)
             self._respond(

--- a/backend/vr_hotspotd/config.py
+++ b/backend/vr_hotspotd/config.py
@@ -1,11 +1,14 @@
+import ipaddress
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Sequence
 
 CONFIG_PATH = Path("/var/lib/vr-hotspot/config.json")
 CONFIG_TMP = Path("/var/lib/vr-hotspot/config.json.tmp")
 CONFIG_SCHEMA_VERSION = 4
+INVALID_NETWORK_CONFIG = "invalid_network_config"
+_LAN_IPV4_PREFIX_LENGTH = 24
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "version": CONFIG_SCHEMA_VERSION,
@@ -93,6 +96,61 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     # Autostart behavior (persisted)
     "autostart": False,
 }
+
+
+class ConfigValidationError(ValueError):
+    def __init__(self, errors: Sequence[str]):
+        self.errors = tuple(dict.fromkeys(str(error) for error in errors if str(error)))
+        super().__init__(f"{INVALID_NETWORK_CONFIG}:" + ",".join(self.errors))
+
+
+def validate_network_config(config: Mapping[str, Any]) -> list[str]:
+    """Validate the effective fixed-/24 LAN and strictly increasing DHCP range."""
+
+    cfg = DEFAULT_CONFIG.copy()
+    if isinstance(config, Mapping):
+        cfg.update(config)
+
+    errors: list[str] = []
+    parsed: Dict[str, ipaddress.IPv4Address] = {}
+    for field in ("lan_gateway_ip", "dhcp_start_ip", "dhcp_end_ip"):
+        value = cfg.get(field)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"invalid_ip:{field}")
+            continue
+        try:
+            parsed[field] = ipaddress.IPv4Address(value.strip())
+        except ipaddress.AddressValueError:
+            errors.append(f"invalid_ip:{field}")
+
+    if errors:
+        return errors
+
+    gateway = parsed["lan_gateway_ip"]
+    start = parsed["dhcp_start_ip"]
+    end = parsed["dhcp_end_ip"]
+    network = ipaddress.IPv4Network(
+        f"{gateway}/{_LAN_IPV4_PREFIX_LENGTH}",
+        strict=False,
+    )
+
+    ordered = start < end
+    if not ordered:
+        errors.append("dhcp_range_invalid")
+
+    in_gateway_subnet = start in network and end in network
+    if not in_gateway_subnet:
+        errors.append("dhcp_range_not_in_gateway_subnet")
+
+    if ordered and in_gateway_subnet:
+        if start <= gateway <= end:
+            errors.append("dhcp_range_includes_gateway")
+        if start <= network.network_address <= end:
+            errors.append("dhcp_range_includes_network_address")
+        if start <= network.broadcast_address <= end:
+            errors.append("dhcp_range_includes_broadcast_address")
+
+    return errors
 
 
 def read_config_file() -> Dict[str, Any]:
@@ -216,7 +274,11 @@ def load_config() -> Dict[str, Any]:
     cfg = DEFAULT_CONFIG.copy()
     cfg.update(read_config_file())
     migrated = _apply_migrations(cfg)
-    if migrated != cfg and CONFIG_PATH.exists():
+    if (
+        migrated != cfg
+        and CONFIG_PATH.exists()
+        and not validate_network_config(migrated)
+    ):
         _write_atomic(CONFIG_PATH, CONFIG_TMP, json.dumps(migrated, indent=2))
         try:
             os.chmod(CONFIG_PATH, 0o600)
@@ -240,6 +302,10 @@ def write_config_file(partial_updates: Dict[str, Any]) -> Dict[str, Any]:
     merged.update(existing)
     merged.update(partial_updates)
     merged["version"] = CONFIG_SCHEMA_VERSION
+
+    validation_errors = validate_network_config(merged)
+    if validation_errors:
+        raise ConfigValidationError(validation_errors)
 
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     _write_atomic(CONFIG_PATH, CONFIG_TMP, json.dumps(merged, indent=2))

--- a/backend/vr_hotspotd/engine/hostapd6_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd6_engine.py
@@ -11,6 +11,7 @@ import time
 from typing import Optional, List, Tuple
 
 from vr_hotspotd import host_probes
+from vr_hotspotd.config import ConfigValidationError, validate_network_config
 from vr_hotspotd.engine.secret_io import (
     add_passphrase_arguments,
     read_passphrase,
@@ -345,26 +346,20 @@ def main() -> int:
     if len(passphrase) < 8:
         raise RuntimeError("invalid_passphrase_min_length_8")
 
-    _maybe_set_regdom(args.country)
-
     # Network plan
     gw_ip = (args.gateway_ip or "192.168.68.1").strip()
-    try:
-        gw_addr = ipaddress.IPv4Address(gw_ip)
-    except Exception as exc:
-        raise RuntimeError("invalid_gateway_ip") from exc
     subnet_prefix = ".".join(gw_ip.split(".")[:3])
     dhcp_start = (args.dhcp_start or f"{subnet_prefix}.10").strip()
     dhcp_end = (args.dhcp_end or f"{subnet_prefix}.250").strip()
-    try:
-        start_addr = ipaddress.IPv4Address(dhcp_start)
-        end_addr = ipaddress.IPv4Address(dhcp_end)
-    except Exception as exc:
-        raise RuntimeError("invalid_dhcp_range") from exc
-    if int(start_addr) >= int(end_addr):
-        raise RuntimeError("invalid_dhcp_range")
-    if (gw_addr.packed[:3] != start_addr.packed[:3]) or (gw_addr.packed[:3] != end_addr.packed[:3]):
-        raise RuntimeError("invalid_dhcp_range_subnet")
+    network_validation_errors = validate_network_config(
+        {
+            "lan_gateway_ip": gw_ip,
+            "dhcp_start_ip": dhcp_start,
+            "dhcp_end_ip": dhcp_end,
+        }
+    )
+    if network_validation_errors:
+        raise ConfigValidationError(network_validation_errors)
     cidr = f"{gw_ip}/24"
     dhcp_dns = (args.dhcp_dns or "gateway").strip().lower()
     if not dhcp_dns:
@@ -379,6 +374,8 @@ def main() -> int:
         except Exception as exc:
             raise RuntimeError("invalid_dhcp_dns") from exc
         dhcp_dns = ",".join(ips)
+
+    _maybe_set_regdom(args.country)
 
     hostapd = _resolve_binary("hostapd", "HOSTAPD")
     dnsmasq = _resolve_binary("dnsmasq", "DNSMASQ")

--- a/backend/vr_hotspotd/engine/hostapd_nat_engine.py
+++ b/backend/vr_hotspotd/engine/hostapd_nat_engine.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional, List, Tuple
 
 from vr_hotspotd import host_probes, os_release
+from vr_hotspotd.config import ConfigValidationError, validate_network_config
 from vr_hotspotd.engine.secret_io import (
     add_passphrase_arguments,
     read_passphrase,
@@ -751,25 +752,19 @@ def main() -> int:
     else:
         raise RuntimeError("invalid_band")
 
-    _maybe_set_regdom(args.country)
-
     gw_ip = (args.gateway_ip or "192.168.68.1").strip()
-    try:
-        gw_addr = ipaddress.IPv4Address(gw_ip)
-    except Exception as exc:
-        raise RuntimeError("invalid_gateway_ip") from exc
     subnet_prefix = ".".join(gw_ip.split(".")[:3])
     dhcp_start = (args.dhcp_start or f"{subnet_prefix}.10").strip()
     dhcp_end = (args.dhcp_end or f"{subnet_prefix}.250").strip()
-    try:
-        start_addr = ipaddress.IPv4Address(dhcp_start)
-        end_addr = ipaddress.IPv4Address(dhcp_end)
-    except Exception as exc:
-        raise RuntimeError("invalid_dhcp_range") from exc
-    if int(start_addr) >= int(end_addr):
-        raise RuntimeError("invalid_dhcp_range")
-    if (gw_addr.packed[:3] != start_addr.packed[:3]) or (gw_addr.packed[:3] != end_addr.packed[:3]):
-        raise RuntimeError("invalid_dhcp_range_subnet")
+    network_validation_errors = validate_network_config(
+        {
+            "lan_gateway_ip": gw_ip,
+            "dhcp_start_ip": dhcp_start,
+            "dhcp_end_ip": dhcp_end,
+        }
+    )
+    if network_validation_errors:
+        raise ConfigValidationError(network_validation_errors)
     cidr = f"{gw_ip}/24"
     dhcp_dns = (args.dhcp_dns or "gateway").strip().lower()
     if not dhcp_dns:
@@ -784,6 +779,8 @@ def main() -> int:
         except Exception as exc:
             raise RuntimeError("invalid_dhcp_dns") from exc
         dhcp_dns = ",".join(ips)
+
+    _maybe_set_regdom(args.country)
 
     hostapd = _resolve_binary("hostapd", "HOSTAPD")
     dnsmasq = _resolve_binary("dnsmasq", "DNSMASQ")

--- a/backend/vr_hotspotd/lifecycle.py
+++ b/backend/vr_hotspotd/lifecycle.py
@@ -17,7 +17,13 @@ from typing import Optional, Set, Dict, Any, List, Tuple
 from vr_hotspotd.state import load_state, update_state
 from vr_hotspotd.adapters.inventory import get_adapters
 from vr_hotspotd.adapters.profiles import apply_adapter_profile
-from vr_hotspotd.config import load_config, ensure_config_file, write_config_file
+from vr_hotspotd.config import (
+    INVALID_NETWORK_CONFIG,
+    ensure_config_file,
+    load_config,
+    validate_network_config,
+    write_config_file,
+)
 from vr_hotspotd.engine.lnxrouter_cmd import build_cmd
 from vr_hotspotd.engine import lnxrouter_conf
 from vr_hotspotd.engine.hostapd6_cmd import build_cmd_6ghz
@@ -3335,6 +3341,19 @@ def _restart_from_watchdog(reason: str) -> None:
     
     # Check if auto channel switch is enabled and reason is quality-related
     cfg = load_config()
+    network_validation_errors = validate_network_config(cfg)
+    if network_validation_errors:
+        warnings = list(st_guard.get("warnings") or [])
+        for error in network_validation_errors:
+            if error not in warnings:
+                warnings.append(error)
+        update_state(
+            last_error=INVALID_NETWORK_CONFIG,
+            last_error_detail={"errors": network_validation_errors},
+            last_correlation_id=cid,
+            warnings=warnings,
+        )
+        return
     auto_switch = bool(cfg.get("auto_channel_switch", False))
     
     if auto_switch and "connection_quality" in reason:
@@ -3700,6 +3719,23 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
     if state.get("phase") in ("starting", "running") and is_running():
         return LifecycleResult("already_running", state)
 
+    cfg = load_config()
+    cfg = _apply_start_overrides(cfg, overrides)
+    network_validation_errors = validate_network_config(cfg)
+    if network_validation_errors:
+        state = update_state(
+            phase="error",
+            running=False,
+            ap_interface=None,
+            last_op="start",
+            last_error=INVALID_NETWORK_CONFIG,
+            last_error_detail={"errors": network_validation_errors},
+            last_correlation_id=correlation_id,
+            warnings=network_validation_errors,
+            engine={"last_error": INVALID_NETWORK_CONFIG, "ap_logs_tail": []},
+        )
+        return LifecycleResult(INVALID_NETWORK_CONFIG, state)
+
     try:
         host_facts_snapshot = build_host_facts_snapshot(
             operation_kind="lifecycle_start",
@@ -3731,8 +3767,6 @@ def _start_hotspot_impl(correlation_id: str = "start", overrides: Optional[dict]
         engine={"ap_logs_tail": []},
     )
 
-    cfg = load_config()
-    cfg = _apply_start_overrides(cfg, overrides)
     allow_fallback_40mhz = bool(cfg.get("allow_fallback_40mhz", False))
     allow_dfs_channels = bool(cfg.get("allow_dfs_channels", False))
     firewall_backend = _snapshot_firewall_backend(host_facts_snapshot)

--- a/tests/test_config_network_validation.py
+++ b/tests/test_config_network_validation.py
@@ -1,0 +1,386 @@
+import io
+import json
+from email.message import Message
+
+import pytest
+
+from vr_hotspotd import api, config, lifecycle
+from vr_hotspotd.engine import hostapd6_engine, hostapd_nat_engine
+
+
+def _config(**updates):
+    candidate = dict(config.DEFAULT_CONFIG)
+    candidate["wpa2_passphrase"] = "password123"
+    candidate.update(updates)
+    return candidate
+
+
+def _api_handler(*, path, body):
+    raw = json.dumps(body).encode("utf-8")
+    handler = api.APIHandler.__new__(api.APIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    headers = Message()
+    headers["Content-Length"] = str(len(raw))
+    headers["X-Api-Token"] = "secret"
+    handler.headers = headers
+    handler.command = "POST"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"POST {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def test_default_and_legacy_missing_network_fields_validate(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "CONFIG_PATH", tmp_path / "missing-config.json")
+
+    loaded = config.load_config_snapshot()
+
+    assert config.validate_network_config(loaded) == []
+    assert config.validate_network_config({"ssid": "legacy-config"}) == []
+    assert loaded["lan_gateway_ip"] == "192.168.68.1"
+    assert loaded["dhcp_start_ip"] == "192.168.68.10"
+    assert loaded["dhcp_end_ip"] == "192.168.68.250"
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_error"),
+    (
+        (
+            {
+                "dhcp_start_ip": "192.168.69.10",
+                "dhcp_end_ip": "192.168.69.20",
+            },
+            "dhcp_range_not_in_gateway_subnet",
+        ),
+        (
+            {
+                "dhcp_start_ip": "192.168.68.200",
+                "dhcp_end_ip": "192.168.68.100",
+            },
+            "dhcp_range_invalid",
+        ),
+        (
+            {
+                "dhcp_start_ip": "192.168.68.1",
+                "dhcp_end_ip": "192.168.68.10",
+            },
+            "dhcp_range_includes_gateway",
+        ),
+        (
+            {
+                "dhcp_start_ip": "192.168.68.0",
+                "dhcp_end_ip": "192.168.68.10",
+            },
+            "dhcp_range_includes_network_address",
+        ),
+        (
+            {
+                "dhcp_start_ip": "192.168.68.250",
+                "dhcp_end_ip": "192.168.68.255",
+            },
+            "dhcp_range_includes_broadcast_address",
+        ),
+        ({"lan_gateway_ip": "not-an-ip"}, "invalid_ip:lan_gateway_ip"),
+        ({"dhcp_start_ip": "192.168.68.999"}, "invalid_ip:dhcp_start_ip"),
+        ({"dhcp_end_ip": "192.168.68/24"}, "invalid_ip:dhcp_end_ip"),
+    ),
+)
+def test_invalid_network_combinations_are_rejected(updates, expected_error):
+    assert expected_error in config.validate_network_config(_config(**updates))
+
+
+def test_single_address_dhcp_range_is_rejected():
+    candidate = _config(
+        dhcp_start_ip="192.168.68.10",
+        dhcp_end_ip="192.168.68.10",
+    )
+
+    assert config.validate_network_config(candidate) == ["dhcp_range_invalid"]
+
+
+@pytest.mark.parametrize(
+    ("engine", "extra_args"),
+    (
+        (
+            hostapd_nat_engine,
+            ["--band", "5ghz", "--ap-security", "wpa2"],
+        ),
+        (hostapd6_engine, []),
+    ),
+)
+def test_hostapd_engines_validate_network_plan_before_host_actions(
+    monkeypatch,
+    engine,
+    extra_args,
+):
+    argv = [
+        engine.__name__,
+        "--ap-ifname",
+        "wlan1",
+        "--ssid",
+        "VR-Hotspot",
+        "--passphrase",
+        "password123",
+        "--country",
+        "US",
+        "--gateway-ip",
+        "192.168.68.1",
+        "--dhcp-start",
+        "192.168.69.10",
+        "--dhcp-end",
+        "192.168.69.20",
+        *extra_args,
+    ]
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("engine host action must not run")
+
+    monkeypatch.setattr(engine.sys, "argv", argv)
+    monkeypatch.setattr(engine, "_maybe_set_regdom", forbidden)
+    monkeypatch.setattr(engine, "_resolve_binary", forbidden)
+
+    with pytest.raises(config.ConfigValidationError) as exc_info:
+        engine.main()
+
+    assert exc_info.value.errors == ("dhcp_range_not_in_gateway_subnet",)
+
+
+def test_write_config_file_rejects_invalid_candidate_without_changing_disk(
+    monkeypatch,
+    tmp_path,
+):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(config, "CONFIG_TMP", tmp_path / "config.json.tmp")
+    config.write_config_file({})
+    before = config_path.read_bytes()
+
+    with pytest.raises(config.ConfigValidationError) as exc_info:
+        config.write_config_file(
+            {
+                "dhcp_start_ip": "10.0.0.10",
+                "dhcp_end_ip": "10.0.0.20",
+            }
+        )
+
+    assert exc_info.value.errors == ("dhcp_range_not_in_gateway_subnet",)
+    assert config_path.read_bytes() == before
+
+
+def test_load_config_does_not_write_invalid_migration(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    config_tmp = tmp_path / "config.json.tmp"
+    on_disk = {
+        "version": config.CONFIG_SCHEMA_VERSION - 1,
+        "ssid": "legacy-invalid",
+        "lan_gateway_ip": "192.168.68.1",
+        "dhcp_start_ip": "192.168.68.10",
+        "dhcp_end_ip": "192.168.68.10",
+    }
+    before = (json.dumps(on_disk, indent=2) + "\n").encode("utf-8")
+    config_path.write_bytes(before)
+    monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(config, "CONFIG_TMP", config_tmp)
+
+    loaded = config.load_config()
+
+    assert loaded["version"] == config.CONFIG_SCHEMA_VERSION
+    assert config.validate_network_config(loaded) == ["dhcp_range_invalid"]
+    assert config_path.read_bytes() == before
+    assert not config_tmp.exists()
+
+
+@pytest.mark.parametrize(
+    "updates",
+    (
+        {"lan_gateway_ip": "10.42.0.1"},
+        {"ssid": "must-not-save", "dhcp_start_ip": "malformed"},
+    ),
+)
+def test_config_api_rejects_invalid_merged_candidate_without_persisting(
+    monkeypatch,
+    updates,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    monkeypatch.setattr(api, "load_config_snapshot", lambda: _config())
+    writes = []
+    monkeypatch.setattr(api, "write_config_file", lambda value: writes.append(value))
+    handler = _api_handler(path="/v1/config", body={"config": updates})
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == config.INVALID_NETWORK_CONFIG
+    assert payload["data"]["validation_errors"]
+    assert writes == []
+
+
+def test_config_api_handles_writer_validation_error_without_persisting(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(config, "CONFIG_TMP", tmp_path / "config.json.tmp")
+    config.write_config_file({})
+    before = config_path.read_bytes()
+    monkeypatch.setattr(
+        api.APIHandler,
+        "_network_config_errors",
+        lambda _self, _updates: [],
+    )
+    proposed_passphrase = "must-not-save-secret"
+    updates = {
+        "ssid": "must-not-save",
+        "wpa2_passphrase": proposed_passphrase,
+        "dhcp_start_ip": "192.168.68.10",
+        "dhcp_end_ip": "192.168.68.10",
+    }
+    handler = _api_handler(path="/v1/config", body={"config": updates})
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert set(payload) == {"correlation_id", "result_code", "warnings", "data"}
+    assert payload["correlation_id"]
+    assert payload["result_code"] == config.INVALID_NETWORK_CONFIG
+    assert payload["warnings"] == ["dhcp_range_invalid"]
+    assert payload["data"] == {"validation_errors": ["dhcp_range_invalid"]}
+    assert proposed_passphrase not in handler.wfile.getvalue().decode("utf-8")
+    assert config_path.read_bytes() == before
+
+
+def test_config_api_preserves_valid_update_behavior(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    stored = _config()
+    monkeypatch.setattr(api, "load_config_snapshot", lambda: dict(stored))
+    monkeypatch.setattr(api, "load_config", lambda: dict(stored))
+    writes = []
+
+    def write(updates):
+        writes.append(dict(updates))
+        stored.update(updates)
+        return dict(stored)
+
+    monkeypatch.setattr(api, "write_config_file", write)
+    handler = _api_handler(
+        path="/v1/config",
+        body={"config": {"dhcp_end_ip": "192.168.68.200"}},
+    )
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert payload["result_code"] == "config_saved"
+    assert payload["data"]["dhcp_end_ip"] == "192.168.68.200"
+    assert writes == [{"dhcp_end_ip": "192.168.68.200"}]
+
+
+@pytest.mark.parametrize("path", ("/v1/start", "/v1/restart"))
+def test_start_apis_reject_invalid_overrides_before_lifecycle_mutation(
+    monkeypatch,
+    path,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    monkeypatch.setattr(api, "load_config_snapshot", lambda: _config())
+    calls = []
+    monkeypatch.setattr(api, "start_hotspot", lambda **_kwargs: calls.append("start"))
+    monkeypatch.setattr(api, "stop_hotspot", lambda **_kwargs: calls.append("stop"))
+    monkeypatch.setattr(api, "repair", lambda **_kwargs: calls.append("repair"))
+    handler = _api_handler(
+        path=path,
+        body={"overrides": {"dhcp_start_ip": "192.168.69.10"}},
+    )
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == config.INVALID_NETWORK_CONFIG
+    assert calls == []
+
+
+@pytest.mark.parametrize("invalid_source", ("persisted", "override"))
+def test_lifecycle_rejects_invalid_network_config_before_snapshot_or_mutation(
+    monkeypatch,
+    invalid_source,
+):
+    candidate = _config()
+    overrides = None
+    if invalid_source == "persisted":
+        candidate["dhcp_end_ip"] = "192.168.69.20"
+    else:
+        overrides = {"dhcp_end_ip": "192.168.69.20"}
+
+    state = {"phase": "stopped", "running": False}
+
+    def update_state(**updates):
+        state.update(updates)
+        return dict(state)
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("host inspection or network mutation must not run")
+
+    monkeypatch.setattr(lifecycle, "ensure_config_file", lambda: None)
+    monkeypatch.setattr(lifecycle, "load_state", lambda: dict(state))
+    monkeypatch.setattr(lifecycle, "load_config", lambda: dict(candidate))
+    monkeypatch.setattr(lifecycle, "update_state", update_state)
+    monkeypatch.setattr(lifecycle, "build_host_facts_snapshot", forbidden)
+    monkeypatch.setattr(lifecycle, "get_adapters", forbidden)
+    monkeypatch.setattr(lifecycle, "_repair_impl", forbidden)
+    monkeypatch.setattr(lifecycle, "_maybe_set_regdom", forbidden)
+    monkeypatch.setattr(lifecycle.system_tuning, "apply_pre", forbidden)
+    monkeypatch.setattr(lifecycle, "start_engine", forbidden)
+
+    result = lifecycle.start_hotspot(overrides=overrides)
+
+    assert result.code == config.INVALID_NETWORK_CONFIG
+    assert result.state["last_error"] == config.INVALID_NETWORK_CONFIG
+    assert result.state["last_error_detail"]["errors"] == [
+        "dhcp_range_not_in_gateway_subnet"
+    ]
+
+
+def test_watchdog_rejects_invalid_network_config_before_teardown(monkeypatch):
+    candidate = _config(
+        dhcp_start_ip="192.168.69.10",
+        dhcp_end_ip="192.168.69.20",
+    )
+    state = {"phase": "running", "running": True, "warnings": []}
+    updates = []
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("watchdog teardown or restart must not run")
+
+    monkeypatch.setattr(lifecycle, "load_state", lambda: dict(state))
+    monkeypatch.setattr(lifecycle, "load_config", lambda: dict(candidate))
+    monkeypatch.setattr(lifecycle, "update_state", lambda **value: updates.append(value))
+    monkeypatch.setattr(lifecycle, "_stop_hotspot_impl", forbidden)
+    monkeypatch.setattr(lifecycle, "_start_hotspot_impl", forbidden)
+
+    lifecycle._restart_from_watchdog("connection_quality_degraded:score=20")
+
+    assert len(updates) == 1
+    assert updates[0]["last_error"] == config.INVALID_NETWORK_CONFIG
+    assert updates[0]["last_error_detail"] == {
+        "errors": ["dhcp_range_not_in_gateway_subnet"],
+    }
+    assert updates[0]["last_correlation_id"].startswith("watchdog-")
+    assert updates[0]["warnings"] == ["dhcp_range_not_in_gateway_subnet"]


### PR DESCRIPTION
Adds centralized cross-field validation for DHCP/network config before invalid settings can be saved or used.

What changed:
- Added centralized network config validation.
- Validates `lan_gateway_ip`, `dhcp_start_ip`, and `dhcp_end_ip`.
- Enforces existing fixed IPv4 /24 behavior.
- Rejects malformed IPv4 values.
- Rejects DHCP ranges outside the gateway /24.
- Rejects DHCP ranges where start is greater than or equal to end.
- Rejects DHCP ranges that include the gateway, network address, or broadcast address.
- Preserves valid defaults and legacy config omissions through defaults.

Enforcement:
- Config writes validate the fully merged candidate before persistence.
- Invalid `/v1/config` updates return `invalid_network_config` and do not persist.
- Invalid `/v1/start` rejects before HostFactsSnapshot collection or host/network mutation.
- Invalid `/v1/restart` rejects before stop/repair/start mutation.
- Watchdog does not destructively tear down or restart with invalid config.
- NAT and 6 GHz engines validate before regulatory/interface/firewall/dnsmasq actions.

Compatibility:
- Existing API envelope shape is preserved.
- Stable validation details include:
  - `invalid_network_config`
  - `invalid_ip:*`
  - `dhcp_range_invalid`
  - `dhcp_range_not_in_gateway_subnet`
  - `dhcp_range_includes_gateway`
  - `dhcp_range_includes_network`
  - `dhcp_range_includes_broadcast`
- DNS validation, `enable_internet`, and `bridge_mode` semantics are preserved.
- No configurable CIDR/subnet, DHCP-disable, lease-time, MTU, IPv6 behavior, live host probing, or HostFactsSnapshot dependency was added.

Tests:
- Added focused coverage for default validity, legacy omissions, malformed IPs, subnet mismatch, reversed/equal ranges, gateway/network/broadcast overlap, API persistence boundaries, start/restart/watchdog safety, invalid migration no-write, API fallback `ConfigValidationError`, and NAT/6 GHz engine pre-mutation validation.
- Tests avoid real host/network commands.

Out of scope:
- No Bazzite cleanup.
- No SBOM/provenance work.
- No Steam Frame support.
- No HostFactsSnapshot work.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `619 passed, 4 subtests passed`

Review:
- `/tmp/vrhotspot-config-cross-field-validation-final-review-v2.md`
- SHA-256: `3470f7befb3d161a73c911ecc035495dc0334d1abb07f6c4a570ce8262099f2d`
- Verdict: approve
