### PR TITLE
Align Bazzite installer policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,18 @@ sudo bash /tmp/vrhotspot-install.sh --non-interactive
 curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh | sudo bash
 ```
 
+**Bazzite support policy**
+
+Bazzite is a supported target through the dedicated `rpm-ostree` installer
+path. VR Hotspot uses its bundled hostapd/dnsmasq stack on Bazzite instead of
+layering system copies. If another required base tool is missing, the installer
+first attempts live package layering; when that is unavailable, it stages the
+packages and asks you to reboot and rerun the installer. The installer does not
+reboot the system automatically.
+
 **Features:**
 - ✅ Auto-detects your OS (SteamOS, Bazzite, CachyOS, Arch, EndeavourOS, Ubuntu, Fedora)
-- ✅ Installs all dependencies automatically (iw, python, libnl, etc.)
+- ✅ Installs required dependencies automatically where the platform permits it
 - ✅ Configures NetworkManager to prevent interference
 - ✅ Starts service and shows you the web UI URL and API token
 - ✅ Perfect for beginners - no Linux knowledge required

--- a/backend/scripts/install.sh
+++ b/backend/scripts/install.sh
@@ -209,6 +209,18 @@ enable_firewalld_uplink_forwarding() {
   ensure_firewalld_action "add-forward" "permanent" "$zone"
 }
 
+validate_bazzite_vendor_stack() {
+  local vendor_bin_dir="$1"
+  local binary
+
+  for binary in hostapd dnsmasq; do
+    if [[ -x "$vendor_bin_dir/bazzite/$binary" || -x "$vendor_bin_dir/$binary" ]]; then
+      continue
+    fi
+    die "Bazzite requires bundled $binary in $vendor_bin_dir/bazzite or $vendor_bin_dir"
+  done
+}
+
 # Allow focused tests to source the firewall helpers without running installation.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
   return 0
@@ -270,7 +282,9 @@ if [[ -d "$INSTALL_DIR/backend/vendor/bin" ]]; then
   chmod +x "$INSTALL_DIR/backend/vendor/bin/"* 2>/dev/null || true
 fi
 
-# Ensure Bazzite prefers bundled hostapd/dnsmasq (system hostapd has been unstable on some installs).
+# Ensure Bazzite uses the bundled hostapd/dnsmasq stack (system hostapd has
+# been unstable on some installs). OS-specific binaries are preferred when
+# present; the tracked base bundle is the supported fallback.
 OS_ID=""
 OS_ID_LIKE=""
 if [[ -r /etc/os-release ]]; then
@@ -280,7 +294,8 @@ if [[ -r /etc/os-release ]]; then
   OS_ID_LIKE="${ID_LIKE:-}"
 fi
 if [[ "$OS_ID" == "bazzite" ]]; then
-  log "Bazzite detected: enforcing bundled vendor binaries in /etc/vr-hotspot/env"
+  validate_bazzite_vendor_stack "$INSTALL_DIR/backend/vendor/bin"
+  log "Bazzite detected: enforcing bundled hostapd/dnsmasq in /etc/vr-hotspot/env"
   install -d -m 755 /etc/vr-hotspot
   touch /etc/vr-hotspot/env
   if grep -q "^VR_HOTSPOT_FORCE_VENDOR_BIN=" /etc/vr-hotspot/env; then

--- a/docs/PLATFORM_COMPATIBILITY.md
+++ b/docs/PLATFORM_COMPATIBILITY.md
@@ -2,12 +2,25 @@
 
 This project targets multiple Linux distros (Bazzite, CachyOS, SteamOS, Arch, EndeavourOS, Fedora, Ubuntu). The goal is to avoid fixes for one OS breaking another.
 
+## Bazzite Support Policy
+
+Bazzite is supported through its exact OS identifier and the specialized
+`rpm-ostree` path. The installer forces the bundled hostapd/dnsmasq stack and
+does not layer system copies of those two packages. Other missing base tools
+may be installed with `rpm-ostree install --apply-live`; if live application
+fails, the installer stages them and requires a user-managed reboot followed
+by an installer rerun. It never orchestrates a reboot.
+
+This policy does not add generic Fedora Atomic support. Fedora continues to use
+the existing `dnf` dependency plan, while non-Bazzite Atomic variants remain
+outside the installer OS mapping.
+
 ## Checklist for OS-Specific Changes
 
 - [ ] Does the change modify `install.sh` or distro detection logic?
 - [ ] Are package names/differences accounted for across apt/dnf/pacman/rpm-ostree?
 - [ ] For SteamOS/CachyOS/Arch/EndeavourOS: do we keep the pacman-specific logic intact while treating immutable SteamOS separately?
-- [ ] For Bazzite (rpm-ostree): do we avoid breaking vendor-bundle or live-layering logic?
+- [ ] For Bazzite (rpm-ostree): do we preserve the bundled hostapd/dnsmasq policy and honest live-layering/reboot guidance?
 - [ ] If a fix is OS-specific, is it guarded by an OS check or feature flag?
 - [ ] For CachyOS: verify vendor hostapd/dnsmasq preference to avoid system package regressions.
 

--- a/install.sh
+++ b/install.sh
@@ -684,6 +684,10 @@ detect_os() {
             ;;
     esac
     print_success "Detected $OS_NAME ($PKG_MANAGER)."
+    if [ "$OS_ID" = "bazzite" ]; then
+        print_info "Bazzite support policy: supported through the rpm-ostree path with bundled hostapd/dnsmasq."
+        print_info "Missing base tools may be layered; if live application is unavailable, reboot and rerun the installer."
+    fi
 }
 
 calculate_dependency_list() {
@@ -703,18 +707,14 @@ calculate_dependency_list() {
             ;;
         rpm-ostree)
             DEPENDENCIES=(python3 python3-pip iw iproute iptables)
-            local script_dir vendor_bundle force_vendor
-            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-            vendor_bundle=0
-            if [ "$OS_ID" = "bazzite" ] && [ -x "$script_dir/backend/vendor/bin/bazzite/hostapd" ]; then
-                vendor_bundle=1
-            fi
-            force_vendor=0
-            case "$(echo "${VR_HOTSPOT_FORCE_VENDOR_BIN:-}" | tr '[:upper:]' '[:lower:]')" in
-                1|true|yes|on) force_vendor=1 ;;
-            esac
-            if [ "$vendor_bundle" -eq 0 ] && [ "$force_vendor" -eq 0 ]; then
-                DEPENDENCIES+=("hostapd" "dnsmasq")
+            if [ "$OS_ID" != "bazzite" ]; then
+                local force_vendor=0
+                case "$(echo "${VR_HOTSPOT_FORCE_VENDOR_BIN:-}" | tr '[:upper:]' '[:lower:]')" in
+                    1|true|yes|on) force_vendor=1 ;;
+                esac
+                if [ "$force_vendor" -eq 0 ]; then
+                    DEPENDENCIES+=("hostapd" "dnsmasq")
+                fi
             fi
             ;;
     esac
@@ -794,21 +794,14 @@ install_dependencies() {
             ;;
         rpm-ostree)
             # Check for missing dependencies to avoid unnecessary layering
-            local script_dir
-            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-            local vendor_bundle=0
-            if [ "$OS_ID" = "bazzite" ] && [ -x "$script_dir/backend/vendor/bin/bazzite/hostapd" ]; then
-                vendor_bundle=1
-            fi
-
             local force_vendor=0
             case "$(echo "${VR_HOTSPOT_FORCE_VENDOR_BIN:-}" | tr '[:upper:]' '[:lower:]')" in
                 1|true|yes|on) force_vendor=1 ;;
             esac
 
             local deps=("python3" "python3-pip" "iw" "iproute" "iptables")
-            if [ "$vendor_bundle" -eq 1 ]; then
-                print_info "Bazzite vendor bundle detected; skipping hostapd/dnsmasq layering."
+            if [ "$OS_ID" = "bazzite" ]; then
+                print_info "Bazzite uses bundled hostapd/dnsmasq; they will not be layered with rpm-ostree."
             elif [ "$force_vendor" -eq 1 ]; then
                 print_info "VR_HOTSPOT_FORCE_VENDOR_BIN=1 set; skipping hostapd/dnsmasq layering."
             else
@@ -922,12 +915,8 @@ configure_install() {
     fi
     if [ "$OS_ID" = "bazzite" ]; then
         echo "VR_HOTSPOT_VENDOR_PROFILE=bazzite" >> "$ENV_FILE"
-        if [ -x "$TEMP_INSTALL_DIR/backend/vendor/bin/bazzite/hostapd" ]; then
-            echo "VR_HOTSPOT_FORCE_VENDOR_BIN=1" >> "$ENV_FILE"
-            print_info "Bazzite vendor bundle detected; forcing bundled hostapd/dnsmasq."
-        else
-            print_warning "Bazzite vendor bundle not found. Using system hostapd until bundled binaries are added."
-        fi
+        echo "VR_HOTSPOT_FORCE_VENDOR_BIN=1" >> "$ENV_FILE"
+        print_info "Bazzite detected; forcing bundled hostapd/dnsmasq."
     fi
     print_success "Configuration saved to $ENV_FILE."
 }

--- a/tests/test_installer_rpm_ostree.py
+++ b/tests/test_installer_rpm_ostree.py
@@ -6,6 +6,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "install.sh"
+BACKEND_INSTALLER = ROOT / "backend" / "scripts" / "install.sh"
+README = ROOT / "README.md"
+PLATFORM_COMPATIBILITY = ROOT / "docs" / "PLATFORM_COMPATIBILITY.md"
+
+
+def make_executable(path: Path, contents: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
 
 
 def run_bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -50,12 +59,12 @@ def test_rpm_ostree_already_requested_detector_requires_expected_terms():
 
 def test_rpm_ostree_install_wrapper_reports_reboot_guidance(tmp_path):
     fake_rpm_ostree = tmp_path / "rpm-ostree"
-    fake_rpm_ostree.write_text(
+    make_executable(
+        fake_rpm_ostree,
         "#!/usr/bin/env bash\n"
         "echo 'error: Package/capability iw is already requested by rpm-ostree' >&2\n"
-        "exit 1\n"
+        "exit 1\n",
     )
-    fake_rpm_ostree.chmod(fake_rpm_ostree.stat().st_mode | stat.S_IXUSR)
 
     env = os.environ.copy()
     env["PATH"] = f"{tmp_path}:{env['PATH']}"
@@ -78,6 +87,182 @@ def test_rpm_ostree_install_wrapper_reports_reboot_guidance(tmp_path):
         "Reboot your system, then rerun the VR Hotspot installer."
     ) in result.stdout
     assert "Package/capability iw is already requested" in result.stderr
+
+
+def test_bazzite_dependency_plan_uses_bundled_network_stack():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=bazzite
+        PKG_MANAGER=rpm-ostree
+        calculate_dependency_list
+        printf '%s\n' "${{DEPENDENCIES[*]}}"
+        """
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip().split() == [
+        "python3",
+        "python3-pip",
+        "iw",
+        "iproute",
+        "iptables",
+    ]
+
+
+def test_bazzite_rpm_ostree_install_does_not_layer_bundled_network_stack(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    rpm_ostree_log = tmp_path / "rpm-ostree.log"
+    make_executable(fake_bin / "rpm", "#!/bin/sh\nexit 1\n")
+    make_executable(
+        fake_bin / "rpm-ostree",
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$RPM_OSTREE_LOG\"\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["RPM_OSTREE_LOG"] = str(rpm_ostree_log)
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=bazzite
+        PKG_MANAGER=rpm-ostree
+        install_dependencies
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "Bazzite uses bundled hostapd/dnsmasq" in result.stdout
+    assert rpm_ostree_log.read_text(encoding="utf-8").splitlines() == [
+        "install --apply-live python3 python3-pip iw iproute iptables"
+    ]
+
+
+def test_bazzite_check_os_explains_support_layering_and_reboot_policy():
+    env = os.environ.copy()
+    env.update(
+        {
+            "VR_HOTSPOT_OS_ID": "bazzite",
+            "VR_HOTSPOT_OS_NAME": "Bazzite",
+            "VR_HOTSPOT_OS_ID_LIKE": "fedora",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(INSTALLER), "--check-os", "--no-clear"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Detected Bazzite (rpm-ostree)." in result.stdout
+    assert (
+        "Bazzite support policy: supported through the rpm-ostree path with "
+        "bundled hostapd/dnsmasq."
+    ) in result.stdout
+    assert "reboot and rerun the installer" in result.stdout
+    assert (
+        "Dependency plan for Bazzite: python3 python3-pip iw iproute iptables"
+        in result.stdout
+    )
+
+
+def test_bazzite_configuration_forces_bundled_network_stack(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    make_executable(fake_bin / "openssl", "#!/bin/sh\necho test-api-token\n")
+    config_dir = tmp_path / "etc-vr-hotspot"
+    env_file = config_dir / "env"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        CONFIG_DIR={config_dir}
+        ENV_FILE={env_file}
+        OS_ID=bazzite
+        INTERACTIVE=0
+        configure_install
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    configured = env_file.read_text(encoding="utf-8").splitlines()
+    assert "VR_HOTSPOT_VENDOR_PROFILE=bazzite" in configured
+    assert "VR_HOTSPOT_FORCE_VENDOR_BIN=1" in configured
+    assert "forcing bundled hostapd/dnsmasq" in result.stdout
+
+
+def test_backend_bazzite_policy_accepts_tracked_base_bundle(tmp_path):
+    vendor_bin = tmp_path / "vendor" / "bin"
+    vendor_bin.mkdir(parents=True)
+    make_executable(vendor_bin / "hostapd")
+    make_executable(vendor_bin / "dnsmasq")
+
+    result = run_bash(
+        f"""
+        source {BACKEND_INSTALLER}
+        validate_bazzite_vendor_stack {vendor_bin}
+        """
+    )
+
+    assert result.returncode == 0
+
+
+def test_backend_bazzite_policy_fails_if_bundled_stack_is_incomplete(tmp_path):
+    vendor_bin = tmp_path / "vendor" / "bin"
+    vendor_bin.mkdir(parents=True)
+    make_executable(vendor_bin / "hostapd")
+
+    result = run_bash(
+        f"""
+        source {BACKEND_INSTALLER}
+        validate_bazzite_vendor_stack {vendor_bin}
+        """
+    )
+
+    assert result.returncode != 0
+    assert "Bazzite requires bundled dnsmasq" in result.stderr
+
+
+def test_bazzite_support_policy_is_consistent_in_user_docs():
+    readme = README.read_text(encoding="utf-8")
+    compatibility = PLATFORM_COMPATIBILITY.read_text(encoding="utf-8")
+
+    assert "Bazzite is a supported target" in readme
+    assert "bundled hostapd/dnsmasq stack" in readme
+    assert "reboot and rerun the installer" in readme
+    assert "Bazzite is supported" in compatibility
+    assert "does not layer system copies" in compatibility
+    assert "user-managed reboot" in compatibility
+
+
+def test_fedora_dependency_plan_remains_dnf_base_tools_only():
+    result = run_bash(
+        f"""
+        source {INSTALLER}
+        OS_ID=fedora
+        PKG_MANAGER=dnf
+        calculate_dependency_list
+        printf '%s\n' "${{DEPENDENCIES[*]}}"
+        """
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip().split() == [
+        "python3",
+        "python3-pip",
+        "iw",
+        "iproute",
+        "iptables",
+    ]
 
 
 def test_cachyos_dependency_plan_installs_dnsmasq_fallback():

--- a/tests/test_preflight_report.py
+++ b/tests/test_preflight_report.py
@@ -392,6 +392,33 @@ def test_report_distinguishes_steamos_from_mutable_linux():
     assert report["platform"]["is_mutable_linux"] is False
 
 
+def test_report_classifies_bazzite_as_immutable_rpm_ostree():
+    bazzite_platform = {
+        **PLATFORM,
+        "os": {
+            "pretty_name": "Bazzite 42",
+            "id": "bazzite",
+            "version_id": "42",
+            "variant_id": "",
+            "id_like": ["fedora"],
+        },
+        "immutability": {
+            "is_immutable": True,
+            "signal": "rpm-ostree",
+            "writable_paths": {},
+        },
+    }
+
+    report = _build(platform_matrix=bazzite_platform)
+
+    assert report["platform"]["os_family"] == "fedora"
+    assert report["platform"]["os_flavor"] == "bazzite"
+    assert report["platform"]["package_manager_family"] == "rpm-ostree"
+    assert report["platform"]["host_kind"] == "immutable_linux"
+    assert report["platform"]["is_immutable"] is True
+    assert report["platform"]["is_mutable_linux"] is False
+
+
 def test_report_blocks_on_missing_required_host_facts_with_human_actions():
     report = _build(
         binaries={

--- a/tools/ci/install_matrix_check.sh
+++ b/tools/ci/install_matrix_check.sh
@@ -15,7 +15,20 @@ declare -A OS_NAMES=(
 
 for os_id in "${!OS_NAMES[@]}"; do
   echo "==> Checking OS mapping for ${os_id}"
-  VR_HOTSPOT_OS_ID="${os_id}" \
-  VR_HOTSPOT_OS_NAME="${OS_NAMES[${os_id}]}" \
-    "${ROOT_DIR}/install.sh" --check-os --no-clear
+  output="$(
+    VR_HOTSPOT_OS_ID="${os_id}" \
+    VR_HOTSPOT_OS_NAME="${OS_NAMES[${os_id}]}" \
+      "${ROOT_DIR}/install.sh" --check-os --no-clear
+  )"
+  printf '%s\n' "$output"
+
+  if [[ "$os_id" == "bazzite" ]]; then
+    dependency_line="$(printf '%s\n' "$output" | grep -F "Dependency plan for Bazzite:")"
+    [[ "$output" == *"Detected Bazzite (rpm-ostree)."* ]]
+    [[ "$dependency_line" == *"Dependency plan for Bazzite: python3 python3-pip iw iproute iptables"* ]]
+    [[ "$dependency_line" != *" hostapd"* ]]
+    [[ "$dependency_line" != *" dnsmasq"* ]]
+    [[ "$output" == *"Bazzite support policy: supported through the rpm-ostree path with bundled hostapd/dnsmasq."* ]]
+    [[ "$output" == *"reboot and rerun the installer"* ]]
+  fi
 done


### PR DESCRIPTION
Aligns Bazzite installer, backend, diagnostics, docs, tests, and CI policy around the bundled hostapd/dnsmasq path.

What changed:
- Fixed the Bazzite policy mismatch where public installer logic layered system hostapd/dnsmasq while backend/runtime policy expected bundled binaries.
- Bazzite no longer layers hostapd/dnsmasq.
- Bazzite keeps its specialized rpm-ostree path.
- Bundled hostapd/dnsmasq are validated and forced for Bazzite.
- Missing base tools may still require rpm-ostree layering, reboot, and installer rerun.
- No reboot orchestration was added.

Docs:
- Updated README.md.
- Updated docs/PLATFORM_COMPATIBILITY.md.
- Clarified Bazzite support as bundled-binary based, with honest layering/reboot/rerun requirements.

Tests:
- Updated Bazzite rpm-ostree installer policy tests.
- Updated platform/preflight diagnostics coverage.
- Updated install matrix check so Bazzite system hostapd/dnsmasq dependencies are rejected.
- Preserved Fedora non-Bazzite behavior.

Out of scope:
- No SBOM/provenance work.
- No Steam Frame support.
- No HostFactsSnapshot work.
- No generic Fedora Atomic expansion.
- No installer rewrite.

Validation:
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `628 passed, 4 subtests passed`

Review:
- `/tmp/vrhotspot-bazzite-policy-mismatch-final-review.md`
- SHA-256: `32c7906b961488368308e50e94e5d4d92a1b5ebfd0737bea48ea761e96c3a29b`
- Verdict: approve
