### PR TITLE
Add vendor manifest

### DIFF
--- a/backend/vendor/VENDOR_MANIFEST.json
+++ b/backend/vendor/VENDOR_MANIFEST.json
@@ -1,0 +1,406 @@
+{
+  "schema_version": "1.0.0",
+  "maintained_by": "VRhotspot maintainers",
+  "policy_doc": "docs/VENDOR_PROVENANCE_SBOM_PLAN.md",
+  "enforcement_status": "inventory_only_not_enforced",
+  "notes": [
+    "This manifest covers only the backend/vendor tree and does not claim repository-wide SBOM completeness.",
+    "SHA-256 values record the exact checked-in bytes with no normalization; they are inventory metadata and are not verified or enforced by CI, the installer, or runtime code in PR #73.",
+    "A documented project, version, or license claim does not prove the exact acquisition source, build recipe, or correspondence between source and the checked-in bytes.",
+    "The executable field records the current Git executable bit. The shared libraries are executable in the current tree; PR #73 does not change those modes."
+  ],
+  "manifest_scope": {
+    "root": "backend/vendor/",
+    "entry_count": 13,
+    "coverage": "Every file tracked under backend/vendor before this manifest was added is represented exactly once.",
+    "excluded_paths": [
+      {
+        "path": "backend/vendor/VENDOR_MANIFEST.json",
+        "reason": "This canonical control file is excluded from its own file list because a stable self-hash is recursive. Future CI may validate the control file separately."
+      }
+    ]
+  },
+  "hashing": {
+    "algorithm": "SHA-256",
+    "input": "exact_file_bytes",
+    "status": "recorded_not_enforced"
+  },
+  "files": [
+    {
+      "path": "backend/vendor/README.md",
+      "file_type": "documentation",
+      "executable": false,
+      "purpose": "Documents the bundled networking stack, profile selection, version claims, and the current manual update process.",
+      "source_project": "VRhotspot",
+      "upstream_url": null,
+      "version": null,
+      "version_evidence": [],
+      "license": "MIT",
+      "license_evidence": [
+        "LICENSE.md"
+      ],
+      "license_status": "allowed",
+      "sha256": "ad9f6e0e2434410defd3e822caca21624627e4c631888d234b982e7edc6b049b",
+      "allowed_platforms": [
+        "all-supported"
+      ],
+      "runtime_trust_boundary": "documentation_only",
+      "update_process": "Update this document whenever a bundled component, profile, version claim, or vendor update procedure changes, and review it with the corresponding manifest entries.",
+      "provenance_status": "project_authored",
+      "reviewer_notes": [
+        "This is VRhotspot control documentation, not an upstream payload."
+      ]
+    },
+    {
+      "path": "backend/vendor/bin/dnsmasq",
+      "file_type": "elf_executable_x86_64",
+      "executable": true,
+      "purpose": "Provides DHCP and DNS service for hotspot clients when the bundled networking stack is selected.",
+      "source_project": "dnsmasq",
+      "upstream_url": "https://thekelleys.org.uk/dnsmasq/doc.html",
+      "version": null,
+      "version_evidence": [],
+      "license": "GPL-2.0-or-later",
+      "license_evidence": [
+        "backend/vendor/licenses/dnsmasq.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "50f7261e749b619d21716d0687bee49da9f1123b8dab40048b006e69956f81b9",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "privileged_network_executable",
+      "update_process": "Record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, replace the binary, refresh this entry and its SHA-256, then run DHCP and DNS smoke tests.",
+      "provenance_status": "unknown",
+      "reviewer_notes": [
+        "The repository does not record a dnsmasq version, exact source artifact, upstream commit, build recipe, or build flags.",
+        "The license is an existing repository claim; correspondence between that claim and these exact bytes has not been independently verified."
+      ]
+    },
+    {
+      "path": "backend/vendor/bin/hostapd",
+      "file_type": "elf_executable_x86_64",
+      "executable": true,
+      "purpose": "Manages the wireless access point when the bundled networking stack is selected.",
+      "source_project": "hostapd",
+      "upstream_url": "https://w1.fi/hostapd/",
+      "version": "2.11",
+      "version_evidence": [
+        "backend/vendor/README.md records v2.11 (hostap_2_11)",
+        "The current ELF contains the embedded string 2.11-hostap_2_11"
+      ],
+      "license": "BSD (dual-license; see upstream COPYING)",
+      "license_evidence": [
+        "backend/vendor/licenses/hostapd.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "4e117d9fd739d03388dafab1c213dea93930308bd575f7c1863737746deef23b",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "privileged_network_executable",
+      "update_process": "Update hostapd and hostapd_cli together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh both manifest entries and SHA-256 values, then run AP-mode smoke tests.",
+      "provenance_status": "version_evidenced_origin_unverified",
+      "reviewer_notes": [
+        "The version is supported by current repository evidence, but the exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The license is an existing repository claim; correspondence between that claim and these exact bytes has not been independently verified."
+      ]
+    },
+    {
+      "path": "backend/vendor/bin/hostapd_cli",
+      "file_type": "elf_executable_x86_64",
+      "executable": true,
+      "purpose": "Queries and controls hostapd for hotspot client diagnostics and access-point status.",
+      "source_project": "hostapd",
+      "upstream_url": "https://w1.fi/hostapd/",
+      "version": "2.11",
+      "version_evidence": [
+        "backend/vendor/README.md records hostapd v2.11 (hostap_2_11)",
+        "The current ELF contains the embedded string hostapd_cli v2.11-hostap_2_11"
+      ],
+      "license": "BSD (dual-license; see upstream COPYING)",
+      "license_evidence": [
+        "backend/vendor/licenses/hostapd.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "d42bd134bdb35a8261ac315db9ab1d060e93accf5087a3accd55be3ab45e7708",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "privileged_network_executable",
+      "update_process": "Update hostapd and hostapd_cli together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh both manifest entries and SHA-256 values, then run AP-control and client-diagnostic tests.",
+      "provenance_status": "version_evidenced_origin_unverified",
+      "reviewer_notes": [
+        "The version is supported by current repository evidence, but the exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The license is an existing repository claim; correspondence between that claim and these exact bytes has not been independently verified."
+      ]
+    },
+    {
+      "path": "backend/vendor/bin/lnxrouter",
+      "file_type": "bash_script",
+      "executable": true,
+      "purpose": "Orchestrates hotspot networking, including hostapd, dnsmasq, interface, routing, and firewall operations.",
+      "source_project": "linux-router",
+      "upstream_url": "https://github.com/garywill/linux-router",
+      "version": "0.8.1",
+      "version_evidence": [
+        "backend/vendor/bin/lnxrouter declares VERSION=0.8.1",
+        "backend/vendor/README.md records linux-router (lnxrouter) v0.8.1"
+      ],
+      "license": "LGPL-2.1-or-later",
+      "license_evidence": [
+        "backend/vendor/licenses/linux-router.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md",
+        "backend/vendor/bin/lnxrouter declares release under LGPL"
+      ],
+      "license_status": "unknown",
+      "sha256": "b331f9b6dc9ca12ec8153cf81fc4af2a0942025a5a83ae44bed48737333f36c3",
+      "allowed_platforms": [
+        "linux"
+      ],
+      "runtime_trust_boundary": "privileged_network_orchestrator",
+      "update_process": "Record the exact upstream tag or commit, source artifact, and VRhotspot-local patch series; review the license and local diff, replace the script, refresh this entry and its SHA-256, then run managed-engine and hotspot lifecycle tests.",
+      "provenance_status": "modified_source_origin_unverified",
+      "reviewer_notes": [
+        "The script declares version 0.8.1 and an upstream URL, but the exact upstream commit and acquisition record are absent.",
+        "The checked-in script contains VRhotspot-local changes, including inherited file-descriptor password handling; no complete local patch series is recorded.",
+        "The license claim is documented, but its review against the exact upstream revision and local modifications has not been independently recorded."
+      ]
+    },
+    {
+      "path": "backend/vendor/lib/libnl-3.so.200",
+      "file_type": "elf_shared_library_x86_64",
+      "executable": true,
+      "purpose": "Provides core netlink protocol support to bundled dynamically linked networking programs, including hostapd.",
+      "source_project": "libnl",
+      "upstream_url": "https://github.com/thom311/libnl",
+      "version": null,
+      "version_evidence": [
+        "backend/vendor/README.md records 3.10 (libnl3_10_0)",
+        "The current libnl-cli shared library contains an embedded 3.11.0 string, which conflicts with the README claim for the bundled set"
+      ],
+      "license": "LGPL-2.1-only",
+      "license_evidence": [
+        "backend/vendor/licenses/libnl.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "dfbde260e6b4640da4c7a9ddd779305f6f355055ab3738b11f03c4692e2995a0",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "privileged_dynamically_loaded_code",
+      "update_process": "Update the compatible libnl library set together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh all libnl entries and SHA-256 values, then run bundled hostapd selection and AP-mode tests.",
+      "provenance_status": "unknown_conflicting_version_evidence",
+      "reviewer_notes": [
+        "The documented 3.10 version is retained as an existing repository claim only; conflicting embedded evidence prevents recording it as the version of these exact bytes.",
+        "The exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The executable bit reflects the current Git mode and is intentionally unchanged in PR #73."
+      ]
+    },
+    {
+      "path": "backend/vendor/lib/libnl-cli-3.so.200",
+      "file_type": "elf_shared_library_x86_64",
+      "executable": true,
+      "purpose": "Provides libnl command-line support APIs in the bundled library directory; no direct current runtime consumer is documented.",
+      "source_project": "libnl",
+      "upstream_url": "https://github.com/thom311/libnl",
+      "version": null,
+      "version_evidence": [
+        "backend/vendor/README.md records 3.10 (libnl3_10_0)",
+        "The current shared library contains an embedded 3.11.0 string, which conflicts with the README claim for the bundled set"
+      ],
+      "license": "LGPL-2.1-only",
+      "license_evidence": [
+        "backend/vendor/licenses/libnl.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "06b6c5515b7b86e160c23005947f3f9a945ddc89cdaa96c3fabf493ffcd2eb28",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "potential_privileged_dynamically_loaded_code",
+      "update_process": "Update the compatible libnl library set together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh all libnl entries and SHA-256 values, then run bundled hostapd selection and AP-mode tests.",
+      "provenance_status": "unknown_conflicting_version_evidence",
+      "reviewer_notes": [
+        "The documented 3.10 version is retained as an existing repository claim only; an embedded 3.11.0 string prevents recording 3.10 as the version of these exact bytes.",
+        "The exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The executable bit reflects the current Git mode and is intentionally unchanged in PR #73."
+      ]
+    },
+    {
+      "path": "backend/vendor/lib/libnl-genl-3.so.200",
+      "file_type": "elf_shared_library_x86_64",
+      "executable": true,
+      "purpose": "Provides generic-netlink support loaded by the bundled hostapd executable.",
+      "source_project": "libnl",
+      "upstream_url": "https://github.com/thom311/libnl",
+      "version": null,
+      "version_evidence": [
+        "backend/vendor/README.md records 3.10 (libnl3_10_0)",
+        "The current libnl-cli shared library contains an embedded 3.11.0 string, which conflicts with the README claim for the bundled set"
+      ],
+      "license": "LGPL-2.1-only",
+      "license_evidence": [
+        "backend/vendor/licenses/libnl.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "78249f8dde742ef599fb92eb1a519220efa3864d4faa3a0f21e0dd4fba63b914",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "privileged_dynamically_loaded_code",
+      "update_process": "Update the compatible libnl library set together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh all libnl entries and SHA-256 values, then run bundled hostapd selection and AP-mode tests.",
+      "provenance_status": "unknown_conflicting_version_evidence",
+      "reviewer_notes": [
+        "The documented 3.10 version is retained as an existing repository claim only; conflicting embedded evidence prevents recording it as the version of these exact bytes.",
+        "The exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The executable bit reflects the current Git mode and is intentionally unchanged in PR #73."
+      ]
+    },
+    {
+      "path": "backend/vendor/lib/libnl-route-3.so.200",
+      "file_type": "elf_shared_library_x86_64",
+      "executable": true,
+      "purpose": "Provides libnl route APIs in the bundled library directory; no direct current runtime consumer is documented.",
+      "source_project": "libnl",
+      "upstream_url": "https://github.com/thom311/libnl",
+      "version": null,
+      "version_evidence": [
+        "backend/vendor/README.md records 3.10 (libnl3_10_0)",
+        "The current libnl-cli shared library contains an embedded 3.11.0 string, which conflicts with the README claim for the bundled set"
+      ],
+      "license": "LGPL-2.1-only",
+      "license_evidence": [
+        "backend/vendor/licenses/libnl.LICENSE.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
+      "license_status": "unknown",
+      "sha256": "82c23195844edf7f508a02abe4e610603d97752204227e3996c2a35fa103b3e4",
+      "allowed_platforms": [
+        "linux-x86_64"
+      ],
+      "runtime_trust_boundary": "potential_privileged_dynamically_loaded_code",
+      "update_process": "Update the compatible libnl library set together; record the exact upstream tag or commit and source artifact, document the build recipe and flags, review redistribution evidence, refresh all libnl entries and SHA-256 values, then run bundled hostapd selection and AP-mode tests.",
+      "provenance_status": "unknown_conflicting_version_evidence",
+      "reviewer_notes": [
+        "The documented 3.10 version is retained as an existing repository claim only; conflicting embedded evidence prevents recording it as the version of these exact bytes.",
+        "The exact acquisition source, upstream commit, source archive hash, build recipe, and build flags are not recorded.",
+        "The executable bit reflects the current Git mode and is intentionally unchanged in PR #73."
+      ]
+    },
+    {
+      "path": "backend/vendor/licenses/dnsmasq.LICENSE.txt",
+      "file_type": "license_reference",
+      "executable": false,
+      "purpose": "Records the repository's dnsmasq license claim and upstream license-text URL.",
+      "source_project": "dnsmasq",
+      "upstream_url": "https://thekelleys.org.uk/dnsmasq/doc.html",
+      "version": null,
+      "version_evidence": [],
+      "license": "GPL-2.0-or-later",
+      "license_evidence": [
+        "backend/vendor/licenses/dnsmasq.LICENSE.txt",
+        "https://thekelleys.org.uk/dnsmasq/COPYING"
+      ],
+      "license_status": "unknown",
+      "sha256": "c787e8b2235ae2b5e6d1796cb3272419d3360a81a4b9708e417b31aaec60e84a",
+      "allowed_platforms": [
+        "all-supported"
+      ],
+      "runtime_trust_boundary": "documentation_only",
+      "update_process": "When dnsmasq changes, compare the applicable upstream license, retain the required local notice or text, update the exact source/version record, and refresh this entry and its SHA-256.",
+      "provenance_status": "reference_record_origin_unverified",
+      "reviewer_notes": [
+        "This file is a short reference record, not the full license text.",
+        "It does not establish which upstream source produced the bundled dnsmasq bytes."
+      ]
+    },
+    {
+      "path": "backend/vendor/licenses/hostapd.LICENSE.txt",
+      "file_type": "license_reference",
+      "executable": false,
+      "purpose": "Records the repository's hostapd and hostapd_cli license claim and upstream COPYING URL.",
+      "source_project": "hostapd",
+      "upstream_url": "https://w1.fi/hostapd/",
+      "version": null,
+      "version_evidence": [],
+      "license": "BSD (dual-license; see upstream COPYING)",
+      "license_evidence": [
+        "backend/vendor/licenses/hostapd.LICENSE.txt",
+        "https://w1.fi/cgit/hostap/plain/COPYING"
+      ],
+      "license_status": "unknown",
+      "sha256": "8b2cc8ac453a9bfe6da3a114c4164fe10b0ae86f7a7f187fb30a77003d944e05",
+      "allowed_platforms": [
+        "all-supported"
+      ],
+      "runtime_trust_boundary": "documentation_only",
+      "update_process": "When hostapd or hostapd_cli changes, compare the applicable upstream license, retain the required local notice or text, update the exact source/version record, and refresh this entry and its SHA-256.",
+      "provenance_status": "reference_record_origin_unverified",
+      "reviewer_notes": [
+        "This file is a short reference record, not the full upstream COPYING text.",
+        "It does not establish which upstream source or build produced the bundled hostapd bytes."
+      ]
+    },
+    {
+      "path": "backend/vendor/licenses/libnl.LICENSE.txt",
+      "file_type": "license_notice",
+      "executable": false,
+      "purpose": "Provides the local libnl LGPL notice, warranty disclaimer, and full-license URL.",
+      "source_project": "libnl",
+      "upstream_url": "https://github.com/thom311/libnl",
+      "version": null,
+      "version_evidence": [],
+      "license": "LGPL-2.1-only",
+      "license_evidence": [
+        "backend/vendor/licenses/libnl.LICENSE.txt",
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html"
+      ],
+      "license_status": "unknown",
+      "sha256": "010ed9fee76e87022e3f08765d00bde0dce8cdc713252d80a40d8f2ee7b1d832",
+      "allowed_platforms": [
+        "all-supported"
+      ],
+      "runtime_trust_boundary": "documentation_only",
+      "update_process": "When the libnl set changes, compare the applicable upstream license and notices, retain the required local material, resolve the exact source/version record, and refresh this entry and its SHA-256.",
+      "provenance_status": "reference_record_origin_unverified",
+      "reviewer_notes": [
+        "This notice identifies LGPL version 2.1 but does not establish the exact source revision of the bundled libraries.",
+        "The current libnl version evidence is conflicting and remains unresolved."
+      ]
+    },
+    {
+      "path": "backend/vendor/licenses/linux-router.LICENSE.txt",
+      "file_type": "license_reference",
+      "executable": false,
+      "purpose": "Records the repository's linux-router license claim and upstream LICENSE URL.",
+      "source_project": "linux-router",
+      "upstream_url": "https://github.com/garywill/linux-router",
+      "version": null,
+      "version_evidence": [],
+      "license": "LGPL-2.1-or-later",
+      "license_evidence": [
+        "backend/vendor/licenses/linux-router.LICENSE.txt",
+        "https://github.com/garywill/linux-router/blob/master/LICENSE"
+      ],
+      "license_status": "unknown",
+      "sha256": "140c966121857fbfcc0fefed7cbb13310cf38dd5814372dfe43d4379547c22b5",
+      "allowed_platforms": [
+        "all-supported"
+      ],
+      "runtime_trust_boundary": "documentation_only",
+      "update_process": "When lnxrouter changes, compare the applicable upstream license, retain the required local notice or text, record the exact upstream revision and local patch series, and refresh this entry and its SHA-256.",
+      "provenance_status": "reference_record_origin_unverified",
+      "reviewer_notes": [
+        "This file is a short reference record, not the full upstream license text.",
+        "It does not establish the exact upstream revision or account for the licensing review of VRhotspot-local script modifications."
+      ]
+    }
+  ]
+}

--- a/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
+++ b/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
@@ -1,12 +1,14 @@
 # Vendor provenance, SBOM, and checksum manifest plan
 
-Status: PR #72 documentation-only plan
+Status: PR #73 manifest-addition step; PR #72 established the documentation-only plan
 
 Date: 2026-07-22
 
 This document defines the supply-chain groundwork for files that VRhotspot
-ships from the repository. It does not add a manifest, generate an SBOM,
-verify a checksum, or change installation or runtime behavior.
+ships from the repository. PR #73 adds the canonical machine-readable
+[`backend/vendor/VENDOR_MANIFEST.json`](../backend/vendor/VENDOR_MANIFEST.json)
+inventory. It does not generate an SBOM, verify or enforce a checksum, or
+change installation or runtime behavior.
 
 ## Problem
 
@@ -29,10 +31,11 @@ The existing repository has useful but fragmented attribution:
   but the implemented support bundle does not report file provenance or
   checksum state.
 
-There is no canonical machine-readable vendor inventory, generated SBOM, or
-reviewed checksum manifest today. A successful version probe also does not
-prove that a file came from the documented source or that its bytes match a
-reviewed artifact.
+PR #73 establishes a canonical machine-readable inventory for the current
+`backend/vendor/` tree. There is still no generated SBOM, checksum enforcement,
+or proof that the inventoried bytes came from the documented sources. A
+successful version probe also does not prove that a file came from the
+documented source or that its bytes match a reviewed upstream artifact.
 
 Future hardware support may increase pressure to add firmware, helper tools,
 driver-related material, device metadata, or other vendor-specific files. The
@@ -41,9 +44,9 @@ before that pressure produces more opaque assets.
 
 ## Current inventory observation
 
-This is an observation for planning, not the future manifest and not an
-approval of the current provenance records. PR #73 must inventory files
-individually and resolve or explicitly mark unknown facts.
+This observation informed the PR #73 manifest; it is not an approval of the
+current provenance records. The manifest inventories files individually and
+explicitly retains unresolved facts.
 
 | Repository area | Files observed | Current documentation | Trust relevance |
 |---|---|---|---|
@@ -52,18 +55,22 @@ individually and resolve or explicitly mark unknown facts.
 | `backend/vendor/licenses/` | `dnsmasq.LICENSE.txt`, `hostapd.LICENSE.txt`, `libnl.LICENSE.txt`, `linux-router.LICENSE.txt` | License identifiers, upstream links, and a partial libnl notice | Attribution/control material; its presence does not by itself establish the exact payload source. |
 | `backend/vendor/README.md` | bundle README | Partial version and update notes | Human-readable control material that is not machine-enforced. |
 
-All 13 files above are tracked. No profile-specific directories are present in
+All 13 files above are tracked and have one entry each in
+[`backend/vendor/VENDOR_MANIFEST.json`](../backend/vendor/VENDOR_MANIFEST.json).
+The manifest control file explicitly excludes itself from the hashed file list
+to avoid a recursive self-hash. No profile-specific directories are present in
 the current tree even though runtime lookup supports profile-specific `bin`
 and `lib` directories.
 
-The PR #73 scope audit must also classify repository-copied third-party assets
-outside `backend/vendor/`. In particular, `assets/qrcode.js` contains an
-upstream origin and MIT license notice, while `assets/chart.js` appears to be a
-prebuilt Chart.js distribution but has no visible version or license banner in
-the checked-in file. These are audit candidates, not newly approved provenance
-claims. Project-authored images, scripts, and generated assets must be
-distinguished from copied third-party material using evidence rather than file
-extension or location alone.
+Repository-copied third-party assets outside `backend/vendor/` remain a future
+scope audit. In particular, `assets/qrcode.js` contains an upstream origin and
+MIT license notice, while `assets/chart.js` appears to be a prebuilt Chart.js
+distribution but has no visible version or license banner in the checked-in
+file. They are future/outside-tree audit candidates documented here, not
+entries in the PR #73 backend vendor manifest and not newly approved
+provenance claims. Project-authored images, scripts, and generated assets must
+be distinguished from copied third-party material using evidence rather than
+file extension or location alone.
 
 System-provided hostapd, dnsmasq, and libraries are outside the file-level
 vendor manifest because their bytes are owned by the host package manager.
@@ -72,14 +79,14 @@ not imply that VRhotspot supplied or checksummed those host files.
 
 ## Goals
 
-- Inventory every vendored file, including executable payloads, shared
-  libraries, license/control material, profile-specific variants, and copied
-  third-party assets outside the current vendor directory.
+- Inventory every file in the declared `backend/vendor/` scope, including
+  executable payloads, shared libraries, and license/control material.
 - Document the source and provenance of every inventoried file.
 - Document its license and redistribution status, including an explicit
   unknown or blocked state where evidence is incomplete.
 - Document its purpose and runtime trust boundary.
-- Add one canonical machine-readable vendor manifest in a later PR.
+- Maintain one canonical machine-readable vendor manifest at
+  `backend/vendor/VENDOR_MANIFEST.json`, added by PR #73.
 - Derive a deterministic SBOM from reviewed manifest data rather than maintain
   a second hand-edited source of truth.
 - Add CI coverage for manifest completeness and schema validity in a later PR.
@@ -89,13 +96,15 @@ not imply that VRhotspot supplied or checksummed those host files.
 - Make the acquisition and review process repeatable before another vendor
   asset can be added or updated.
 
-## Non-goals for PR #72
+## PR #72 non-goals and PR #73 retained boundaries
 
 - No runtime enforcement.
-- No installer behavior change.
-- No CI behavior change.
-- No checksum verification yet.
-- No machine-readable manifest or generated SBOM yet.
+- No installer behavior change or enforcement.
+- No CI behavior change in PR #73; manifest coverage remains future PR #74 work.
+- No checksum verification or enforcement in PR #73; that remains future PR
+  #75 work.
+- PR #73 adds `backend/vendor/VENDOR_MANIFEST.json`, but no generated SBOM
+  exists yet and the manifest does not claim repository-wide SBOM completeness.
 - No new or replaced vendored binaries, libraries, firmware, scripts, or
   other vendor files.
 - No Steam Frame driver support.
@@ -146,16 +155,17 @@ The following rules govern subsequent implementation work:
     approval after the documentation, manifest, CI coverage, and checksum
     process have demonstrated stable behavior.
 
-## Future manifest contract
+## Manifest contract
 
-PR #73 should choose a documented format and schema for one canonical manifest.
-Its control file should live outside the payload namespace it hashes where
-practical; otherwise the schema must explicitly exclude the manifest from
-self-hashing while CI still validates that control file. Unknown historical
-facts must be represented honestly and assigned a review status rather than
-filled with guesses.
+PR #73 selects reviewable JSON with `schema_version` `1.0.0` for the canonical
+manifest at `backend/vendor/VENDOR_MANIFEST.json`. Because the control file is
+inside the namespace it inventories, `manifest_scope.excluded_paths` explicitly
+excludes the manifest from self-hashing. PR #74 may validate that control file
+separately. Unknown historical facts are represented as `null`, `unknown`, or
+an explicit unverified/conflicting provenance status rather than filled with
+guesses.
 
-Each file entry needs at least these fields:
+Each file entry has these fields:
 
 | Field | Required meaning |
 |---|---|
@@ -163,11 +173,11 @@ Each file entry needs at least these fields:
 | `file_type` | Controlled value such as ELF executable, shared library, script, browser JavaScript, firmware, license text, or documentation. |
 | `executable` | Boolean matching the reviewed Git executable bit, independently of `file_type`. |
 | `purpose` | Why VRhotspot ships the file and which component consumes it. |
-| `source_project_or_vendor` | Upstream project, vendor, or documented project-authored origin. |
-| `upstream_url_or_source_note` | Stable upstream URL or an explicit source note when no public URL applies. |
-| `version`, `commit`, `release` | Exact version evidence when known; fields may be null only with an explicit unknown status and reviewer note. |
-| `license` | SPDX identifier when reliable, otherwise the exact declared license name. |
-| `license_status` | Reviewed redistribution state such as allowed, restricted, blocked, or unknown, with evidence linkage. |
+| `source_project` | Upstream project or documented project-authored origin. |
+| `upstream_url` | Stable upstream project URL, or `null` for project-authored control material with no separate upstream. |
+| `version`, `version_evidence` | Exact version when supported and the current repository evidence for it; unresolved or conflicting versions remain `null`. |
+| `license`, `license_evidence` | SPDX identifier when reliable, otherwise the exact declared license name, with local or upstream evidence references. |
+| `license_status` | Reviewed redistribution state such as allowed, restricted, blocked, or unknown. An existing license claim is not treated as verified payload provenance. |
 | `sha256` | Lowercase SHA-256 of the exact checked-in bytes; no newline or binary normalization. |
 | `allowed_platforms` | Explicit platform/profile allowlist or a reviewed `all-supported` value. |
 | `runtime_trust_boundary` | Whether the file is privileged executable code, dynamically loaded code, unprivileged/browser code, data, or documentation-only material. |
@@ -198,8 +208,8 @@ redistribution review.
 | Stage | Scope | Exit condition |
 |---|---|---|
 | PR #72 | This documentation-only provenance, SBOM, and checksum-manifest plan. | Boundaries, current gaps, schema fields, stages, and future acceptance criteria are reviewable with no behavior change. |
-| PR #73 | Add the canonical vendor manifest and complete the initial provenance/license inventory. Classify copied third-party assets outside `backend/vendor/` and define deterministic SBOM output. | Every covered current file has one honest entry; unknowns are explicit; no payload is added or replaced merely to complete the inventory. |
-| PR #74 | Add CI schema and manifest-coverage checks, plus deterministic SBOM generation or validation once the chosen format is stable. | CI fails for missing, extra, duplicate, invalid, or stale manifest paths and can reproduce the reviewed SBOM representation. |
+| PR #73 | Add `backend/vendor/VENDOR_MANIFEST.json` for the 13 current files under `backend/vendor/` and record exact current SHA-256 values as non-enforced inventory metadata. Keep outside-tree assets as future audit candidates. | Every covered current file has one honest entry; unknowns are explicit; the manifest excludes its own recursive self-hash; no payload, CI, installer, or runtime behavior changes. |
+| PR #74 | Add CI schema and manifest-coverage checks. | CI fails for missing, extra, duplicate, invalid, or stale manifest paths. |
 | PR #75 | Add checksum verification, likely CI-only first. | Exact checked-in bytes and executable modes match reviewed entries; changes require a manifest diff; installer/runtime behavior remains unchanged unless separately approved. |
 | PR #76 | Add sanitized support-bundle provenance output. | A bundle can report bounded component, selection, provenance, and checksum status without arbitrary file reads or secret disclosure. |
 | PR #77 | Write the Flatpak architecture plan. | The UI/control-app boundary, daemon API, host installation/update ownership, and trust/update story are explicit before packaging starts. |


### PR DESCRIPTION
Adds the machine-readable vendor manifest for currently tracked backend/vendor files.

What changed:
- Added `backend/vendor/VENDOR_MANIFEST.json`.
- Updated `docs/VENDOR_PROVENANCE_SBOM_PLAN.md` to mark PR #73 as the manifest-addition step.
- Inventoried all 13 tracked non-manifest files under `backend/vendor/`.
- Recorded current SHA-256 values for all inventoried files.
- Recorded current executable flags and file classifications.
- Preserved unknown/unverified provenance gaps honestly.

Manifest scope:
- Covers only `backend/vendor/`.
- Excludes the manifest file itself to avoid recursive self-hash.
- Does not include outside-tree assets such as `assets/qrcode.js` or `assets/chart.js`.
- Does not claim complete SBOM coverage beyond `backend/vendor/`.

Known retained gaps:
- dnsmasq version/source/build provenance remains unknown.
- hostapd 2.11 and lnxrouter 0.8.1 are recorded with unverified origin/build lineage.
- libnl version remains unresolved because documented 3.10 claims conflict with embedded 3.11.0 evidence.
- Exact payload/license correspondence remains unverified.

Out of scope:
- No CI enforcement.
- No runtime enforcement.
- No installer behavior changes.
- No checksum enforcement.
- No support-bundle provenance output.
- No Flatpak work.
- No Steam Frame work.
- No adapter registry work.
- No HostFactsSnapshot work.
- No vendored payload or permission changes.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `628 passed, 4 subtests passed`

Review:
- `/tmp/vrhotspot-vendor-manifest-final-review-v2.md`
- SHA-256: `8bc0a81b673bc6aeff531fe8c9df30ae4101fdebd4014f1264847b698af6d1c4`
- Verdict: approve
