### PR TITLE
Add vendor manifest CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Ruff
         run: ruff check .
 
+      - name: Validate vendor manifest and generate deterministic vendor-only SBOM
+        run: python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json
+
       - name: Pytest
         run: pytest -q
 

--- a/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
+++ b/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
@@ -1,14 +1,15 @@
 # Vendor provenance, SBOM, and checksum manifest plan
 
-Status: PR #73 manifest-addition step; PR #72 established the documentation-only plan
+Status: PR #74 CI manifest-coverage and deterministic vendor-only SBOM step
 
 Date: 2026-07-22
 
 This document defines the supply-chain groundwork for files that VRhotspot
-ships from the repository. PR #73 adds the canonical machine-readable
+ships from the repository. PR #73 added the canonical machine-readable
 [`backend/vendor/VENDOR_MANIFEST.json`](../backend/vendor/VENDOR_MANIFEST.json)
-inventory. It does not generate an SBOM, verify or enforce a checksum, or
-change installation or runtime behavior.
+inventory. PR #74 validates that inventory in CI and generates a deterministic
+vendor-only SBOM under `/tmp`; it does not compare payload checksums or change
+installation or runtime behavior.
 
 ## Problem
 
@@ -31,11 +32,12 @@ The existing repository has useful but fragmented attribution:
   but the implemented support bundle does not report file provenance or
   checksum state.
 
-PR #73 establishes a canonical machine-readable inventory for the current
-`backend/vendor/` tree. There is still no generated SBOM, checksum enforcement,
-or proof that the inventoried bytes came from the documented sources. A
-successful version probe also does not prove that a file came from the
-documented source or that its bytes match a reviewed upstream artifact.
+PR #73 established a canonical machine-readable inventory for the current
+`backend/vendor/` tree. PR #74 can deterministically generate a temporary SBOM
+from that inventory, but there is still no payload checksum comparison or
+enforcement and no proof that the inventoried bytes came from the documented
+sources. A successful version probe also does not prove that a file came from
+the documented source or that its bytes match a reviewed upstream artifact.
 
 Future hardware support may increase pressure to add firmware, helper tools,
 driver-related material, device metadata, or other vendor-specific files. The
@@ -89,22 +91,23 @@ not imply that VRhotspot supplied or checksummed those host files.
   `backend/vendor/VENDOR_MANIFEST.json`, added by PR #73.
 - Derive a deterministic SBOM from reviewed manifest data rather than maintain
   a second hand-edited source of truth.
-- Add CI coverage for manifest completeness and schema validity in a later PR.
+- Add CI coverage for manifest completeness and schema validity in PR #74.
 - Add reviewed checksum verification in a later PR, likely in CI before any
   installer or runtime use.
 - Expose bounded, sanitized provenance status in support bundles later.
 - Make the acquisition and review process repeatable before another vendor
   asset can be added or updated.
 
-## PR #72 non-goals and PR #73 retained boundaries
+## PR #74 scope and retained boundaries
 
 - No runtime enforcement.
 - No installer behavior change or enforcement.
-- No CI behavior change in PR #73; manifest coverage remains future PR #74 work.
-- No checksum verification or enforcement in PR #73; that remains future PR
-  #75 work.
-- PR #73 adds `backend/vendor/VENDOR_MANIFEST.json`, but no generated SBOM
-  exists yet and the manifest does not claim repository-wide SBOM completeness.
+- PR #74 adds CI manifest structure, coverage, path, and executable-mode checks.
+- SHA-256 validation in PR #74 is syntax-only. Payload bytes are not hashed or
+  compared; checksum verification remains future PR #75 work.
+- PR #74 generates an untracked, deterministic CycloneDX JSON SBOM from the
+  manifest at `/tmp/vrhotspot-vendor-sbom.json`. It covers only
+  `backend/vendor/` and does not claim repository-wide SBOM completeness.
 - No new or replaced vendored binaries, libraries, firmware, scripts, or
   other vendor files.
 - No Steam Frame driver support.
@@ -160,10 +163,10 @@ The following rules govern subsequent implementation work:
 PR #73 selects reviewable JSON with `schema_version` `1.0.0` for the canonical
 manifest at `backend/vendor/VENDOR_MANIFEST.json`. Because the control file is
 inside the namespace it inventories, `manifest_scope.excluded_paths` explicitly
-excludes the manifest from self-hashing. PR #74 may validate that control file
-separately. Unknown historical facts are represented as `null`, `unknown`, or
-an explicit unverified/conflicting provenance status rather than filled with
-guesses.
+excludes the manifest from self-hashing. PR #74 validates that exclusion and
+the control file's structure separately. Unknown historical facts are
+represented as `null`, `unknown`, or an explicit unverified/conflicting
+provenance status rather than filled with guesses or rejected by CI.
 
 Each file entry has these fields:
 
@@ -192,10 +195,11 @@ level assumption.
 ### Manifest and SBOM roles
 
 The vendor manifest is the repository's reviewed file-level source of truth.
-An SBOM should be generated deterministically from it in SPDX or CycloneDX
-format once PR #73 has selected the representation and PR #74 has a validation
-path. The SBOM should identify shipped third-party components, versions,
-licenses, file relationships, and external system dependencies where useful.
+PR #74 generates CycloneDX 1.6 JSON deterministically from it. The generated
+document identifies the inventoried files, declared versions and licenses,
+declared SHA-256 values, and their relationship to the `backend/vendor/`
+inventory. It explicitly identifies its coverage as vendor-only rather than a
+full-project SBOM.
 
 The generated SBOM must not become a separately edited inventory. CI or a
 release process should be able to reproduce it from the same reviewed manifest,
@@ -203,13 +207,21 @@ and generation must not require downloading current upstream metadata. A
 component appearing in the SBOM does not replace its per-file checksum or
 redistribution review.
 
+`tools/ci/vendor_manifest_check.py` uses sorted entries and keys and emits no
+timestamp, hostname, absolute repository path, random identifier, or
+environment-derived field. CI writes the generated document only to
+`/tmp/vrhotspot-vendor-sbom.json`; it is not a tracked second source of truth.
+The tool checks that each declared SHA-256 is 64-character lowercase hex but
+does not read payload bytes to recompute it. That CI checksum comparison remains
+the separate PR #75 step, and runtime or installer enforcement remains absent.
+
 ## Staged roadmap
 
 | Stage | Scope | Exit condition |
 |---|---|---|
 | PR #72 | This documentation-only provenance, SBOM, and checksum-manifest plan. | Boundaries, current gaps, schema fields, stages, and future acceptance criteria are reviewable with no behavior change. |
 | PR #73 | Add `backend/vendor/VENDOR_MANIFEST.json` for the 13 current files under `backend/vendor/` and record exact current SHA-256 values as non-enforced inventory metadata. Keep outside-tree assets as future audit candidates. | Every covered current file has one honest entry; unknowns are explicit; the manifest excludes its own recursive self-hash; no payload, CI, installer, or runtime behavior changes. |
-| PR #74 | Add CI schema and manifest-coverage checks. | CI fails for missing, extra, duplicate, invalid, or stale manifest paths. |
+| PR #74 | Add CI schema, manifest-coverage, executable-mode, and deterministic vendor-only SBOM checks. | CI fails for missing, extra, duplicate, invalid, unsorted, outside-scope, or stale manifest paths and mode mismatches; SHA-256 is syntax-only and the untracked SBOM is reproducible. |
 | PR #75 | Add checksum verification, likely CI-only first. | Exact checked-in bytes and executable modes match reviewed entries; changes require a manifest diff; installer/runtime behavior remains unchanged unless separately approved. |
 | PR #76 | Add sanitized support-bundle provenance output. | A bundle can report bounded component, selection, provenance, and checksum status without arbitrary file reads or secret disclosure. |
 | PR #77 | Write the Flatpak architecture plan. | The UI/control-app boundary, daemon API, host installation/update ownership, and trust/update story are explicit before packaging starts. |

--- a/tests/test_vendor_manifest.py
+++ b/tests/test_vendor_manifest.py
@@ -1,0 +1,114 @@
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.ci import vendor_manifest_check as checker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_FILE = ROOT / checker.MANIFEST_PATH
+
+
+def _manifest():
+    return checker.load_manifest(MANIFEST_FILE)
+
+
+def _errors(manifest):
+    tracked = checker.discover_tracked_vendor_files(ROOT)
+    return checker.validate_manifest(manifest, tracked, ROOT)
+
+
+def test_repository_vendor_manifest_is_structurally_valid_and_complete():
+    assert _errors(_manifest()) == []
+
+
+def test_manifest_json_parse_failure_is_reported(tmp_path):
+    invalid_manifest = tmp_path / "VENDOR_MANIFEST.json"
+    invalid_manifest.write_text('{"schema_version":', encoding="utf-8")
+
+    with pytest.raises(checker.ManifestLoadError, match="cannot parse"):
+        checker.load_manifest(invalid_manifest)
+
+
+def test_manifest_requires_schema_entry_fields_and_lowercase_sha256():
+    manifest = _manifest()
+    manifest.pop("schema_version")
+    manifest["files"][0].pop("purpose")
+    manifest["files"][0]["sha256"] = "A" * 64
+
+    errors = _errors(manifest)
+
+    assert "manifest is missing required top-level field: schema_version" in errors
+    assert "files[0] is missing required field: purpose" in errors
+    assert "files[0].sha256 must be exactly 64 lowercase hexadecimal characters" in errors
+
+
+def test_manifest_rejects_duplicate_unsorted_missing_and_outside_paths():
+    duplicate = _manifest()
+    duplicate["files"].append(deepcopy(duplicate["files"][0]))
+    duplicate["manifest_scope"]["entry_count"] += 1
+    assert any("manifest path appears more than once" in error for error in _errors(duplicate))
+
+    unsorted = _manifest()
+    unsorted["files"][0], unsorted["files"][1] = unsorted["files"][1], unsorted["files"][0]
+    assert "manifest files entries must be sorted lexicographically by path" in _errors(unsorted)
+
+    missing = _manifest()
+    removed_path = missing["files"].pop()["path"]
+    missing["manifest_scope"]["entry_count"] -= 1
+    assert f"tracked vendor file is missing a manifest entry: {removed_path}" in _errors(missing)
+
+    outside = _manifest()
+    outside["files"][0]["path"] = "README.md"
+    outside_errors = _errors(outside)
+    assert any("points outside backend/vendor/" in error for error in outside_errors)
+    assert any("tracked vendor file is missing a manifest entry" in error for error in outside_errors)
+
+
+def test_manifest_excludes_itself_and_matches_executable_modes():
+    manifest = _manifest()
+    assert manifest["manifest_scope"]["excluded_paths"][0]["path"] == checker.MANIFEST_PATH
+
+    manifest["files"][0]["executable"] = not manifest["files"][0]["executable"]
+    errors = _errors(manifest)
+
+    assert any("manifest executable does not match Git mode" in error for error in errors)
+    assert any("manifest executable does not match working-tree mode" in error for error in errors)
+
+
+def test_unknown_provenance_and_valid_declared_hash_are_not_payload_failures():
+    manifest = _manifest()
+    manifest["files"][0]["license_status"] = "unknown"
+    manifest["files"][0]["provenance_status"] = "unknown_unverified"
+    manifest["files"][0]["sha256"] = "0" * 64
+
+    assert _errors(manifest) == []
+
+
+def test_vendor_sbom_is_deterministic_sorted_and_bounded():
+    manifest = _manifest()
+    expected = checker.render_sbom(manifest)
+    reordered = deepcopy(manifest)
+    reordered["files"].reverse()
+
+    assert checker.render_sbom(reordered) == expected
+
+    sbom = json.loads(expected)
+    component_paths = [component["bom-ref"] for component in sbom["components"]]
+    declared_hashes = {entry["path"]: entry["sha256"] for entry in manifest["files"]}
+
+    assert component_paths == sorted(component_paths)
+    assert len(component_paths) == manifest["manifest_scope"]["entry_count"]
+    assert all(
+        component["hashes"] == [
+            {"alg": "SHA-256", "content": declared_hashes[component["bom-ref"]]}
+        ]
+        for component in sbom["components"]
+    )
+    assert "backend/vendor only; not a full-project SBOM" in expected
+    assert "syntax-only; payload bytes not compared" in expected
+    assert "timestamp" not in expected
+    assert "serialNumber" not in expected
+    assert str(ROOT) not in expected

--- a/tools/ci/vendor_manifest_check.py
+++ b/tools/ci/vendor_manifest_check.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""Validate the source-tree vendor manifest and emit a deterministic vendor-only SBOM.
+
+This CI tool intentionally validates only SHA-256 syntax. It does not hash or compare
+vendored payload bytes and is not installer or runtime security enforcement.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+import subprocess
+import sys
+from typing import Any, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VENDOR_ROOT = "backend/vendor/"
+MANIFEST_PATH = "backend/vendor/VENDOR_MANIFEST.json"
+POLICY_PATH = "docs/VENDOR_PROVENANCE_SBOM_PLAN.md"
+DEFAULT_SBOM_PATH = Path("/tmp/vrhotspot-vendor-sbom.json")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+REQUIRED_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "maintained_by",
+        "policy_doc",
+        "enforcement_status",
+        "notes",
+        "manifest_scope",
+        "hashing",
+        "files",
+    }
+)
+REQUIRED_SCOPE_FIELDS = frozenset({"root", "entry_count", "coverage", "excluded_paths"})
+REQUIRED_HASHING_FIELDS = frozenset({"algorithm", "input", "status"})
+REQUIRED_ENTRY_FIELDS = frozenset(
+    {
+        "path",
+        "file_type",
+        "executable",
+        "purpose",
+        "source_project",
+        "upstream_url",
+        "version",
+        "version_evidence",
+        "license",
+        "license_evidence",
+        "license_status",
+        "sha256",
+        "allowed_platforms",
+        "runtime_trust_boundary",
+        "update_process",
+        "provenance_status",
+        "reviewer_notes",
+    }
+)
+
+
+class ManifestLoadError(ValueError):
+    """The manifest could not be loaded as a JSON object."""
+
+
+class VendorTreeError(RuntimeError):
+    """The tracked vendor tree could not be inspected."""
+
+
+@dataclass(frozen=True)
+class TrackedFile:
+    path: str
+    git_mode: str
+
+    @property
+    def executable(self) -> bool:
+        return self.git_mode == "100755"
+
+    @property
+    def regular(self) -> bool:
+        return self.git_mode in {"100644", "100755"}
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ManifestLoadError(f"cannot parse {path}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestLoadError(f"cannot parse {path}: top-level JSON value must be an object")
+    return manifest
+
+
+def discover_tracked_vendor_files(repo_root: Path) -> list[TrackedFile]:
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "--stage", "-z", "--", VENDOR_ROOT.rstrip("/")],
+            cwd=repo_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise VendorTreeError(f"cannot inspect tracked vendor files: {exc}") from exc
+    if completed.returncode != 0:
+        detail = os.fsdecode(completed.stderr).strip() or "git ls-files failed"
+        raise VendorTreeError(detail)
+
+    tracked: list[TrackedFile] = []
+    for raw_record in completed.stdout.split(b"\0"):
+        if not raw_record:
+            continue
+        record = os.fsdecode(raw_record)
+        try:
+            metadata, path = record.split("\t", 1)
+            mode, _object_id, stage = metadata.split(" ")
+        except ValueError as exc:
+            raise VendorTreeError(f"unexpected git ls-files record: {record!r}") from exc
+        if stage != "0":
+            raise VendorTreeError(f"unmerged vendor path is not valid manifest input: {path}")
+        tracked.append(TrackedFile(path=path, git_mode=mode))
+    return sorted(tracked, key=lambda item: item.path)
+
+
+def _missing_fields(value: dict[str, Any], required: frozenset[str]) -> list[str]:
+    return sorted(required.difference(value))
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_string_list(
+    errors: list[str], value: Any, label: str, *, require_nonempty: bool = False
+) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be an array of non-empty strings")
+        return
+    if require_nonempty and not value:
+        errors.append(f"{label} must not be empty")
+    for index, item in enumerate(value):
+        if not _is_nonempty_string(item):
+            errors.append(f"{label}[{index}] must be a non-empty string")
+
+
+def _validate_repository_path(path: Any, label: str, errors: list[str]) -> bool:
+    if not _is_nonempty_string(path):
+        errors.append(f"{label} must be a non-empty repository-relative path")
+        return False
+    if "\\" in path:
+        errors.append(f"{label} must use forward slashes: {path!r}")
+        return False
+
+    parsed = PurePosixPath(path)
+    normalized = parsed.as_posix()
+    if parsed.is_absolute() or path != normalized or any(part in {".", ".."} for part in parsed.parts):
+        errors.append(f"{label} is not a normalized repository-relative path: {path!r}")
+        return False
+    if not path.startswith(VENDOR_ROOT) or path == VENDOR_ROOT.rstrip("/"):
+        errors.append(f"{label} points outside {VENDOR_ROOT}: {path!r}")
+        return False
+    return True
+
+
+def _validate_top_level(manifest: dict[str, Any], errors: list[str]) -> None:
+    for field in _missing_fields(manifest, REQUIRED_TOP_LEVEL_FIELDS):
+        errors.append(f"manifest is missing required top-level field: {field}")
+
+    if manifest.get("schema_version") != "1.0.0":
+        errors.append("schema_version must be the supported value '1.0.0'")
+    if not _is_nonempty_string(manifest.get("maintained_by")):
+        errors.append("maintained_by must be a non-empty string")
+    if manifest.get("policy_doc") != POLICY_PATH:
+        errors.append(f"policy_doc must be {POLICY_PATH!r}")
+    if manifest.get("enforcement_status") != "inventory_only_not_enforced":
+        errors.append("enforcement_status must remain 'inventory_only_not_enforced' for PR #74")
+    _validate_string_list(errors, manifest.get("notes"), "notes", require_nonempty=True)
+
+
+def _validate_scope(manifest: dict[str, Any], errors: list[str]) -> None:
+    scope = manifest.get("manifest_scope")
+    if not isinstance(scope, dict):
+        errors.append("manifest_scope must be an object")
+        return
+    for field in _missing_fields(scope, REQUIRED_SCOPE_FIELDS):
+        errors.append(f"manifest_scope is missing required field: {field}")
+
+    if scope.get("root") != VENDOR_ROOT:
+        errors.append(f"manifest_scope.root must be {VENDOR_ROOT!r}")
+    if not _is_nonempty_string(scope.get("coverage")):
+        errors.append("manifest_scope.coverage must be a non-empty string")
+
+    files = manifest.get("files")
+    expected_count = len(files) if isinstance(files, list) else None
+    entry_count = scope.get("entry_count")
+    if type(entry_count) is not int:
+        errors.append("manifest_scope.entry_count must be an integer")
+    elif expected_count is not None and entry_count != expected_count:
+        errors.append(
+            "manifest_scope.entry_count does not match files length: "
+            f"{entry_count} != {expected_count}"
+        )
+
+    excluded = scope.get("excluded_paths")
+    if not isinstance(excluded, list):
+        errors.append("manifest_scope.excluded_paths must be an array")
+        return
+
+    excluded_paths: list[str] = []
+    for index, record in enumerate(excluded):
+        label = f"manifest_scope.excluded_paths[{index}]"
+        if not isinstance(record, dict):
+            errors.append(f"{label} must be an object")
+            continue
+        path = record.get("path")
+        if _validate_repository_path(path, f"{label}.path", errors):
+            excluded_paths.append(path)
+        if not _is_nonempty_string(record.get("reason")):
+            errors.append(f"{label}.reason must be a non-empty string")
+
+    if excluded_paths != [MANIFEST_PATH]:
+        errors.append(
+            "manifest_scope.excluded_paths must contain only the manifest control file "
+            f"{MANIFEST_PATH!r}"
+        )
+
+
+def _validate_hashing(manifest: dict[str, Any], errors: list[str]) -> None:
+    hashing = manifest.get("hashing")
+    if not isinstance(hashing, dict):
+        errors.append("hashing must be an object")
+        return
+    for field in _missing_fields(hashing, REQUIRED_HASHING_FIELDS):
+        errors.append(f"hashing is missing required field: {field}")
+    if hashing.get("algorithm") != "SHA-256":
+        errors.append("hashing.algorithm must be 'SHA-256'")
+    if hashing.get("input") != "exact_file_bytes":
+        errors.append("hashing.input must be 'exact_file_bytes'")
+    if hashing.get("status") != "recorded_not_enforced":
+        errors.append("hashing.status must remain 'recorded_not_enforced' for PR #74")
+
+
+def _validate_entry(entry: Any, index: int, errors: list[str]) -> Optional[str]:
+    label = f"files[{index}]"
+    if not isinstance(entry, dict):
+        errors.append(f"{label} must be an object")
+        return None
+
+    for field in _missing_fields(entry, REQUIRED_ENTRY_FIELDS):
+        errors.append(f"{label} is missing required field: {field}")
+
+    path = entry.get("path")
+    valid_path = _validate_repository_path(path, f"{label}.path", errors)
+
+    for field in (
+        "file_type",
+        "purpose",
+        "source_project",
+        "license",
+        "license_status",
+        "runtime_trust_boundary",
+        "update_process",
+        "provenance_status",
+    ):
+        if not _is_nonempty_string(entry.get(field)):
+            errors.append(f"{label}.{field} must be a non-empty string")
+
+    if type(entry.get("executable")) is not bool:
+        errors.append(f"{label}.executable must be a boolean")
+    for field in ("upstream_url", "version"):
+        value = entry.get(field)
+        if value is not None and not _is_nonempty_string(value):
+            errors.append(f"{label}.{field} must be null or a non-empty string")
+    for field in ("version_evidence", "license_evidence", "reviewer_notes"):
+        _validate_string_list(errors, entry.get(field), f"{label}.{field}")
+    _validate_string_list(
+        errors, entry.get("allowed_platforms"), f"{label}.allowed_platforms", require_nonempty=True
+    )
+
+    sha256 = entry.get("sha256")
+    if not isinstance(sha256, str) or SHA256_RE.fullmatch(sha256) is None:
+        errors.append(f"{label}.sha256 must be exactly 64 lowercase hexadecimal characters")
+    return path if valid_path else None
+
+
+def _worktree_executable(path: Path) -> bool:
+    mode = path.stat().st_mode
+    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def _validate_coverage_and_modes(
+    manifest: dict[str, Any],
+    tracked_files: list[TrackedFile],
+    repo_root: Path,
+    entry_paths: list[str],
+    errors: list[str],
+) -> None:
+    tracked_by_path = {item.path: item for item in tracked_files}
+    manifest_control = tracked_by_path.get(MANIFEST_PATH)
+    if manifest_control is None:
+        errors.append(f"manifest control file is not tracked: {MANIFEST_PATH}")
+    elif not manifest_control.regular:
+        errors.append(f"manifest control file must be a regular Git file: {MANIFEST_PATH}")
+
+    if MANIFEST_PATH in entry_paths:
+        errors.append(f"manifest control file must be excluded from files entries: {MANIFEST_PATH}")
+
+    expected_paths = set(tracked_by_path).difference({MANIFEST_PATH})
+    actual_paths = set(entry_paths)
+    for path in sorted(expected_paths.difference(actual_paths)):
+        errors.append(f"tracked vendor file is missing a manifest entry: {path}")
+    for path in sorted(actual_paths.difference(expected_paths)):
+        errors.append(f"manifest entry is not a tracked non-manifest vendor file: {path}")
+
+    entries = manifest.get("files")
+    entries_by_path = {}
+    if isinstance(entries, list):
+        entries_by_path = {
+            entry.get("path"): entry
+            for entry in entries
+            if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+        }
+
+    for path in sorted(expected_paths):
+        tracked = tracked_by_path[path]
+        if not tracked.regular:
+            errors.append(f"tracked vendor path is not a regular Git file: {path} ({tracked.git_mode})")
+            continue
+
+        worktree_path = repo_root.joinpath(*PurePosixPath(path).parts)
+        if worktree_path.is_symlink():
+            errors.append(f"tracked vendor path must not be a symlink: {path}")
+            continue
+        if not worktree_path.is_file():
+            errors.append(f"tracked vendor file is missing from the working tree: {path}")
+            continue
+
+        worktree_executable = _worktree_executable(worktree_path)
+        if worktree_executable != tracked.executable:
+            errors.append(
+                f"working-tree executable mode differs from Git mode for {path}: "
+                f"working tree={worktree_executable}, git={tracked.executable}"
+            )
+
+        entry = entries_by_path.get(path)
+        if isinstance(entry, dict) and type(entry.get("executable")) is bool:
+            declared = entry["executable"]
+            if declared != tracked.executable:
+                errors.append(
+                    f"manifest executable does not match Git mode for {path}: "
+                    f"manifest={declared}, git={tracked.executable}"
+                )
+            if declared != worktree_executable:
+                errors.append(
+                    f"manifest executable does not match working-tree mode for {path}: "
+                    f"manifest={declared}, working tree={worktree_executable}"
+                )
+
+
+def validate_manifest(
+    manifest: dict[str, Any], tracked_files: list[TrackedFile], repo_root: Path
+) -> list[str]:
+    """Return deterministic structural and source-tree consistency errors."""
+
+    errors: list[str] = []
+    _validate_top_level(manifest, errors)
+    _validate_scope(manifest, errors)
+    _validate_hashing(manifest, errors)
+
+    files = manifest.get("files")
+    entry_paths: list[str] = []
+    if not isinstance(files, list):
+        errors.append("files must be an array")
+    else:
+        for index, entry in enumerate(files):
+            path = _validate_entry(entry, index, errors)
+            if path is not None:
+                entry_paths.append(path)
+
+    duplicate_paths = sorted(path for path, count in Counter(entry_paths).items() if count > 1)
+    for path in duplicate_paths:
+        errors.append(f"manifest path appears more than once: {path}")
+    if entry_paths != sorted(entry_paths):
+        errors.append("manifest files entries must be sorted lexicographically by path")
+
+    _validate_coverage_and_modes(manifest, tracked_files, repo_root, entry_paths, errors)
+    return errors
+
+
+def _component_properties(entry: dict[str, Any]) -> list[dict[str, str]]:
+    values = {
+        "vrhotspot:allowed-platforms": json.dumps(
+            entry["allowed_platforms"], ensure_ascii=False, separators=(",", ":")
+        ),
+        "vrhotspot:executable": str(entry["executable"]).lower(),
+        "vrhotspot:file-type": entry["file_type"],
+        "vrhotspot:license-status": entry["license_status"],
+        "vrhotspot:provenance-status": entry["provenance_status"],
+        "vrhotspot:runtime-trust-boundary": entry["runtime_trust_boundary"],
+        "vrhotspot:sha256-verification": "declared-syntax-only-not-compared",
+        "vrhotspot:source-project": entry["source_project"],
+    }
+    return [{"name": name, "value": values[name]} for name in sorted(values)]
+
+
+def generate_sbom(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Generate deterministic CycloneDX JSON data covering only backend/vendor."""
+
+    components: list[dict[str, Any]] = []
+    for entry in sorted(manifest["files"], key=lambda item: item["path"]):
+        component: dict[str, Any] = {
+            "bom-ref": entry["path"],
+            "description": entry["purpose"],
+            "hashes": [{"alg": "SHA-256", "content": entry["sha256"]}],
+            "licenses": [{"license": {"name": entry["license"]}}],
+            "name": entry["path"],
+            "properties": _component_properties(entry),
+            "type": "file",
+        }
+        if entry["upstream_url"] is not None:
+            component["externalReferences"] = [
+                {"type": "website", "url": entry["upstream_url"]}
+            ]
+        if entry["version"] is not None:
+            component["version"] = entry["version"]
+        components.append(component)
+
+    component_refs = [component["bom-ref"] for component in components]
+    return {
+        "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+        "bomFormat": "CycloneDX",
+        "components": components,
+        "dependencies": [
+            {
+                "dependsOn": component_refs,
+                "ref": "vrhotspot:backend/vendor-inventory",
+            }
+        ],
+        "metadata": {
+            "component": {
+                "bom-ref": "vrhotspot:backend/vendor-inventory",
+                "name": "VRhotspot backend/vendor inventory",
+                "properties": [
+                    {
+                        "name": "vrhotspot:coverage",
+                        "value": "backend/vendor only; not a full-project SBOM",
+                    },
+                    {
+                        "name": "vrhotspot:manifest-schema-version",
+                        "value": manifest["schema_version"],
+                    },
+                    {"name": "vrhotspot:source-manifest", "value": MANIFEST_PATH},
+                    {
+                        "name": "vrhotspot:sha256-verification",
+                        "value": "syntax-only; payload bytes not compared",
+                    },
+                ],
+                "type": "data",
+            }
+        },
+        "specVersion": "1.6",
+        "version": 1,
+    }
+
+
+def render_sbom(manifest: dict[str, Any]) -> str:
+    return json.dumps(generate_sbom(manifest), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _parse_args(argv: Optional[list[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sbom-output",
+        type=Path,
+        default=DEFAULT_SBOM_PATH,
+        help=f"deterministic generated SBOM path (default: {DEFAULT_SBOM_PATH})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    manifest_file = REPO_ROOT / MANIFEST_PATH
+    try:
+        manifest = load_manifest(manifest_file)
+        tracked_files = discover_tracked_vendor_files(REPO_ROOT)
+    except (ManifestLoadError, VendorTreeError) as exc:
+        print(f"vendor manifest validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate_manifest(manifest, tracked_files, REPO_ROOT)
+    if errors:
+        print("vendor manifest validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    sbom_text = render_sbom(manifest)
+    try:
+        args.sbom_output.write_text(sbom_text, encoding="utf-8")
+    except OSError as exc:
+        print(f"could not write deterministic vendor SBOM to {args.sbom_output}: {exc}", file=sys.stderr)
+        return 1
+
+    vendor_file_count = len(manifest["files"])
+    print(f"vendor manifest validation passed: {vendor_file_count} tracked files covered")
+    print(
+        f"deterministic vendor-only SBOM written: {args.sbom_output} "
+        f"({vendor_file_count} file components)"
+    )
+    print("SHA-256 validation: syntax only; payload bytes were not compared")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds CI/test coverage for the vendor manifest and deterministic vendor-only SBOM handling.

What changed:
- Added `tools/ci/vendor_manifest_check.py`.
- Added `tests/test_vendor_manifest.py`.
- Wired the vendor manifest validator into GitHub Actions.
- Updated `docs/VENDOR_PROVENANCE_SBOM_PLAN.md` to mark PR #74 as the CI manifest coverage / deterministic SBOM handling step.

Validator behavior:
- Offline and standard-library only.
- Validates manifest JSON parseability.
- Validates required top-level metadata.
- Validates required per-entry fields.
- Validates unique and deterministic backend/vendor paths.
- Validates exact tracked backend/vendor coverage.
- Rejects outside-scope paths, untracked paths, missing paths, symlinks, and manifest self-inclusion.
- Validates executable field against current source-tree file modes.
- Validates SHA-256 fields as lowercase 64-character hex syntax only.
- Allows unknown/unverified provenance values.

Deterministic SBOM behavior:
- Generates a vendor-only CycloneDX 1.6 JSON SBOM.
- Covers only backend/vendor manifest entries.
- Sorts entries and JSON keys.
- Avoids timestamps, hostnames, absolute repo paths, random IDs, and environment-specific data.
- Writes generated SBOM output to `/tmp/vrhotspot-vendor-sbom.json`.
- Does not track generated SBOM output.

Boundary:
- SHA-256 validation is syntax-only.
- No payload-byte SHA-256 comparison was added.
- No runtime checksum enforcement was added.
- No installer checksum enforcement was added.
- PR #75 remains the future checksum verification/enforcement step.

Out of scope:
- No runtime code changes.
- No installer behavior changes.
- No vendored payload or permission changes.
- No support-bundle provenance output.
- No Flatpak work.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest tests/test_vendor_manifest.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `7 passed` focused vendor manifest tests
- `635 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-vendor-ci-coverage-final-review.md`
- SHA-256: `77afcf9e641d1121c1f97b15fd40ac28ef110341b27b66790b417a511e4397b5`
- Verdict: approve
