### PR TITLE
Verify vendor manifest checksums in CI

### DIFF
--- a/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
+++ b/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
@@ -1,6 +1,6 @@
 # Vendor provenance, SBOM, and checksum manifest plan
 
-Status: PR #74 CI manifest-coverage and deterministic vendor-only SBOM step
+Status: PR #75 CI/source-tree payload SHA-256 verification
 
 Date: 2026-07-22
 
@@ -8,8 +8,9 @@ This document defines the supply-chain groundwork for files that VRhotspot
 ships from the repository. PR #73 added the canonical machine-readable
 [`backend/vendor/VENDOR_MANIFEST.json`](../backend/vendor/VENDOR_MANIFEST.json)
 inventory. PR #74 validates that inventory in CI and generates a deterministic
-vendor-only SBOM under `/tmp`; it does not compare payload checksums or change
-installation or runtime behavior.
+vendor-only SBOM under `/tmp`. PR #75 extends that existing validator to compare
+each declared SHA-256 with the exact bytes in the committed source tree. This
+does not change installation or runtime behavior.
 
 ## Problem
 
@@ -34,7 +35,8 @@ The existing repository has useful but fragmented attribution:
 
 PR #73 established a canonical machine-readable inventory for the current
 `backend/vendor/` tree. PR #74 can deterministically generate a temporary SBOM
-from that inventory, but there is still no payload checksum comparison or
+from that inventory, and PR #75 verifies that current source-tree payload bytes
+match the committed manifest. There is still no installer or runtime checksum
 enforcement and no proof that the inventoried bytes came from the documented
 sources. A successful version probe also does not prove that a file came from
 the documented source or that its bytes match a reviewed upstream artifact.
@@ -92,22 +94,27 @@ not imply that VRhotspot supplied or checksummed those host files.
 - Derive a deterministic SBOM from reviewed manifest data rather than maintain
   a second hand-edited source of truth.
 - Add CI coverage for manifest completeness and schema validity in PR #74.
-- Add reviewed checksum verification in a later PR, likely in CI before any
-  installer or runtime use.
-- Expose bounded, sanitized provenance status in support bundles later.
+- Add CI/source-tree payload checksum verification in PR #75 without installer
+  or runtime enforcement.
+- Expose bounded, sanitized provenance status in support bundles in future PR
+  #76.
 - Make the acquisition and review process repeatable before another vendor
   asset can be added or updated.
 
-## PR #74 scope and retained boundaries
+## PR #75 scope and retained boundaries
 
 - No runtime enforcement.
 - No installer behavior change or enforcement.
 - PR #74 adds CI manifest structure, coverage, path, and executable-mode checks.
-- SHA-256 validation in PR #74 is syntax-only. Payload bytes are not hashed or
-  compared; checksum verification remains future PR #75 work.
+- PR #75 extends the existing CI/source-tree validator to hash exact current
+  file bytes and compare them with each manifest SHA-256.
+- This is committed-tree consistency checking, not end-user runtime tamper
+  protection. Installed files are not checked.
 - PR #74 generates an untracked, deterministic CycloneDX JSON SBOM from the
   manifest at `/tmp/vrhotspot-vendor-sbom.json`. It covers only
-  `backend/vendor/` and does not claim repository-wide SBOM completeness.
+  `backend/vendor/` and does not claim repository-wide SBOM completeness. PR
+  #75 does not change its deterministic generation behavior.
+- Support-bundle provenance output remains future PR #76 work.
 - No new or replaced vendored binaries, libraries, firmware, scripts, or
   other vendor files.
 - No Steam Frame driver support.
@@ -142,9 +149,9 @@ The following rules govern subsequent implementation work:
    credentials, tokens, account data, and other unrelated content must not be
    committed or included in support bundles.
 6. Existing bundled hostapd-, dnsmasq-, lnxrouter-, and libnl-style assets must
-   be fully documented before checksum enforcement is introduced. Current
-   filenames, executable bits, version output, or notices are evidence inputs;
-   none alone proves origin or integrity.
+   be fully documented before installer or runtime checksum enforcement is
+   introduced. Current filenames, executable bits, version output, or notices
+   are evidence inputs; none alone proves origin or integrity.
 7. A changed payload byte, executable bit, source reference, license status,
    platform allowlist, or trust-boundary classification requires explicit
    manifest review. Checksum-only update commits without a source/update
@@ -211,9 +218,11 @@ redistribution review.
 timestamp, hostname, absolute repository path, random identifier, or
 environment-derived field. CI writes the generated document only to
 `/tmp/vrhotspot-vendor-sbom.json`; it is not a tracked second source of truth.
-The tool checks that each declared SHA-256 is 64-character lowercase hex but
-does not read payload bytes to recompute it. That CI checksum comparison remains
-the separate PR #75 step, and runtime or installer enforcement remains absent.
+PR #75 keeps those deterministic SBOM properties and extends the tool to compare
+each declared SHA-256 with the exact current source-tree file bytes before
+writing the SBOM. The manifest control file remains excluded from its own
+recursive hash. This comparison is CI/source-tree validation only; runtime and
+installer checksum enforcement remain absent.
 
 ## Staged roadmap
 
@@ -222,7 +231,7 @@ the separate PR #75 step, and runtime or installer enforcement remains absent.
 | PR #72 | This documentation-only provenance, SBOM, and checksum-manifest plan. | Boundaries, current gaps, schema fields, stages, and future acceptance criteria are reviewable with no behavior change. |
 | PR #73 | Add `backend/vendor/VENDOR_MANIFEST.json` for the 13 current files under `backend/vendor/` and record exact current SHA-256 values as non-enforced inventory metadata. Keep outside-tree assets as future audit candidates. | Every covered current file has one honest entry; unknowns are explicit; the manifest excludes its own recursive self-hash; no payload, CI, installer, or runtime behavior changes. |
 | PR #74 | Add CI schema, manifest-coverage, executable-mode, and deterministic vendor-only SBOM checks. | CI fails for missing, extra, duplicate, invalid, unsorted, outside-scope, or stale manifest paths and mode mismatches; SHA-256 is syntax-only and the untracked SBOM is reproducible. |
-| PR #75 | Add checksum verification, likely CI-only first. | Exact checked-in bytes and executable modes match reviewed entries; changes require a manifest diff; installer/runtime behavior remains unchanged unless separately approved. |
+| PR #75 | Add CI/source-tree payload checksum verification. | Exact committed-tree bytes and executable modes match reviewed entries; changes require a manifest diff; this is not end-user runtime tamper protection, and installer/runtime behavior remains unchanged. |
 | PR #76 | Add sanitized support-bundle provenance output. | A bundle can report bounded component, selection, provenance, and checksum status without arbitrary file reads or secret disclosure. |
 | PR #77 | Write the Flatpak architecture plan. | The UI/control-app boundary, daemon API, host installation/update ownership, and trust/update story are explicit before packaging starts. |
 | PR #81+ | Begin Steam Frame / VR Direct Link evidence and adapter-intelligence work only after explicit approval. | Research starts from lawful, user-provided or public evidence and derived metadata, not redistributed drivers or automatic depot downloads. |

--- a/tests/test_vendor_manifest.py
+++ b/tests/test_vendor_manifest.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import hashlib
 import json
 from pathlib import Path
 
@@ -20,8 +21,16 @@ def _errors(manifest):
     return checker.validate_manifest(manifest, tracked, ROOT)
 
 
-def test_repository_vendor_manifest_is_structurally_valid_and_complete():
+def test_repository_vendor_manifest_is_valid_complete_and_payload_hashes_match():
     assert _errors(_manifest()) == []
+
+
+def test_repository_payload_bytes_match_declared_sha256_values():
+    manifest = _manifest()
+
+    for entry in manifest["files"]:
+        payload = ROOT / entry["path"]
+        assert hashlib.sha256(payload.read_bytes()).hexdigest() == entry["sha256"]
 
 
 def test_manifest_json_parse_failure_is_reported(tmp_path):
@@ -78,11 +87,18 @@ def test_manifest_excludes_itself_and_matches_executable_modes():
     assert any("manifest executable does not match working-tree mode" in error for error in errors)
 
 
-def test_unknown_provenance_and_valid_declared_hash_are_not_payload_failures():
+def test_manifest_rejects_sha256_that_does_not_match_current_file_bytes():
+    manifest = _manifest()
+    path = manifest["files"][0]["path"]
+    manifest["files"][0]["sha256"] = "0" * 64
+
+    assert f"manifest SHA-256 does not match current file bytes for {path}" in _errors(manifest)
+
+
+def test_unknown_provenance_fields_remain_allowed():
     manifest = _manifest()
     manifest["files"][0]["license_status"] = "unknown"
     manifest["files"][0]["provenance_status"] = "unknown_unverified"
-    manifest["files"][0]["sha256"] = "0" * 64
 
     assert _errors(manifest) == []
 
@@ -108,7 +124,8 @@ def test_vendor_sbom_is_deterministic_sorted_and_bounded():
         for component in sbom["components"]
     )
     assert "backend/vendor only; not a full-project SBOM" in expected
-    assert "syntax-only; payload bytes not compared" in expected
+    assert "CI/source-tree payload bytes compared before SBOM output" in expected
+    assert "syntax-only" not in expected
     assert "timestamp" not in expected
     assert "serialNumber" not in expected
     assert str(ROOT) not in expected

--- a/tools/ci/vendor_manifest_check.py
+++ b/tools/ci/vendor_manifest_check.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Validate the source-tree vendor manifest and emit a deterministic vendor-only SBOM.
 
-This CI tool intentionally validates only SHA-256 syntax. It does not hash or compare
-vendored payload bytes and is not installer or runtime security enforcement.
+This CI tool compares declared SHA-256 values with current vendored file bytes. It is
+committed-tree consistency checking, not installer or runtime security enforcement.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 from collections import Counter
 from dataclasses import dataclass
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -178,7 +179,10 @@ def _validate_top_level(manifest: dict[str, Any], errors: list[str]) -> None:
     if manifest.get("policy_doc") != POLICY_PATH:
         errors.append(f"policy_doc must be {POLICY_PATH!r}")
     if manifest.get("enforcement_status") != "inventory_only_not_enforced":
-        errors.append("enforcement_status must remain 'inventory_only_not_enforced' for PR #74")
+        errors.append(
+            "enforcement_status must remain 'inventory_only_not_enforced' "
+            "for CI/source-tree verification"
+        )
     _validate_string_list(errors, manifest.get("notes"), "notes", require_nonempty=True)
 
 
@@ -242,7 +246,10 @@ def _validate_hashing(manifest: dict[str, Any], errors: list[str]) -> None:
     if hashing.get("input") != "exact_file_bytes":
         errors.append("hashing.input must be 'exact_file_bytes'")
     if hashing.get("status") != "recorded_not_enforced":
-        errors.append("hashing.status must remain 'recorded_not_enforced' for PR #74")
+        errors.append(
+            "hashing.status must remain 'recorded_not_enforced' "
+            "for CI/source-tree verification"
+        )
 
 
 def _validate_entry(entry: Any, index: int, errors: list[str]) -> Optional[str]:
@@ -293,7 +300,15 @@ def _worktree_executable(path: Path) -> bool:
     return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
 
 
-def _validate_coverage_and_modes(
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as payload:
+        for chunk in iter(lambda: payload.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_source_tree(
     manifest: dict[str, Any],
     tracked_files: list[TrackedFile],
     repo_root: Path,
@@ -348,7 +363,10 @@ def _validate_coverage_and_modes(
             )
 
         entry = entries_by_path.get(path)
-        if isinstance(entry, dict) and type(entry.get("executable")) is bool:
+        if not isinstance(entry, dict):
+            continue
+
+        if type(entry.get("executable")) is bool:
             declared = entry["executable"]
             if declared != tracked.executable:
                 errors.append(
@@ -360,6 +378,17 @@ def _validate_coverage_and_modes(
                     f"manifest executable does not match working-tree mode for {path}: "
                     f"manifest={declared}, working tree={worktree_executable}"
                 )
+
+        declared_sha256 = entry.get("sha256")
+        if not isinstance(declared_sha256, str) or SHA256_RE.fullmatch(declared_sha256) is None:
+            continue
+        try:
+            actual_sha256 = _sha256_file(worktree_path)
+        except OSError:
+            errors.append(f"cannot read current file bytes for SHA-256 verification: {path}")
+            continue
+        if actual_sha256 != declared_sha256:
+            errors.append(f"manifest SHA-256 does not match current file bytes for {path}")
 
 
 def validate_manifest(
@@ -388,7 +417,7 @@ def validate_manifest(
     if entry_paths != sorted(entry_paths):
         errors.append("manifest files entries must be sorted lexicographically by path")
 
-    _validate_coverage_and_modes(manifest, tracked_files, repo_root, entry_paths, errors)
+    _validate_source_tree(manifest, tracked_files, repo_root, entry_paths, errors)
     return errors
 
 
@@ -402,7 +431,7 @@ def _component_properties(entry: dict[str, Any]) -> list[dict[str, str]]:
         "vrhotspot:license-status": entry["license_status"],
         "vrhotspot:provenance-status": entry["provenance_status"],
         "vrhotspot:runtime-trust-boundary": entry["runtime_trust_boundary"],
-        "vrhotspot:sha256-verification": "declared-syntax-only-not-compared",
+        "vrhotspot:sha256-verification": "ci-source-tree-payload-bytes-compared",
         "vrhotspot:source-project": entry["source_project"],
     }
     return [{"name": name, "value": values[name]} for name in sorted(values)]
@@ -457,7 +486,7 @@ def generate_sbom(manifest: dict[str, Any]) -> dict[str, Any]:
                     {"name": "vrhotspot:source-manifest", "value": MANIFEST_PATH},
                     {
                         "name": "vrhotspot:sha256-verification",
-                        "value": "syntax-only; payload bytes not compared",
+                        "value": "CI/source-tree payload bytes compared before SBOM output",
                     },
                 ],
                 "type": "data",
@@ -513,7 +542,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         f"deterministic vendor-only SBOM written: {args.sbom_output} "
         f"({vendor_file_count} file components)"
     )
-    print("SHA-256 validation: syntax only; payload bytes were not compared")
+    print(
+        f"SHA-256 validation passed: {vendor_file_count} source-tree files "
+        "matched manifest values"
+    )
     return 0
 
 


### PR DESCRIPTION
Adds CI/source-tree payload SHA-256 verification for the vendor manifest.

What changed:
- Updated `tools/ci/vendor_manifest_check.py`.
- Updated `tests/test_vendor_manifest.py`.
- Updated `docs/VENDOR_PROVENANCE_SBOM_PLAN.md`.

Checksum verification:
- Computes SHA-256 over the actual current bytes for all 13 backend/vendor manifest entries.
- Fails when a manifest SHA-256 value does not match the corresponding file bytes.
- Reports mismatched paths without dumping file contents.
- Keeps the manifest file excluded from self-hashing.
- Keeps unknown/unverified provenance fields allowed.

Boundary:
- This is CI/source-tree consistency verification only.
- It does not add runtime tamper protection.
- It does not add installer enforcement.
- It does not add daemon startup verification.
- It does not verify upstream provenance.
- Support-bundle provenance remains future PR #76.

Deterministic SBOM:
- Existing deterministic vendor-only SBOM generation remains unchanged.
- SBOM output remains generated under `/tmp`.
- No generated SBOM file is tracked.

Out of scope:
- No workflow changes.
- No runtime code changes.
- No installer behavior changes.
- No vendored payload, reference, license, or permission changes.
- No support-bundle provenance output.
- No Flatpak work.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest tests/test_vendor_manifest.py -q`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `9 passed` targeted vendor manifest tests
- `637 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-vendor-checksum-verification-final-review.md`
- SHA-256: `3f3591764df41a9f6dfc995ec5a152aaf4af578deeeb7e6285228905e00eab46`
- Verdict: approve
