### PR TITLE
Add vendor provenance to support bundles

### DIFF
--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime, timezone
 import hashlib
 import json
 import logging
@@ -41,6 +42,10 @@ from vr_hotspotd.diagnostics.support_bundle import (
     assemble_support_bundle,
     file_collection_result,
     redact_support_bundle_data,
+)
+from vr_hotspotd.diagnostics.vendor_provenance import (
+    collect_vendor_provenance,
+    unavailable_vendor_provenance_report,
 )
 from vr_hotspotd import __version__
 from vr_hotspotd import telemetry
@@ -988,6 +993,7 @@ class APIHandler(BaseHTTPRequestHandler):
         )
 
     def _build_support_bundle(self):
+        generated_at = datetime.now(timezone.utc)
         files = [
             self._support_bundle_json_file(
                 "vr-hotspot/version.json",
@@ -1065,8 +1071,29 @@ class APIHandler(BaseHTTPRequestHandler):
                 )
             )
 
+        try:
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/vendor_provenance.json",
+                    "vendor provenance",
+                    collect_vendor_provenance(generated_at=generated_at),
+                )
+            )
+        except Exception:
+            warnings.append("vendor_provenance_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/vendor_provenance.json",
+                    "vendor provenance",
+                    unavailable_vendor_provenance_report(generated_at=generated_at),
+                    status=CollectorStatus.FAILED,
+                    error_summary="vendor provenance unavailable",
+                )
+            )
+
         return assemble_support_bundle(
             files=files,
+            generated_at=generated_at,
             vr_hotspot_version=APP_VERSION,
             warnings=warnings,
         )

--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -203,6 +203,11 @@ SUPPORT_BUNDLE_ARCHIVE_LAYOUT = (
     ArchiveFileMetadata("vr-hotspot/status.json", "vr hotspot status", "application/json"),
     ArchiveFileMetadata("vr-hotspot/adapters.json", "vr hotspot adapters", "application/json"),
     ArchiveFileMetadata("vr-hotspot/readiness.json", "vr hotspot readiness", "application/json"),
+    ArchiveFileMetadata(
+        "vr-hotspot/vendor_provenance.json",
+        "vendor provenance",
+        "application/json",
+    ),
     ArchiveFileMetadata("vr-hotspot/config.redacted.json", "vr hotspot config", "application/json"),
     ArchiveFileMetadata("wireless/iw-dev.txt", "iw dev"),
     ArchiveFileMetadata("wireless/iw-list.txt", "iw list"),

--- a/backend/vr_hotspotd/diagnostics/vendor_provenance.py
+++ b/backend/vr_hotspotd/diagnostics/vendor_provenance.py
@@ -1,0 +1,347 @@
+"""Bounded vendor provenance reporting for diagnostics support bundles only."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import stat
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+
+VENDOR_PROVENANCE_REPORT_SCHEMA_VERSION = 1
+VENDOR_MANIFEST_PATH = "backend/vendor/VENDOR_MANIFEST.json"
+VENDOR_POLICY_DOC_PATH = "docs/VENDOR_PROVENANCE_SBOM_PLAN.md"
+VENDOR_PROVENANCE_ENFORCEMENT_BOUNDARY = "reporting_only"
+
+_VENDOR_PATH_PREFIX = "backend/vendor/"
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_MAX_MANIFEST_ENTRIES = 512
+_MAX_VENDOR_FILE_BYTES = 64 * 1024 * 1024
+_HASH_CHUNK_BYTES = 1024 * 1024
+_MAX_MANIFEST_STRING_LENGTH = 4096
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_REPORTED_ENTRY_FIELDS = (
+    "path",
+    "file_type",
+    "executable",
+    "purpose",
+    "source_project",
+    "version",
+    "license",
+    "provenance_status",
+    "sha256",
+)
+
+
+class _MissingLocalFile(Exception):
+    pass
+
+
+class _UnreadableLocalFile(Exception):
+    pass
+
+
+def collect_vendor_provenance(
+    *,
+    repository_root: Optional[Path] = None,
+    generated_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Report manifest claims and local checksum state without enforcing either."""
+
+    report = _empty_report(generated_at=generated_at)
+    root = (
+        Path(repository_root)
+        if repository_root is not None
+        else Path(__file__).resolve().parents[3]
+    )
+
+    try:
+        raw_manifest = _read_bounded_regular_file(
+            root,
+            VENDOR_MANIFEST_PATH,
+            maximum_bytes=_MAX_MANIFEST_BYTES,
+        )
+    except _MissingLocalFile:
+        report["manifest_status"] = "missing"
+        return report
+    except _UnreadableLocalFile:
+        report["manifest_status"] = "unreadable"
+        return report
+
+    try:
+        manifest = json.loads(raw_manifest.decode("utf-8"))
+        entries = _validated_manifest_entries(manifest)
+    except (UnicodeError, json.JSONDecodeError, ValueError):
+        report["manifest_status"] = "invalid"
+        return report
+
+    report["manifest_status"] = "present"
+    report["manifest_schema_version"] = manifest["schema_version"]
+    report["policy_doc_path"] = manifest["policy_doc"]
+    report["total_manifest_entries"] = len(entries)
+
+    reported_entries = []
+    for entry in entries:
+        reported = {field: entry[field] for field in _REPORTED_ENTRY_FIELDS}
+        local_status, checksum_status, local_sha256 = _local_checksum_status(
+            root,
+            entry["path"],
+            entry["sha256"],
+        )
+        reported["local_file_status"] = local_status
+        reported["checksum_status"] = checksum_status
+        if local_sha256 is not None:
+            reported["local_computed_sha256"] = local_sha256
+        reported_entries.append(reported)
+
+    report["entries"] = reported_entries
+    report["summary"] = _summary(reported_entries)
+    return report
+
+
+def unavailable_vendor_provenance_report(
+    *,
+    generated_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Return a safe report shape when the provenance collector itself fails."""
+
+    return _empty_report(generated_at=generated_at)
+
+
+def _empty_report(*, generated_at: Optional[datetime]) -> Dict[str, Any]:
+    when = generated_at or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    generated_at_text = when.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "report_schema_version": VENDOR_PROVENANCE_REPORT_SCHEMA_VERSION,
+        "generated_at": generated_at_text,
+        "manifest_status": "unreadable",
+        "manifest_schema_version": None,
+        "manifest_path": VENDOR_MANIFEST_PATH,
+        "policy_doc_path": VENDOR_POLICY_DOC_PATH,
+        "enforcement_boundary": VENDOR_PROVENANCE_ENFORCEMENT_BOUNDARY,
+        "total_manifest_entries": 0,
+        "entries": [],
+        "summary": _summary([]),
+    }
+
+
+def _validated_manifest_entries(manifest: Any) -> list[Dict[str, Any]]:
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest must be an object")
+    if not _bounded_string(manifest.get("schema_version")):
+        raise ValueError("invalid schema version")
+    if manifest.get("policy_doc") != VENDOR_POLICY_DOC_PATH:
+        raise ValueError("invalid policy document path")
+
+    files = manifest.get("files")
+    if not isinstance(files, list) or len(files) > _MAX_MANIFEST_ENTRIES:
+        raise ValueError("invalid manifest file list")
+    scope = manifest.get("manifest_scope")
+    if not isinstance(scope, dict) or scope.get("entry_count") != len(files):
+        raise ValueError("manifest entry count mismatch")
+
+    entries: list[Dict[str, Any]] = []
+    seen_paths = set()
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise ValueError("invalid manifest entry")
+        path = entry.get("path")
+        if not _safe_vendor_path(path) or path in seen_paths:
+            raise ValueError("invalid or duplicate vendor path")
+        seen_paths.add(path)
+
+        if type(entry.get("executable")) is not bool:
+            raise ValueError("invalid executable field")
+        for field in (
+            "file_type",
+            "purpose",
+            "source_project",
+            "license",
+            "provenance_status",
+        ):
+            if not _bounded_string(entry.get(field)):
+                raise ValueError(f"invalid {field} field")
+        version = entry.get("version")
+        if version is not None and not _bounded_string(version):
+            raise ValueError("invalid version field")
+        sha256 = entry.get("sha256")
+        if not isinstance(sha256, str) or _SHA256_RE.fullmatch(sha256) is None:
+            raise ValueError("invalid sha256 field")
+        entries.append(entry)
+
+    return sorted(entries, key=lambda item: item["path"])
+
+
+def _bounded_string(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and len(value) <= _MAX_MANIFEST_STRING_LENGTH
+    )
+
+
+def _safe_vendor_path(path: Any) -> bool:
+    if (
+        not isinstance(path, str)
+        or not path
+        or len(path) > _MAX_MANIFEST_STRING_LENGTH
+        or "\\" in path
+        or "\x00" in path
+    ):
+        return False
+    parsed = PurePosixPath(path)
+    return (
+        not parsed.is_absolute()
+        and path == parsed.as_posix()
+        and all(part not in {".", ".."} for part in parsed.parts)
+        and path.startswith(_VENDOR_PATH_PREFIX)
+        and path != _VENDOR_PATH_PREFIX.rstrip("/")
+        and path != VENDOR_MANIFEST_PATH
+    )
+
+
+def _local_checksum_status(
+    repository_root: Path,
+    path: str,
+    declared_sha256: str,
+) -> Tuple[str, str, Optional[str]]:
+    try:
+        local_sha256 = _sha256_bounded_regular_file(
+            repository_root,
+            path,
+            maximum_bytes=_MAX_VENDOR_FILE_BYTES,
+        )
+    except _MissingLocalFile:
+        return "missing", "not_checked", None
+    except _UnreadableLocalFile:
+        return "unreadable", "not_checked", None
+
+    if local_sha256 is None:
+        return "present", "not_checked", None
+    if local_sha256 == declared_sha256:
+        return "present", "hash_match", local_sha256
+    return "present", "hash_mismatch", local_sha256
+
+
+def _summary(entries: list[Dict[str, Any]]) -> Dict[str, int]:
+    summary = {
+        "present": 0,
+        "missing": 0,
+        "unreadable": 0,
+        "hash_match": 0,
+        "hash_mismatch": 0,
+        "not_checked": 0,
+    }
+    for entry in entries:
+        summary[entry["local_file_status"]] += 1
+        summary[entry["checksum_status"]] += 1
+    return summary
+
+
+def _read_bounded_regular_file(
+    repository_root: Path,
+    path: str,
+    *,
+    maximum_bytes: int,
+) -> bytes:
+    with _open_regular_file_no_follow(repository_root, path) as (fd, size):
+        if size > maximum_bytes:
+            raise _UnreadableLocalFile
+        chunks = []
+        total = 0
+        while True:
+            chunk = os.read(fd, min(_HASH_CHUNK_BYTES, maximum_bytes - total + 1))
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > maximum_bytes:
+                raise _UnreadableLocalFile
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+
+def _sha256_bounded_regular_file(
+    repository_root: Path,
+    path: str,
+    *,
+    maximum_bytes: int,
+) -> Optional[str]:
+    with _open_regular_file_no_follow(repository_root, path) as (fd, size):
+        if size > maximum_bytes:
+            return None
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(fd, _HASH_CHUNK_BYTES)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > maximum_bytes:
+                return None
+            digest.update(chunk)
+        return digest.hexdigest()
+
+
+@contextmanager
+def _open_regular_file_no_follow(
+    repository_root: Path,
+    path: str,
+) -> Iterator[Tuple[int, int]]:
+    if not _safe_repository_path(path):
+        raise _UnreadableLocalFile
+
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    file_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptors = []
+    try:
+        current_fd = os.open(repository_root, directory_flags)
+        descriptors.append(current_fd)
+        parts = PurePosixPath(path).parts
+        for part in parts[:-1]:
+            current_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            descriptors.append(current_fd)
+        file_fd = os.open(parts[-1], file_flags, dir_fd=current_fd)
+        descriptors.append(file_fd)
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise _UnreadableLocalFile
+        yield file_fd, file_stat.st_size
+    except FileNotFoundError as exc:
+        raise _MissingLocalFile from exc
+    except _UnreadableLocalFile:
+        raise
+    except OSError as exc:
+        raise _UnreadableLocalFile from exc
+    finally:
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _safe_repository_path(path: str) -> bool:
+    if not isinstance(path, str) or not path or "\\" in path or "\x00" in path:
+        return False
+    parsed = PurePosixPath(path)
+    return (
+        not parsed.is_absolute()
+        and path == parsed.as_posix()
+        and all(part not in {".", ".."} for part in parsed.parts)
+    )

--- a/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
+++ b/docs/VENDOR_PROVENANCE_SBOM_PLAN.md
@@ -1,6 +1,6 @@
 # Vendor provenance, SBOM, and checksum manifest plan
 
-Status: PR #75 CI/source-tree payload SHA-256 verification
+Status: PR #76 read-only support-bundle vendor provenance output
 
 Date: 2026-07-22
 
@@ -9,8 +9,10 @@ ships from the repository. PR #73 added the canonical machine-readable
 [`backend/vendor/VENDOR_MANIFEST.json`](../backend/vendor/VENDOR_MANIFEST.json)
 inventory. PR #74 validates that inventory in CI and generates a deterministic
 vendor-only SBOM under `/tmp`. PR #75 extends that existing validator to compare
-each declared SHA-256 with the exact bytes in the committed source tree. This
-does not change installation or runtime behavior.
+each declared SHA-256 with the exact bytes in the committed source tree. PR #76
+adds a bounded `vr-hotspot/vendor_provenance.json` support-bundle report of the
+manifest claims and safely checkable local file/checksum status. These stages
+do not change installation or runtime trust enforcement.
 
 ## Problem
 
@@ -29,17 +31,19 @@ The existing repository has useful but fragmented attribution:
 - `THIRD_PARTY_NOTICES.md` names the current upstream projects and licenses.
 - `backend/vendor/licenses/` contains license texts or references.
 - `README.md` lists the bundled components.
-- `docs/support-bundle.md` anticipates reporting bundled component versions,
-  but the implemented support bundle does not report file provenance or
-  checksum state.
+- `docs/support-bundle.md` anticipates reporting bundled component versions.
+  PR #76 adds file provenance and checksum state to the implemented support
+  bundle without including payload contents.
 
 PR #73 established a canonical machine-readable inventory for the current
 `backend/vendor/` tree. PR #74 can deterministically generate a temporary SBOM
 from that inventory, and PR #75 verifies that current source-tree payload bytes
-match the committed manifest. There is still no installer or runtime checksum
-enforcement and no proof that the inventoried bytes came from the documented
-sources. A successful version probe also does not prove that a file came from
-the documented source or that its bytes match a reviewed upstream artifact.
+match the committed manifest. PR #76 reports manifest entries and bounded local
+checksum results for support diagnostics only. There is still no installer or
+runtime checksum enforcement and no proof that the inventoried bytes came from
+the documented sources. A successful version probe or local checksum match
+also does not prove that a file came from the documented source or that its
+bytes match a reviewed upstream artifact.
 
 Future hardware support may increase pressure to add firmware, helper tools,
 driver-related material, device metadata, or other vendor-specific files. The
@@ -96,25 +100,36 @@ not imply that VRhotspot supplied or checksummed those host files.
 - Add CI coverage for manifest completeness and schema validity in PR #74.
 - Add CI/source-tree payload checksum verification in PR #75 without installer
   or runtime enforcement.
-- Expose bounded, sanitized provenance status in support bundles in future PR
-  #76.
+- Expose bounded, sanitized provenance and local checksum status in support
+  bundles in PR #76 without using the result as a trust gate.
 - Make the acquisition and review process repeatable before another vendor
   asset can be added or updated.
 
-## PR #75 scope and retained boundaries
+## PR #76 scope and retained boundaries
 
 - No runtime enforcement.
 - No installer behavior change or enforcement.
 - PR #74 adds CI manifest structure, coverage, path, and executable-mode checks.
 - PR #75 extends the existing CI/source-tree validator to hash exact current
   file bytes and compare them with each manifest SHA-256.
-- This is committed-tree consistency checking, not end-user runtime tamper
-  protection. Installed files are not checked.
+- PR #76 adds `vr-hotspot/vendor_provenance.json` to authenticated support
+  bundles. It reports the manifest schema and relative paths, selected
+  provenance fields, manifest SHA-256 values, bounded local checksum results,
+  and summary counts.
+- Missing, unreadable, and mismatched vendor files are diagnostic findings
+  only. They do not block bundle generation, daemon startup, hotspot start,
+  installer execution, or any API action.
+- The support report reads only normalized manifest paths inside
+  `backend/vendor/`, refuses symlinked or non-regular local payloads, includes
+  no payload contents or absolute host paths, and passes through the existing
+  support-bundle redaction path.
+- PR #75 is committed-tree consistency checking. PR #76 may compare the local
+  installed payload bytes when generating a bundle, but the result is
+  diagnostic reporting rather than end-user runtime tamper protection.
 - PR #74 generates an untracked, deterministic CycloneDX JSON SBOM from the
   manifest at `/tmp/vrhotspot-vendor-sbom.json`. It covers only
   `backend/vendor/` and does not claim repository-wide SBOM completeness. PR
   #75 does not change its deterministic generation behavior.
-- Support-bundle provenance output remains future PR #76 work.
 - No new or replaced vendored binaries, libraries, firmware, scripts, or
   other vendor files.
 - No Steam Frame driver support.
@@ -232,7 +247,7 @@ installer checksum enforcement remain absent.
 | PR #73 | Add `backend/vendor/VENDOR_MANIFEST.json` for the 13 current files under `backend/vendor/` and record exact current SHA-256 values as non-enforced inventory metadata. Keep outside-tree assets as future audit candidates. | Every covered current file has one honest entry; unknowns are explicit; the manifest excludes its own recursive self-hash; no payload, CI, installer, or runtime behavior changes. |
 | PR #74 | Add CI schema, manifest-coverage, executable-mode, and deterministic vendor-only SBOM checks. | CI fails for missing, extra, duplicate, invalid, unsorted, outside-scope, or stale manifest paths and mode mismatches; SHA-256 is syntax-only and the untracked SBOM is reproducible. |
 | PR #75 | Add CI/source-tree payload checksum verification. | Exact committed-tree bytes and executable modes match reviewed entries; changes require a manifest diff; this is not end-user runtime tamper protection, and installer/runtime behavior remains unchanged. |
-| PR #76 | Add sanitized support-bundle provenance output. | A bundle can report bounded component, selection, provenance, and checksum status without arbitrary file reads or secret disclosure. |
+| PR #76 | Add sanitized support-bundle provenance output. | Authenticated bundles include `vr-hotspot/vendor_provenance.json` with bounded manifest fields, honest unknown/unverified provenance, and present/missing/unreadable plus match/mismatch/not-checked local status; collection does not read arbitrary paths, include payload bytes, or enforce the result. |
 | PR #77 | Write the Flatpak architecture plan. | The UI/control-app boundary, daemon API, host installation/update ownership, and trust/update story are explicit before packaging starts. |
 | PR #81+ | Begin Steam Frame / VR Direct Link evidence and adapter-intelligence work only after explicit approval. | Research starts from lawful, user-provided or public evidence and derived metadata, not redistributed drivers or automatic depot downloads. |
 
@@ -269,10 +284,9 @@ installer checksum enforcement remain absent.
 
 ### Support output and enforcement gate
 
-- The support bundle can report manifest/schema version, relative component
-  path or ID, declared source/version/license status, selected/not-selected
-  state where known, and checksum state such as `match`, `mismatch`, `missing`,
-  or `unreadable`.
+- The support bundle reports manifest/schema version, relative component path,
+  declared source/version/license and provenance status, and checksum state
+  such as `match`, `mismatch`, `missing`, or `unreadable`.
 - Support collection reads only allowlisted manifest paths, does not follow
   arbitrary symlinks, does not include payload bytes, and applies the existing
   redaction policy before archive creation.

--- a/tests/test_api_support_bundle.py
+++ b/tests/test_api_support_bundle.py
@@ -1,3 +1,4 @@
+from datetime import timezone
 import io
 import json
 import zipfile
@@ -75,6 +76,47 @@ def _stub_bundle_sources(monkeypatch):
             "secret": "raw-readiness-secret",
         },
     )
+    monkeypatch.setattr(
+        api,
+        "collect_vendor_provenance",
+        lambda **kwargs: {
+            "report_schema_version": 1,
+            "generated_at": kwargs["generated_at"]
+            .astimezone(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "manifest_status": "present",
+            "manifest_schema_version": "1.0.0",
+            "manifest_path": "backend/vendor/VENDOR_MANIFEST.json",
+            "policy_doc_path": "docs/VENDOR_PROVENANCE_SBOM_PLAN.md",
+            "enforcement_boundary": "reporting_only",
+            "total_manifest_entries": 1,
+            "entries": [
+                {
+                    "path": "backend/vendor/bin/example",
+                    "file_type": "test_payload",
+                    "executable": True,
+                    "purpose": "support diagnostics",
+                    "source_project": "test-project",
+                    "version": None,
+                    "license": "unknown",
+                    "provenance_status": "unknown",
+                    "sha256": "1" * 64,
+                    "local_file_status": "present",
+                    "checksum_status": "hash_match",
+                    "local_computed_sha256": "1" * 64,
+                }
+            ],
+            "summary": {
+                "present": 1,
+                "missing": 0,
+                "unreadable": 0,
+                "hash_match": 1,
+                "hash_mismatch": 0,
+                "not_checked": 0,
+            },
+        },
+    )
 
 
 def test_support_bundle_requires_auth(monkeypatch):
@@ -103,7 +145,17 @@ def test_support_bundle_returns_zip_headers_and_required_members(monkeypatch):
     assert headers["content-disposition"].endswith(".zip\"")
     assert "manifest.json" in members
     assert "README.txt" in members
-    assert json.loads(members["manifest.json"].decode("utf-8"))
+    bundle_manifest = json.loads(members["manifest.json"].decode("utf-8"))
+    vendor_provenance = json.loads(
+        members["vr-hotspot/vendor_provenance.json"].decode("utf-8")
+    )
+    assert any(
+        item["path"] == "vr-hotspot/vendor_provenance.json"
+        for item in bundle_manifest["files"]
+    )
+    assert vendor_provenance["generated_at"] == bundle_manifest["generated_at"]
+    assert vendor_provenance["enforcement_boundary"] == "reporting_only"
+    assert vendor_provenance["entries"][0]["checksum_status"] == "hash_match"
 
 
 def test_support_bundle_archive_does_not_leak_raw_tokens_or_passphrases(monkeypatch):
@@ -124,3 +176,30 @@ def test_support_bundle_archive_does_not_leak_raw_tokens_or_passphrases(monkeypa
     assert b"raw-config-passphrase" not in all_member_bytes
     assert b"raw-adapter-token" not in all_member_bytes
     assert b"raw-readiness-secret" not in all_member_bytes
+
+
+def test_support_bundle_reports_vendor_collector_failure_without_failing_bundle(
+    monkeypatch,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    _stub_bundle_sources(monkeypatch)
+    monkeypatch.setattr(
+        api,
+        "collect_vendor_provenance",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("collector failed")),
+    )
+
+    handler = _make_handler()
+    handler.headers["X-Api-Token"] = "secret"
+    handler.do_GET()
+
+    members = _zip_members(handler)
+    bundle_manifest = json.loads(members["manifest.json"].decode("utf-8"))
+    vendor_provenance = json.loads(
+        members["vr-hotspot/vendor_provenance.json"].decode("utf-8")
+    )
+
+    assert handler._last_code == 200
+    assert "vendor_provenance_unavailable" in bundle_manifest["warnings"]
+    assert vendor_provenance["manifest_status"] == "unreadable"
+    assert vendor_provenance["enforcement_boundary"] == "reporting_only"

--- a/tests/test_support_bundle_manifest.py
+++ b/tests/test_support_bundle_manifest.py
@@ -76,6 +76,11 @@ def test_manifest_includes_file_metadata_and_archive_layout_metadata():
         "collector": "iw dev",
         "content_type": "text/plain",
     } in layout
+    assert {
+        "path": "vr-hotspot/vendor_provenance.json",
+        "collector": "vendor provenance",
+        "content_type": "application/json",
+    } in layout
 
 
 def test_manifest_records_missing_command():

--- a/tests/test_support_bundle_vendor_provenance.py
+++ b/tests/test_support_bundle_vendor_provenance.py
@@ -1,0 +1,174 @@
+from datetime import datetime, timezone
+import hashlib
+import json
+
+from vr_hotspotd.diagnostics.vendor_provenance import collect_vendor_provenance
+
+
+GENERATED_AT = datetime(2026, 7, 22, 14, 30, tzinfo=timezone.utc)
+
+
+def _entry(path, declared_sha256, *, provenance_status="unknown_unverified"):
+    return {
+        "path": path,
+        "file_type": "test_payload",
+        "executable": False,
+        "purpose": "Exercises bounded support-bundle provenance reporting.",
+        "source_project": "test-project",
+        "version": None,
+        "license": "unknown",
+        "provenance_status": provenance_status,
+        "sha256": declared_sha256,
+    }
+
+
+def _write_manifest(repository_root, entries):
+    manifest_path = repository_root / "backend/vendor/VENDOR_MANIFEST.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "policy_doc": "docs/VENDOR_PROVENANCE_SBOM_PLAN.md",
+                "manifest_scope": {"entry_count": len(entries)},
+                "files": entries,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_vendor_provenance_reports_hash_match_without_file_contents(tmp_path):
+    payload_bytes = b"payload-contents-must-not-appear"
+    payload_path = "backend/vendor/bin/example"
+    local_path = tmp_path / payload_path
+    local_path.parent.mkdir(parents=True)
+    local_path.write_bytes(payload_bytes)
+    declared_sha256 = hashlib.sha256(payload_bytes).hexdigest()
+    _write_manifest(tmp_path, [_entry(payload_path, declared_sha256)])
+
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["generated_at"] == "2026-07-22T14:30:00Z"
+    assert report["manifest_status"] == "present"
+    assert report["manifest_schema_version"] == "1.0.0"
+    assert report["manifest_path"] == "backend/vendor/VENDOR_MANIFEST.json"
+    assert report["policy_doc_path"] == "docs/VENDOR_PROVENANCE_SBOM_PLAN.md"
+    assert report["enforcement_boundary"] == "reporting_only"
+    assert report["total_manifest_entries"] == 1
+    assert report["entries"] == [
+        {
+            "path": payload_path,
+            "file_type": "test_payload",
+            "executable": False,
+            "purpose": "Exercises bounded support-bundle provenance reporting.",
+            "source_project": "test-project",
+            "version": None,
+            "license": "unknown",
+            "provenance_status": "unknown_unverified",
+            "sha256": declared_sha256,
+            "local_file_status": "present",
+            "checksum_status": "hash_match",
+            "local_computed_sha256": declared_sha256,
+        }
+    ]
+    assert report["summary"] == {
+        "present": 1,
+        "missing": 0,
+        "unreadable": 0,
+        "hash_match": 1,
+        "hash_mismatch": 0,
+        "not_checked": 0,
+    }
+    assert payload_bytes.decode("utf-8") not in json.dumps(report)
+
+
+def test_vendor_provenance_reports_missing_file_without_raising(tmp_path):
+    payload_path = "backend/vendor/bin/missing"
+    _write_manifest(
+        tmp_path,
+        [_entry(payload_path, hashlib.sha256(b"expected").hexdigest())],
+    )
+
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["entries"][0]["local_file_status"] == "missing"
+    assert report["entries"][0]["checksum_status"] == "not_checked"
+    assert "local_computed_sha256" not in report["entries"][0]
+    assert report["summary"]["missing"] == 1
+    assert report["summary"]["not_checked"] == 1
+
+
+def test_vendor_provenance_reports_hash_mismatch_as_finding(tmp_path):
+    payload_path = "backend/vendor/bin/changed"
+    local_path = tmp_path / payload_path
+    local_path.parent.mkdir(parents=True)
+    local_path.write_bytes(b"current-local-bytes")
+    declared_sha256 = hashlib.sha256(b"expected-reviewed-bytes").hexdigest()
+    local_sha256 = hashlib.sha256(b"current-local-bytes").hexdigest()
+    _write_manifest(tmp_path, [_entry(payload_path, declared_sha256)])
+
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["entries"][0]["local_file_status"] == "present"
+    assert report["entries"][0]["checksum_status"] == "hash_mismatch"
+    assert report["entries"][0]["local_computed_sha256"] == local_sha256
+    assert report["summary"]["hash_mismatch"] == 1
+
+
+def test_vendor_provenance_refuses_symlinked_payload(tmp_path):
+    outside_payload = tmp_path / "outside-payload"
+    outside_payload.write_bytes(b"outside-file-contents-must-not-appear")
+    payload_path = "backend/vendor/bin/symlinked"
+    local_path = tmp_path / payload_path
+    local_path.parent.mkdir(parents=True)
+    local_path.symlink_to(outside_payload)
+    _write_manifest(
+        tmp_path,
+        [_entry(payload_path, hashlib.sha256(outside_payload.read_bytes()).hexdigest())],
+    )
+
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["entries"][0]["local_file_status"] == "unreadable"
+    assert report["entries"][0]["checksum_status"] == "not_checked"
+    assert "outside-file-contents-must-not-appear" not in json.dumps(report)
+
+
+def test_vendor_provenance_reports_missing_manifest_without_raising(tmp_path):
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["manifest_status"] == "missing"
+    assert report["manifest_schema_version"] is None
+    assert report["total_manifest_entries"] == 0
+    assert report["entries"] == []
+
+
+def test_vendor_provenance_rejects_manifest_path_outside_vendor_scope(tmp_path):
+    _write_manifest(
+        tmp_path,
+        [_entry("../../etc/passwd", hashlib.sha256(b"not-read").hexdigest())],
+    )
+
+    report = collect_vendor_provenance(
+        repository_root=tmp_path,
+        generated_at=GENERATED_AT,
+    )
+
+    assert report["manifest_status"] == "invalid"
+    assert report["entries"] == []


### PR DESCRIPTION
Adds read-only vendor provenance output to support bundles.

What changed:
- Added `backend/vr_hotspotd/diagnostics/vendor_provenance.py`.
- Updated support-bundle generation to include `vr-hotspot/vendor_provenance.json`.
- Updated support-bundle API/tests for the new artifact.
- Updated `docs/VENDOR_PROVENANCE_SBOM_PLAN.md` to mark PR #76 as support-bundle provenance reporting.

Support-bundle artifact:
- Path: `vr-hotspot/vendor_provenance.json`
- Separate from the archive `manifest.json`.
- Reporting-only diagnostic artifact.

Included data:
- Report metadata and manifest status.
- Manifest schema version.
- Manifest path.
- Policy document path.
- Enforcement boundary: `reporting_only`.
- Entry totals and summary counts.
- Per-entry manifest fields:
  - path
  - file type
  - executable
  - purpose
  - source project
  - version
  - license
  - provenance status
  - declared SHA-256
  - local file status
  - checksum status
  - safely computed local SHA-256

Local vendor-file behavior:
- Reports present, missing, unreadable, unsafe, symlinked, oversized, and mismatched files as findings.
- Reports checksum states such as `hash_match`, `hash_mismatch`, and `not_checked`.
- Missing or mismatched files are nonfatal support-bundle findings only.

Safety/privacy boundary:
- No file contents are included.
- No binary strings are dumped.
- No credentials, passphrases, tokens, environment dumps, or absolute host paths are exposed.
- Symlink traversal is refused.
- Reads are bounded to normalized `backend/vendor/` regular files.
- Output passes through existing support-bundle redaction.

Out of scope:
- No runtime enforcement.
- No installer enforcement.
- No daemon startup checksum verification.
- No API gate/blocking behavior.
- No lifecycle or hotspot engine behavior changes.
- No vendored payload, reference, license, or permission changes.
- No Flatpak work.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q tests/test_support_bundle_vendor_provenance.py tests/test_api_support_bundle.py tests/test_support_bundle_manifest.py tests/test_support_bundle_assembly.py tests/test_support_bundle_archive.py tests/test_support_bundle_redaction.py`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `34 passed` focused support-bundle tests
- `644 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-support-bundle-vendor-provenance-final-review.md`
- SHA-256: `8bf0128da6556cd0abb51c3c8a98128670727363cca55741b1ef89bfbf36a1f1`
- Verdict: approve
