### PR TITLE
Add Flatpak local API client prototype

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,13 +1,14 @@
 # Flatpak control app architecture plan
 
-Status: PR #77 documentation-only architecture plan
+Status: PR #78 local API client prototype; PR #77 architecture retained
 
 Date: 2026-07-23
 
 This document defines the boundary for a possible future Flatpak control
-application for VRhotspot. It does not add a Flatpak package, manifest, desktop
-application, API endpoint, UI, or runtime behavior. The Flatpak application
-does not exist yet.
+application for VRhotspot. PR #78 adds only the testable, read-only local API
+client prototype described below. It does not add a Flatpak package, manifest,
+desktop application, API endpoint, UI, or runtime behavior. No Flatpak package
+or manifest exists yet, and the Flatpak application does not exist yet.
 
 ## Architectural decision
 
@@ -67,6 +68,34 @@ loopback origin, reject redirects, and avoid accepting arbitrary remote base
 URLs. A future need for port discovery or a different local transport requires
 a separately reviewed design; this plan does not add D-Bus, a Unix socket, or
 another daemon interface.
+
+### PR #78 prototype
+
+PR #78 adds `flatpak_client/`, a top-level Python prototype kept separate from
+both the privileged `vr_hotspotd` daemon package and the existing Web UI. It is
+not included in daemon packaging and does not add Flatpak packaging metadata.
+The prototype uses only the Python standard library and exposes three
+read-only methods:
+
+- `health()` performs `GET /healthz`.
+- `preflight_report()` performs `GET /v1/diagnostics/preflight`.
+- `adapter_readiness()` performs `GET /v1/adapters/readiness`.
+
+The client accepts its token explicitly and does not discover, read, pair,
+store, rotate, or persist credentials. Authenticated requests use
+`X-Api-Token`; request and client representations redact or omit the token, and
+sanitized exceptions do not retain transport exception chains. The default
+origin is `http://127.0.0.1:8732`; only literal IPv4 or IPv6 loopback HTTP
+origins are accepted. Proxies and redirects are disabled by the standard
+transport, and redirects returned by injected test transports are rejected.
+
+The injectable transport makes the client offline-testable without a daemon or
+live network. Response handling preserves the daemon envelope, bounds response
+and error-body processing, rejects malformed JSON and invalid envelopes, and
+distinguishes connection failures, authentication failures, and the daemon's
+fail-closed `503` / `api_token_missing` response. There is no generic public
+request method and no lifecycle, configuration, diagnostic execution, support
+bundle generation, or other mutation method.
 
 The client must treat API calls as requests to a privileged authority:
 
@@ -239,7 +268,7 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | Phase | Scope | Exit condition |
 |---|---|---|
 | PR #77 | Architecture plan only. No package, manifest, API, UI, runtime, installer, CI, or vendor change. | This document makes ownership, API/authentication, sandbox, privacy, support-bundle, distribution, and non-goal boundaries reviewable. |
-| PR #78 | Flatpak local API client prototype. Start with a small client layer against a fake/mock daemon, explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. Exact packaging scope requires separate approval. |
+| PR #78 | Flatpak local API client prototype (current phase). Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
 | PR #79 | Token pairing and first-run flow. Define and implement the daemon-authorized pairing protocol, secure credential storage/recovery, missing-daemon and missing-token guidance, and version compatibility UX. | Pairing cannot bypass fail-closed daemon auth, leak tokens, or read protected host configuration; security tests cover expiry, rotation, rejection, and interrupted first run. |
 | PR #80 | Flatpak diagnostics/control UI. Implement reviewed Basic/Pro views using the client contract, including daemon-owned status, lifecycle controls, diagnostics, and support-bundle export. | UI behavior is tested, sandbox permissions remain minimal, and all privileged effects are mediated by authenticated daemon calls. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
@@ -322,11 +351,13 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #77
+## Explicit non-goals for PR #78
 
 - No Flatpak packaging, manifest, build definition, finish-args, desktop file,
   icon set, metainfo, repository submission, or release artifact.
-- No Flatpak UI or other frontend code.
+- No Flatpak GUI, control panel, diagnostics UI, or existing Web UI change.
+- No token pairing, discovery, storage, keyring, rotation, or first-run flow;
+  those remain future PR #79 work.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No installer, uninstaller, systemd-unit, platform, or CI behavior change.
@@ -344,6 +375,8 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #77 authorizes only this architecture plan. It does not claim that a
-Flatpak, Steam Frame support, VR Direct Link support, or a known-adapter
-registry exists.
+PR #78 authorizes only the isolated read-only client prototype, its offline
+tests, and this plan update. It does not claim that a Flatpak package or UI,
+Steam Frame support, VR Direct Link support, or a known-adapter registry
+exists. PR #79 token pairing/first-run and PR #80 diagnostics/control UI remain
+future, separately approved work.

--- a/flatpak_client/__init__.py
+++ b/flatpak_client/__init__.py
@@ -1,0 +1,41 @@
+"""Read-only local API client prototype for a future Flatpak control app."""
+
+from .client import (
+    DEFAULT_BASE_URL,
+    ApiResponse,
+    AuthenticationError,
+    ConnectionFailure,
+    DaemonApiError,
+    DaemonTokenMissingError,
+    HttpRequest,
+    HttpResponse,
+    InvalidBaseUrlError,
+    InvalidJsonError,
+    InvalidResponseError,
+    LocalApiClient,
+    LocalApiClientError,
+    RedirectRejectedError,
+    ResponseTooLargeError,
+    Transport,
+    UrlLibTransport,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "ApiResponse",
+    "AuthenticationError",
+    "ConnectionFailure",
+    "DaemonApiError",
+    "DaemonTokenMissingError",
+    "HttpRequest",
+    "HttpResponse",
+    "InvalidBaseUrlError",
+    "InvalidJsonError",
+    "InvalidResponseError",
+    "LocalApiClient",
+    "LocalApiClientError",
+    "RedirectRejectedError",
+    "ResponseTooLargeError",
+    "Transport",
+    "UrlLibTransport",
+]

--- a/flatpak_client/client.py
+++ b/flatpak_client/client.py
@@ -1,0 +1,547 @@
+"""Small, read-only HTTP client for the local VRhotspot daemon API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import ipaddress
+import json
+import math
+from typing import Any, Dict, Mapping, Optional, Protocol, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import (
+    build_opener,
+    HTTPRedirectHandler,
+    OpenerDirector,
+    ProxyHandler,
+    Request,
+)
+import uuid
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8732"
+
+_HEALTH_PATH = "/healthz"
+_PREFLIGHT_PATH = "/v1/diagnostics/preflight"
+_ADAPTER_READINESS_PATH = "/v1/adapters/readiness"
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+_MAX_RESPONSE_BYTES = 1_000_000
+_MAX_ERROR_BODY_BYTES = 4_096
+_MAX_ERROR_SNIPPET_CHARS = 256
+_REDACTED = "[redacted]"
+_AUTH_HEADER_NAMES = frozenset({"authorization", "x-api-token"})
+
+
+class LocalApiClientError(RuntimeError):
+    """Base class for expected, sanitized client failures."""
+
+
+class InvalidBaseUrlError(LocalApiClientError):
+    """The configured daemon origin is not a loopback-only HTTP origin."""
+
+
+class ConnectionFailure(LocalApiClientError):
+    """The local daemon could not be reached."""
+
+
+class RedirectRejectedError(LocalApiClientError):
+    """The daemon returned a redirect, which the client never follows."""
+
+    def __init__(self, status: int):
+        self.status = status
+        super().__init__(
+            f"Local daemon API redirect rejected (HTTP {status}); redirects are not allowed."
+        )
+
+
+class AuthenticationError(LocalApiClientError):
+    """The daemon rejected the explicit API token."""
+
+    def __init__(self, status: int):
+        self.status = status
+        super().__init__(f"Local daemon API authentication failed (HTTP {status}).")
+
+
+class DaemonTokenMissingError(LocalApiClientError):
+    """The daemon is fail-closed because it has no configured API token."""
+
+    def __init__(self):
+        self.status = 503
+        self.result_code = "api_token_missing"
+        super().__init__(
+            "The local daemon has no configured API token "
+            "(HTTP 503; result_code=api_token_missing)."
+        )
+
+
+class DaemonApiError(LocalApiClientError):
+    """A non-success HTTP status or API result code from the daemon."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[int] = None,
+        result_code: Optional[str] = None,
+        body_snippet: str = "",
+    ):
+        self.status = status
+        self.result_code = result_code
+        self.body_snippet = body_snippet
+        super().__init__(message)
+
+
+class InvalidJsonError(LocalApiClientError):
+    """The daemon returned a response that was not valid JSON."""
+
+
+class InvalidResponseError(LocalApiClientError):
+    """The daemon returned JSON that did not match the response contract."""
+
+
+class ResponseTooLargeError(LocalApiClientError):
+    """The daemon returned more data than this prototype accepts."""
+
+
+@dataclass(frozen=True, repr=False)
+class HttpRequest:
+    """A GET request passed to the injectable transport."""
+
+    url: str
+    method: str
+    headers: Mapping[str, str]
+    timeout: float
+
+    def __repr__(self) -> str:
+        safe_headers = {
+            key: (_REDACTED if key.lower() in _AUTH_HEADER_NAMES else value)
+            for key, value in self.headers.items()
+        }
+        return (
+            "HttpRequest("
+            f"url={self.url!r}, method={self.method!r}, "
+            f"headers={safe_headers!r}, timeout={self.timeout!r})"
+        )
+
+
+@dataclass(frozen=True, repr=False)
+class HttpResponse:
+    """A bounded response returned by the injectable transport."""
+
+    status: int
+    headers: Mapping[str, str] = field(default_factory=dict)
+    body: bytes = b""
+    body_truncated: bool = False
+
+    def __repr__(self) -> str:
+        header_names = tuple(sorted(str(key).lower() for key in self.headers))
+        return (
+            "HttpResponse("
+            f"status={self.status!r}, header_names={header_names!r}, "
+            f"body_bytes={len(self.body)!r}, body_truncated={self.body_truncated!r})"
+        )
+
+
+@dataclass(frozen=True, repr=False)
+class ApiResponse:
+    """The validated daemon envelope returned by a read-only JSON method."""
+
+    correlation_id: str
+    result_code: str
+    warnings: Tuple[str, ...]
+    data: Dict[str, Any]
+
+    def __repr__(self) -> str:
+        return (
+            "ApiResponse("
+            f"correlation_id={self.correlation_id!r}, "
+            f"result_code={self.result_code!r}, "
+            f"warning_count={len(self.warnings)!r}, "
+            f"data_keys={tuple(sorted(self.data))!r})"
+        )
+
+
+class Transport(Protocol):
+    """Minimal injectable transport used by the offline unit tests."""
+
+    def send(self, request: HttpRequest) -> HttpResponse:
+        """Send one request without following redirects."""
+
+
+class _RedirectSignal(Exception):
+    def __init__(self, status: int):
+        self.status = status
+        super().__init__(status)
+
+
+class _RejectRedirectHandler(HTTPRedirectHandler):
+    """Stop redirects before urllib can forward authentication headers."""
+
+    def _reject(self, _request, response, status, _message, _headers):
+        try:
+            response.close()
+        except OSError:
+            pass
+        raise _RedirectSignal(status)
+
+    http_error_301 = _reject
+    http_error_302 = _reject
+    http_error_303 = _reject
+    http_error_307 = _reject
+    http_error_308 = _reject
+
+
+def _read_bounded(stream, limit: int) -> Tuple[bytes, bool]:
+    raw = stream.read(limit + 1)
+    return raw[:limit], len(raw) > limit
+
+
+class UrlLibTransport:
+    """Standard-library HTTP transport with proxies and redirects disabled."""
+
+    def __init__(self, opener: Optional[OpenerDirector] = None):
+        self._opener = opener or build_opener(ProxyHandler({}), _RejectRedirectHandler())
+
+    def __repr__(self) -> str:
+        return "UrlLibTransport(redirects=False, proxies=False)"
+
+    def send(self, request: HttpRequest) -> HttpResponse:
+        urllib_request = Request(
+            request.url,
+            headers=dict(request.headers),
+            method=request.method,
+        )
+        try:
+            with self._opener.open(urllib_request, timeout=request.timeout) as response:
+                body, truncated = _read_bounded(response, _MAX_RESPONSE_BYTES)
+                return HttpResponse(
+                    status=int(response.status),
+                    headers=dict(response.headers.items()),
+                    body=body,
+                    body_truncated=truncated,
+                )
+        except _RedirectSignal as exc:
+            return HttpResponse(status=exc.status)
+        except HTTPError as exc:
+            try:
+                body, truncated = _read_bounded(exc, _MAX_ERROR_BODY_BYTES)
+                headers = dict(exc.headers.items()) if exc.headers else {}
+                return HttpResponse(
+                    status=int(exc.code),
+                    headers=headers,
+                    body=body,
+                    body_truncated=truncated,
+                )
+            finally:
+                exc.close()
+
+
+def _validated_base_url(value: str) -> str:
+    if not isinstance(value, str):
+        raise InvalidBaseUrlError("Base URL must be a loopback-only HTTP origin.")
+
+    parsed = urlsplit(value.strip())
+    try:
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        raise InvalidBaseUrlError(
+            "Base URL contains an invalid loopback host or port."
+        ) from None
+
+    if (
+        parsed.scheme != "http"
+        or not parsed.netloc
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or bool(parsed.query)
+        or bool(parsed.fragment)
+    ):
+        raise InvalidBaseUrlError(
+            "Base URL must be an origin such as http://127.0.0.1:8732."
+        )
+
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        raise InvalidBaseUrlError(
+            "Base URL host must be an IPv4 or IPv6 loopback address."
+        ) from None
+    if not address.is_loopback:
+        raise InvalidBaseUrlError("Base URL host must be a loopback address.")
+    if port == 0:
+        raise InvalidBaseUrlError("Base URL port must be between 1 and 65535.")
+
+    rendered_host = (
+        f"[{address.compressed}]" if address.version == 6 else address.compressed
+    )
+    rendered_port = f":{port}" if port is not None else ""
+    return f"http://{rendered_host}{rendered_port}"
+
+
+def _validated_token(value: str) -> str:
+    if not isinstance(value, str):
+        raise LocalApiClientError("API token must be supplied explicitly as text.")
+    if any(ord(character) < 0x20 or ord(character) > 0x7E for character in value):
+        raise LocalApiClientError(
+            "API token contains characters that are unsafe for an HTTP header."
+        )
+    return value
+
+
+def _validated_timeout(value: float) -> float:
+    if isinstance(value, bool):
+        raise LocalApiClientError("HTTP timeout must be a finite positive number.")
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        raise LocalApiClientError(
+            "HTTP timeout must be a finite positive number."
+        ) from None
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise LocalApiClientError("HTTP timeout must be a finite positive number.")
+    return timeout
+
+
+def _contains_secret(value: Any, secret: str) -> bool:
+    if not secret:
+        return False
+    if isinstance(value, str):
+        return secret in value
+    if isinstance(value, Mapping):
+        return any(
+            _contains_secret(key, secret) or _contains_secret(item, secret)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret(item, secret) for item in value)
+    return False
+
+
+class LocalApiClient:
+    """GET-only client for the future unprivileged Flatpak control app."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        transport: Optional[Transport] = None,
+    ):
+        self._base_url = _validated_base_url(base_url)
+        self._token = _validated_token(token)
+        self._timeout = _validated_timeout(timeout)
+        self._transport = transport or UrlLibTransport()
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def timeout(self) -> float:
+        return self._timeout
+
+    @property
+    def token_configured(self) -> bool:
+        return bool(self._token)
+
+    def __repr__(self) -> str:
+        return (
+            "LocalApiClient("
+            f"base_url={self._base_url!r}, timeout={self._timeout!r}, "
+            f"token_configured={bool(self._token)!r}, "
+            f"transport={type(self._transport).__name__})"
+        )
+
+    def health(self) -> bool:
+        """Return true only for the daemon's exact unauthenticated health response."""
+
+        response = self._get(_HEALTH_PATH, authenticated=False)
+        self._raise_for_status(response)
+        self._ensure_success_body_is_bounded(response)
+        if response.body.strip() != b"ok":
+            raise InvalidResponseError(
+                "The local daemon returned an invalid health response."
+            )
+        return True
+
+    def preflight_report(self) -> ApiResponse:
+        """Fetch the daemon-owned canonical preflight report."""
+
+        return self._get_api_response(_PREFLIGHT_PATH)
+
+    def adapter_readiness(self) -> ApiResponse:
+        """Fetch the daemon-owned adapter readiness model."""
+
+        return self._get_api_response(_ADAPTER_READINESS_PATH)
+
+    def _get_api_response(self, path: str) -> ApiResponse:
+        response = self._get(path, authenticated=True)
+        self._raise_for_status(response)
+        self._ensure_success_body_is_bounded(response)
+        return self._parse_envelope(response.body)
+
+    def _get(self, path: str, *, authenticated: bool) -> HttpResponse:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "vrhotspot-flatpak-client-prototype",
+            "X-Correlation-Id": f"flatpak-client-{uuid.uuid4()}",
+        }
+        if authenticated and self._token:
+            headers["X-Api-Token"] = self._token
+        request = HttpRequest(
+            url=self._base_url + path,
+            method="GET",
+            headers=headers,
+            timeout=self._timeout,
+        )
+
+        connection_error: Optional[ConnectionFailure] = None
+        try:
+            response = self._transport.send(request)
+        except Exception as exc:
+            reason = getattr(exc, "reason", exc) if isinstance(exc, URLError) else exc
+            safe_detail = self._safe_text(reason)
+            if isinstance(exc, TimeoutError) or isinstance(reason, TimeoutError):
+                message = "Timed out while connecting to the local daemon API."
+            else:
+                message = "Unable to connect to the local daemon API."
+                if safe_detail:
+                    message += f" {safe_detail}"
+            connection_error = ConnectionFailure(message)
+            exc = None
+            reason = None
+        if connection_error is not None:
+            raise connection_error
+        if not isinstance(response, HttpResponse):
+            raise InvalidResponseError(
+                "The local API transport returned an invalid response object."
+            )
+        return response
+
+    def _raise_for_status(self, response: HttpResponse) -> None:
+        status = response.status
+        if 200 <= status < 300:
+            return
+        if 300 <= status < 400:
+            raise RedirectRejectedError(status)
+        if status in {401, 403}:
+            raise AuthenticationError(status)
+
+        result_code = self._error_result_code(response.body)
+        if status == 503 and result_code == "api_token_missing":
+            raise DaemonTokenMissingError()
+
+        snippet = self._error_body_snippet(response.body, response.body_truncated)
+        detail_parts = [f"HTTP {status}"]
+        if result_code:
+            detail_parts.append(f"result_code={result_code}")
+        message = f"Local daemon API request failed ({'; '.join(detail_parts)})."
+        if snippet:
+            message += f" Response: {snippet}"
+        raise DaemonApiError(
+            message,
+            status=status,
+            result_code=result_code,
+            body_snippet=snippet,
+        )
+
+    def _ensure_success_body_is_bounded(self, response: HttpResponse) -> None:
+        if response.body_truncated or len(response.body) > _MAX_RESPONSE_BYTES:
+            raise ResponseTooLargeError(
+                "The local daemon API response exceeded the client size limit."
+            )
+
+    def _parse_envelope(self, body: bytes) -> ApiResponse:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise InvalidJsonError(
+                "The local daemon API returned invalid JSON."
+            ) from None
+        if not isinstance(payload, Mapping):
+            raise InvalidResponseError(
+                "The local daemon API returned an invalid response envelope."
+            )
+        if _contains_secret(payload, self._token):
+            raise InvalidResponseError(
+                "The local daemon API reflected the authentication token; "
+                "the response was discarded."
+            )
+
+        correlation_id = payload.get("correlation_id")
+        result_code = payload.get("result_code")
+        warnings = payload.get("warnings")
+        data = payload.get("data")
+        if (
+            not isinstance(correlation_id, str)
+            or not isinstance(result_code, str)
+            or not isinstance(warnings, list)
+            or not all(isinstance(warning, str) for warning in warnings)
+            or not isinstance(data, Mapping)
+        ):
+            raise InvalidResponseError(
+                "The local daemon API returned an invalid response envelope."
+            )
+        if result_code != "ok":
+            safe_result_code = self._safe_text(result_code)
+            raise DaemonApiError(
+                f"The local daemon API returned result_code={safe_result_code}.",
+                status=200,
+                result_code=safe_result_code,
+            )
+        return ApiResponse(
+            correlation_id=correlation_id,
+            result_code=result_code,
+            warnings=tuple(warnings),
+            data=dict(data),
+        )
+
+    def _error_result_code(self, body: bytes) -> Optional[str]:
+        try:
+            payload = json.loads(body[:_MAX_ERROR_BODY_BYTES].decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        result_code = payload.get("result_code")
+        if not isinstance(result_code, str) or not result_code:
+            return None
+        return self._safe_text(result_code)
+
+    def _error_body_snippet(self, body: bytes, was_truncated: bool) -> str:
+        bounded = body[:_MAX_ERROR_BODY_BYTES]
+        text = bounded.decode("utf-8", "replace")
+        text = " ".join(text.split())
+        text = self._redact(text)
+        truncated = was_truncated or len(body) > _MAX_ERROR_BODY_BYTES
+        if len(text) > _MAX_ERROR_SNIPPET_CHARS:
+            text = text[:_MAX_ERROR_SNIPPET_CHARS]
+            truncated = True
+        return text + ("…" if text and truncated else "")
+
+    def _safe_text(self, value: object) -> str:
+        try:
+            text = str(value)
+        except Exception:
+            text = type(value).__name__
+        text = " ".join(text.split())
+        text = self._redact(text)
+        if len(text) > _MAX_ERROR_SNIPPET_CHARS:
+            return text[:_MAX_ERROR_SNIPPET_CHARS] + "…"
+        return text
+
+    def _redact(self, text: str) -> str:
+        if not self._token:
+            return text
+        variants = {
+            self._token,
+            json.dumps(self._token, ensure_ascii=True)[1:-1],
+        }
+        for variant in variants:
+            if variant:
+                text = text.replace(variant, _REDACTED)
+        return text

--- a/tests/test_flatpak_local_api_client.py
+++ b/tests/test_flatpak_local_api_client.py
@@ -1,0 +1,274 @@
+import inspect
+import json
+
+import pytest
+
+from flatpak_client import (
+    DEFAULT_BASE_URL,
+    AuthenticationError,
+    ConnectionFailure,
+    DaemonApiError,
+    DaemonTokenMissingError,
+    HttpResponse,
+    InvalidBaseUrlError,
+    InvalidJsonError,
+    InvalidResponseError,
+    LocalApiClient,
+    RedirectRejectedError,
+)
+
+
+def _envelope(data=None, **overrides):
+    payload = {
+        "correlation_id": "test-correlation-id",
+        "result_code": "ok",
+        "warnings": [],
+        "data": data or {},
+    }
+    payload.update(overrides)
+    return json.dumps(payload).encode("utf-8")
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        if isinstance(responses, list):
+            self.responses = list(responses)
+        else:
+            self.responses = [responses]
+        self.requests = []
+
+    def send(self, request):
+        self.requests.append(request)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def test_default_origin_is_loopback_only_and_health_is_unauthenticated():
+    transport = FakeTransport(HttpResponse(status=200, body=b"ok\n"))
+    client = LocalApiClient(token="explicit-token", transport=transport)
+
+    assert client.base_url == DEFAULT_BASE_URL
+    assert client.health() is True
+    assert transport.requests[0].url == "http://127.0.0.1:8732/healthz"
+    assert transport.requests[0].method == "GET"
+    assert "X-Api-Token" not in transport.requests[0].headers
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "http://localhost:8732",
+        "http://192.168.1.20:8732",
+        "http://0.0.0.0:8732",
+        "http://example.com:8732",
+        "https://127.0.0.1:8732",
+        "http://127.0.0.1:8732/v1",
+        "http://user:password@127.0.0.1:8732",
+        "http://127.0.0.1:0",
+    ),
+)
+def test_non_loopback_or_non_origin_base_urls_are_rejected(base_url):
+    with pytest.raises(InvalidBaseUrlError):
+        LocalApiClient(token="explicit-token", base_url=base_url)
+
+
+def test_ipv4_and_ipv6_loopback_origins_are_accepted_and_normalized():
+    ipv4 = LocalApiClient(token="", base_url="http://127.0.0.2:9000/")
+    ipv6 = LocalApiClient(token="", base_url="http://[0:0:0:0:0:0:0:1]:9000")
+
+    assert ipv4.base_url == "http://127.0.0.2:9000"
+    assert ipv6.base_url == "http://[::1]:9000"
+
+
+def test_token_header_is_added_without_exposure_in_repr_or_transport_errors():
+    secret = "flatpak-client-secret-token"
+
+    class FailingTransport:
+        def __init__(self):
+            self.request = None
+
+        def send(self, request):
+            self.request = request
+            raise RuntimeError(f"transport failed with {secret}; request={request!r}")
+
+    transport = FailingTransport()
+    client = LocalApiClient(token=secret, transport=transport)
+
+    with pytest.raises(ConnectionFailure) as exc_info:
+        client.preflight_report()
+
+    assert transport.request.headers["X-Api-Token"] == secret
+    assert secret not in repr(transport.request)
+    assert secret not in repr(client)
+    assert secret not in str(exc_info.value)
+    assert secret not in repr(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
+
+
+def test_redirect_is_rejected_without_a_followup_request():
+    transport = FakeTransport(
+        HttpResponse(
+            status=302,
+            headers={"Location": "http://127.0.0.1:9999/elsewhere"},
+        )
+    )
+    client = LocalApiClient(token="explicit-token", transport=transport)
+
+    with pytest.raises(RedirectRejectedError) as exc_info:
+        client.preflight_report()
+
+    assert exc_info.value.status == 302
+    assert len(transport.requests) == 1
+
+
+def test_read_only_json_methods_parse_and_preserve_daemon_envelopes():
+    transport = FakeTransport(
+        [
+            HttpResponse(
+                status=200,
+                body=_envelope(
+                    {"overall_readiness": "ready"},
+                    warnings=["example_warning"],
+                ),
+            ),
+            HttpResponse(
+                status=200,
+                body=_envelope(
+                    {
+                        "recommended": "wlan1",
+                        "summary": {"readiness_state": "ready"},
+                    }
+                ),
+            ),
+        ]
+    )
+    client = LocalApiClient(token="explicit-token", transport=transport)
+
+    preflight = client.preflight_report()
+    readiness = client.adapter_readiness()
+
+    assert preflight.correlation_id == "test-correlation-id"
+    assert preflight.result_code == "ok"
+    assert preflight.warnings == ("example_warning",)
+    assert preflight.data == {"overall_readiness": "ready"}
+    assert readiness.data["recommended"] == "wlan1"
+    assert [request.url for request in transport.requests] == [
+        "http://127.0.0.1:8732/v1/diagnostics/preflight",
+        "http://127.0.0.1:8732/v1/adapters/readiness",
+    ]
+    assert all(request.method == "GET" for request in transport.requests)
+
+
+@pytest.mark.parametrize("status", (401, 403))
+def test_authentication_failures_have_a_distinct_safe_error(status):
+    secret = "rejected-token"
+    transport = FakeTransport(
+        HttpResponse(
+            status=status,
+            body=_envelope(
+                {"reflected": secret},
+                result_code="unauthorized",
+            ),
+        )
+    )
+    client = LocalApiClient(token=secret, transport=transport)
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        client.adapter_readiness()
+
+    assert exc_info.value.status == status
+    assert secret not in str(exc_info.value)
+    assert secret not in repr(exc_info.value)
+
+
+def test_missing_daemon_token_503_has_a_distinct_error():
+    transport = FakeTransport(
+        HttpResponse(
+            status=503,
+            body=_envelope(
+                {"hint": "configure the daemon"},
+                result_code="api_token_missing",
+                warnings=["api_token_not_configured"],
+            ),
+        )
+    )
+    client = LocalApiClient(token="explicit-token", transport=transport)
+
+    with pytest.raises(DaemonTokenMissingError) as exc_info:
+        client.preflight_report()
+
+    assert exc_info.value.status == 503
+    assert exc_info.value.result_code == "api_token_missing"
+
+
+def test_invalid_json_has_a_distinct_error_without_response_body_exposure():
+    malformed = b'{"result_code":"ok","data":'
+    transport = FakeTransport(HttpResponse(status=200, body=malformed))
+    client = LocalApiClient(token="explicit-token", transport=transport)
+
+    with pytest.raises(InvalidJsonError) as exc_info:
+        client.preflight_report()
+
+    assert malformed.decode("utf-8") not in str(exc_info.value)
+
+
+def test_error_body_snippet_is_bounded_normalized_and_token_redacted():
+    secret = "bounded-body-secret-token"
+    body = (f"{secret}\n" + ("x" * 10_000)).encode("utf-8")
+    transport = FakeTransport(HttpResponse(status=500, body=body))
+    client = LocalApiClient(token=secret, transport=transport)
+
+    with pytest.raises(DaemonApiError) as exc_info:
+        client.preflight_report()
+
+    error = exc_info.value
+    assert error.status == 500
+    assert len(error.body_snippet) <= 257
+    assert error.body_snippet.endswith("…")
+    assert "\n" not in error.body_snippet
+    assert secret not in error.body_snippet
+    assert secret not in str(error)
+    assert "x" * 300 not in str(error)
+
+
+def test_success_response_reflecting_token_is_discarded():
+    secret = "must-not-enter-api-response"
+    transport = FakeTransport(
+        HttpResponse(status=200, body=_envelope({"reflected": secret}))
+    )
+    client = LocalApiClient(token=secret, transport=transport)
+
+    with pytest.raises(InvalidResponseError) as exc_info:
+        client.preflight_report()
+
+    assert secret not in str(exc_info.value)
+    assert secret not in repr(exc_info.value)
+
+
+def test_client_has_no_mutation_methods_or_generic_public_request_method():
+    public_methods = {
+        name
+        for name, value in inspect.getmembers(LocalApiClient, inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+    assert public_methods == {
+        "health",
+        "preflight_report",
+        "adapter_readiness",
+    }
+    assert public_methods.isdisjoint(
+        {
+            "start",
+            "stop",
+            "restart",
+            "repair",
+            "save_config",
+            "update_config",
+            "request",
+            "post",
+        }
+    )


### PR DESCRIPTION
Adds a local API client prototype for the future Flatpak control app.

What changed:
- Added `flatpak_client/__init__.py`.
- Added `flatpak_client/client.py`.
- Added `tests/test_flatpak_local_api_client.py`.
- Updated `docs/FLATPAK_ARCHITECTURE_PLAN.md` to mark PR #78 as the local API client prototype step.

Client scope:
- Local daemon HTTP client only.
- Read-only methods only:
  - `health()`
  - `preflight_report()`
  - `adapter_readiness()`
- Defaults to `http://127.0.0.1:8732`.
- Allows only literal IPv4/IPv6 loopback HTTP origins.
- Rejects non-loopback hosts.
- Rejects redirects.
- Disables/bypasses proxies.

Token/security behavior:
- Token input is explicit constructor input only.
- Authenticated requests use `X-Api-Token`.
- No token discovery.
- No token storage.
- No keyring integration.
- No pairing or first-run flow.
- Tokens are redacted or omitted from reprs, exceptions, errors, and response snippets.

Error handling:
- Distinguishes connection failure, authentication failure, missing daemon token / 503, redirect, invalid JSON, invalid envelope, oversized response, and daemon API errors.
- Error response snippets are bounded.
- Error output does not expose secrets.

Out of scope:
- No Flatpak packaging manifest.
- No UI/frontend implementation.
- No daemon API behavior changes.
- No runtime behavior changes.
- No installer behavior changes.
- No CI behavior changes.
- No vendor changes.
- No token pairing / first-run flow.
- No diagnostics/control UI.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q tests/test_flatpak_local_api_client.py`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `20 passed` focused client tests
- `664 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-flatpak-local-api-client-final-review.md`
- SHA-256: `cf3002e0fa9ed88a6d957a1f829867f76e92f4e497c96342629909ad2d673a3b`
- Verdict: approve
