### PR TITLE
Add Flatpak token pairing foundation

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,14 +1,15 @@
 # Flatpak control app architecture plan
 
-Status: PR #78 local API client prototype; PR #77 architecture retained
+Status: PR #79 token pairing / first-run foundation; PRs #77-#78 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for a possible future Flatpak control
-application for VRhotspot. PR #78 adds only the testable, read-only local API
-client prototype described below. It does not add a Flatpak package, manifest,
-desktop application, API endpoint, UI, or runtime behavior. No Flatpak package
-or manifest exists yet, and the Flatpak application does not exist yet.
+application for VRhotspot. PR #79 adds only the testable token pairing and
+first-run state foundation described below, on top of PR #78's read-only local
+API client. It does not add a Flatpak package, manifest, desktop application,
+graphical UI, API endpoint, or runtime behavior. No Flatpak package or manifest
+exists yet, and no graphical Flatpak application exists yet.
 
 ## Architectural decision
 
@@ -158,32 +159,58 @@ The Flatpak must explain that the host daemon needs configuration; it must not
 mint a replacement token locally or treat the failure as an unauthenticated
 setup mode.
 
-The first API-client prototype in PR #78 may accept a manually entered token.
-PR #79 is responsible for a separately reviewed token pairing and first-run
-flow. That design must meet these requirements:
+PR #79 accepts a token explicitly from its caller and asks the existing daemon
+to validate it through the authenticated, read-only
+`GET /v1/adapters/readiness` endpoint. In this foundation, "pairing" means that
+the daemon accepted the existing credential; it does not mean credential
+issuance, token exchange, or a new daemon-side pairing endpoint.
+
+The `flatpak_client/pairing.py` controller first calls public `/healthz` without
+a token. Health success proves daemon reachability only. Without a caller-
+supplied token, the result remains `daemon_reachable_unpaired`. With a supplied
+token, the controller creates a token-bearing `LocalApiClient` only for the
+authenticated read-only validation call and maps the result to one of these
+fixed states:
+
+- `daemon_unreachable`
+- `daemon_reachable_unpaired`
+- `token_accepted`
+- `token_rejected`
+- `daemon_token_missing`
+- `invalid_response`
+
+The returned messages and detail codes are fixed, bounded, and token-free.
+Client or transport exception text is not copied into pairing state. The
+controller does not log the token, retain it after evaluation, discover it from
+the environment or host files, or persist it. PR #79 adds no storage backend:
+the caller must keep the token in memory for the current interaction and supply
+it again when needed.
+
+The PR #79 foundation has these boundaries:
 
 - Pairing is authorized and completed by the daemon. The sandbox cannot read
   `/etc/vr-hotspot/env` or other protected host configuration.
 - Initial pairing requires an explicit, local user action and must not expose
   a long-lived token in a URL, process argument, notification, or log.
-- Whether pairing reuses the current daemon token or issues a derived,
-  revocable credential remains unresolved. It must not weaken the current
-  token requirement.
+- PR #79 validates the current daemon token. Whether a future pairing protocol
+  issues a derived, revocable credential remains unresolved and requires
+  separate daemon API review.
 - Token rotation, invalidation, and authorization decisions remain daemon
-  responsibilities. The client handles `401`/`403` by discarding invalid
-  credentials and returning to pairing or login.
+  responsibilities. The controller maps `401`/`403` to `token_rejected`, so a
+  future UI can return to token entry without retaining the rejected value.
 - Tokens are attached only to the pinned local origin and are never forwarded
   across redirects.
 - Tokens are not logged, included in analytics, copied into support bundles,
   or exposed in error text. Debug output may record only non-secret facts such
   as whether a credential was present.
-- Long-lived credentials should use an appropriate desktop secret-storage
-  mechanism available to the sandbox. App-private files are not automatically
-  equivalent to secret storage. If safe storage is unavailable, the client
-  should prefer an in-memory session and prompt again.
-
-The pairing threat model, credential scope, recovery path, rotation behavior,
-and storage backend must be documented before PR #79 is considered complete.
+- Long-lived credential storage remains future work and should use an
+  appropriate desktop secret-storage mechanism available to the sandbox.
+  App-private files are not automatically equivalent to secret storage. Until
+  a backend is separately approved, the client uses an in-memory session and
+  prompts again.
+- Missing daemon, rejected token, missing daemon token, and malformed response
+  recovery are represented as state only. Graphical guidance, compatibility
+  UX, rotation workflows, and recovery controls remain future UI/API work.
 
 ## Sandbox and portal expectations
 
@@ -268,8 +295,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | Phase | Scope | Exit condition |
 |---|---|---|
 | PR #77 | Architecture plan only. No package, manifest, API, UI, runtime, installer, CI, or vendor change. | This document makes ownership, API/authentication, sandbox, privacy, support-bundle, distribution, and non-goal boundaries reviewable. |
-| PR #78 | Flatpak local API client prototype (current phase). Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
-| PR #79 | Token pairing and first-run flow. Define and implement the daemon-authorized pairing protocol, secure credential storage/recovery, missing-daemon and missing-token guidance, and version compatibility UX. | Pairing cannot bypass fail-closed daemon auth, leak tokens, or read protected host configuration; security tests cover expiry, rotation, rejection, and interrupted first run. |
+| PR #78 | Flatpak local API client prototype. Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
+| PR #79 | Token pairing and first-run foundation (current phase). Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
 | PR #80 | Flatpak diagnostics/control UI. Implement reviewed Basic/Pro views using the client contract, including daemon-owned status, lifecycle controls, diagnostics, and support-bundle export. | UI behavior is tested, sandbox permissions remain minimal, and all privileged effects are mediated by authenticated daemon calls. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
@@ -351,13 +378,14 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #78
+## Explicit non-goals for PR #79
 
 - No Flatpak packaging, manifest, build definition, finish-args, desktop file,
   icon set, metainfo, repository submission, or release artifact.
 - No Flatpak GUI, control panel, diagnostics UI, or existing Web UI change.
-- No token pairing, discovery, storage, keyring, rotation, or first-run flow;
-  those remain future PR #79 work.
+- No token discovery, persistent storage, keyring/portal integration, token
+  issuance, rotation, or daemon-side pairing endpoint. PR #79 only validates a
+  caller-supplied token and returns first-run state.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No installer, uninstaller, systemd-unit, platform, or CI behavior change.
@@ -375,8 +403,8 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #78 authorizes only the isolated read-only client prototype, its offline
-tests, and this plan update. It does not claim that a Flatpak package or UI,
-Steam Frame support, VR Direct Link support, or a known-adapter registry
-exists. PR #79 token pairing/first-run and PR #80 diagnostics/control UI remain
-future, separately approved work.
+PR #79 authorizes only the isolated token pairing/first-run state foundation,
+its offline tests, the required exports, and this plan update. It does not
+claim that a Flatpak package or graphical UI, Steam Frame support, VR Direct
+Link support, or a known-adapter registry exists. PR #80 diagnostics/control
+UI and all other future phases remain separately approved work.

--- a/flatpak_client/__init__.py
+++ b/flatpak_client/__init__.py
@@ -19,6 +19,13 @@ from .client import (
     Transport,
     UrlLibTransport,
 )
+from .pairing import (
+    FirstRunResult,
+    FirstRunState,
+    PairingClient,
+    PairingClientFactory,
+    TokenPairingController,
+)
 
 __all__ = [
     "DEFAULT_BASE_URL",
@@ -38,4 +45,9 @@ __all__ = [
     "ResponseTooLargeError",
     "Transport",
     "UrlLibTransport",
+    "FirstRunResult",
+    "FirstRunState",
+    "PairingClient",
+    "PairingClientFactory",
+    "TokenPairingController",
 ]

--- a/flatpak_client/pairing.py
+++ b/flatpak_client/pairing.py
@@ -1,0 +1,152 @@
+"""Token pairing and first-run state for the future Flatpak control app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from .client import (
+    ApiResponse,
+    AuthenticationError,
+    ConnectionFailure,
+    DaemonTokenMissingError,
+    LocalApiClient,
+    LocalApiClientError,
+)
+
+
+class FirstRunState(str, Enum):
+    """Stable, non-secret outcomes a future first-run UI can render."""
+
+    DAEMON_UNREACHABLE = "daemon_unreachable"
+    DAEMON_REACHABLE_UNPAIRED = "daemon_reachable_unpaired"
+    TOKEN_ACCEPTED = "token_accepted"
+    TOKEN_REJECTED = "token_rejected"
+    DAEMON_TOKEN_MISSING = "daemon_token_missing"
+    INVALID_RESPONSE = "invalid_response"
+
+
+_STATE_MESSAGES = {
+    FirstRunState.DAEMON_UNREACHABLE: (
+        "The local VRhotspot daemon could not be reached."
+    ),
+    FirstRunState.DAEMON_REACHABLE_UNPAIRED: (
+        "The local daemon is reachable. Enter an API token to continue."
+    ),
+    FirstRunState.TOKEN_ACCEPTED: "The supplied API token was accepted.",
+    FirstRunState.TOKEN_REJECTED: "The supplied API token was rejected.",
+    FirstRunState.DAEMON_TOKEN_MISSING: (
+        "The local daemon has no configured API token."
+    ),
+    FirstRunState.INVALID_RESPONSE: (
+        "The local daemon returned an invalid or unsupported response."
+    ),
+}
+
+_STATE_DETAIL_CODES = {
+    FirstRunState.DAEMON_UNREACHABLE: "connection_failed",
+    FirstRunState.DAEMON_REACHABLE_UNPAIRED: "token_required",
+    FirstRunState.TOKEN_ACCEPTED: "authenticated_read_only_check_succeeded",
+    FirstRunState.TOKEN_REJECTED: "authentication_failed",
+    FirstRunState.DAEMON_TOKEN_MISSING: "api_token_missing",
+    FirstRunState.INVALID_RESPONSE: "unexpected_daemon_response",
+}
+
+
+@dataclass(frozen=True, repr=False)
+class FirstRunResult:
+    """A fixed, token-free first-run result."""
+
+    state: FirstRunState
+
+    @property
+    def message(self) -> str:
+        return _STATE_MESSAGES[self.state]
+
+    @property
+    def detail_code(self) -> str:
+        return _STATE_DETAIL_CODES[self.state]
+
+    @property
+    def paired(self) -> bool:
+        return self.state is FirstRunState.TOKEN_ACCEPTED
+
+    def __repr__(self) -> str:
+        return f"FirstRunResult(state={self.state.value!r})"
+
+
+class PairingClient(Protocol):
+    """Read-only client behavior used by the first-run controller."""
+
+    def health(self) -> bool:
+        """Return whether the daemon's public health contract is valid."""
+
+    def adapter_readiness(self) -> ApiResponse:
+        """Call an authenticated, read-only endpoint."""
+
+
+class PairingClientFactory(Protocol):
+    """Create a local API client using a caller-supplied token."""
+
+    def __call__(self, *, token: str) -> PairingClient:
+        """Return a loopback-only, read-only client."""
+
+
+class TokenPairingController:
+    """Map daemon reachability and token validation to safe first-run state."""
+
+    def __init__(self, client_factory: PairingClientFactory = LocalApiClient):
+        self._client_factory = client_factory
+
+    def __repr__(self) -> str:
+        return "TokenPairingController(client_factory_configured=True)"
+
+    def evaluate(self, *, token: str | None = None) -> FirstRunResult:
+        """Evaluate first-run state without discovering or retaining a token."""
+
+        health_result = self._check_health()
+        if health_result is not None:
+            return health_result
+
+        if token is None or token == "":
+            return FirstRunResult(FirstRunState.DAEMON_REACHABLE_UNPAIRED)
+        if not isinstance(token, str):
+            return FirstRunResult(FirstRunState.TOKEN_REJECTED)
+
+        try:
+            client = self._client_factory(token=token)
+        except LocalApiClientError:
+            return FirstRunResult(FirstRunState.TOKEN_REJECTED)
+        except Exception:
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        try:
+            response = client.adapter_readiness()
+        except AuthenticationError:
+            return FirstRunResult(FirstRunState.TOKEN_REJECTED)
+        except DaemonTokenMissingError:
+            return FirstRunResult(FirstRunState.DAEMON_TOKEN_MISSING)
+        except ConnectionFailure:
+            return FirstRunResult(FirstRunState.DAEMON_UNREACHABLE)
+        except LocalApiClientError:
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+        except Exception:
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        if not isinstance(response, ApiResponse):
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+        return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+
+    def _check_health(self) -> FirstRunResult | None:
+        try:
+            client = self._client_factory(token="")
+            reachable = client.health()
+        except ConnectionFailure:
+            return FirstRunResult(FirstRunState.DAEMON_UNREACHABLE)
+        except Exception:
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        if reachable is not True:
+            return FirstRunResult(FirstRunState.INVALID_RESPONSE)
+        return None

--- a/tests/test_flatpak_token_pairing.py
+++ b/tests/test_flatpak_token_pairing.py
@@ -1,0 +1,284 @@
+import builtins
+import inspect
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from flatpak_client import (
+    ApiResponse,
+    ConnectionFailure,
+    FirstRunState,
+    HttpResponse,
+    LocalApiClient,
+    TokenPairingController,
+)
+
+
+def _envelope(data=None, **overrides):
+    payload = {
+        "correlation_id": "pairing-test-correlation-id",
+        "result_code": "ok",
+        "warnings": [],
+        "data": data or {},
+    }
+    payload.update(overrides)
+    return json.dumps(payload).encode("utf-8")
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def send(self, request):
+        self.requests.append(request)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+class LocalClientFactory:
+    def __init__(self, responses):
+        self.transport = FakeTransport(responses)
+        self.tokens = []
+
+    def __call__(self, *, token):
+        self.tokens.append(token)
+        return LocalApiClient(token=token, transport=self.transport)
+
+
+def _controller(*responses):
+    factory = LocalClientFactory(responses)
+    return TokenPairingController(factory), factory
+
+
+def test_reachable_health_without_token_is_unpaired_not_paired():
+    controller, factory = _controller(HttpResponse(status=200, body=b"ok\n"))
+
+    result = controller.evaluate()
+
+    assert result.state is FirstRunState.DAEMON_REACHABLE_UNPAIRED
+    assert result.paired is False
+    assert factory.tokens == [""]
+    assert len(factory.transport.requests) == 1
+    request = factory.transport.requests[0]
+    assert request.url == "http://127.0.0.1:8732/healthz"
+    assert "X-Api-Token" not in request.headers
+
+
+def test_unreachable_daemon_has_a_distinct_first_run_state():
+    controller, _factory = _controller(ConnectionRefusedError("offline"))
+
+    result = controller.evaluate(token="supplied-token")
+
+    assert result.state is FirstRunState.DAEMON_UNREACHABLE
+    assert result.detail_code == "connection_failed"
+    assert result.paired is False
+
+
+def test_supplied_token_is_accepted_by_authenticated_read_only_endpoint():
+    secret = "accepted-pairing-token"
+    controller, factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        HttpResponse(
+            status=200,
+            body=_envelope({"summary": {"readiness_state": "ready"}}),
+        ),
+    )
+
+    result = controller.evaluate(token=secret)
+
+    assert result.state is FirstRunState.TOKEN_ACCEPTED
+    assert result.paired is True
+    assert factory.tokens == ["", secret]
+    assert len(factory.transport.requests) == 2
+    request = factory.transport.requests[1]
+    assert request.url == "http://127.0.0.1:8732/v1/adapters/readiness"
+    assert request.method == "GET"
+    assert request.headers["X-Api-Token"] == secret
+
+
+def test_supplied_token_rejected_on_401():
+    controller, _factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        HttpResponse(
+            status=401,
+            body=_envelope(result_code="unauthorized"),
+        ),
+    )
+
+    result = controller.evaluate(token="rejected-pairing-token")
+
+    assert result.state is FirstRunState.TOKEN_REJECTED
+    assert result.detail_code == "authentication_failed"
+    assert result.paired is False
+
+
+def test_daemon_token_missing_503_has_a_distinct_first_run_state():
+    controller, _factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        HttpResponse(
+            status=503,
+            body=_envelope(
+                result_code="api_token_missing",
+                warnings=["api_token_not_configured"],
+            ),
+        ),
+    )
+
+    result = controller.evaluate(token="caller-supplied-token")
+
+    assert result.state is FirstRunState.DAEMON_TOKEN_MISSING
+    assert result.detail_code == "api_token_missing"
+    assert result.paired is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        b'{"result_code":"ok","data":',
+        json.dumps({"result_code": "ok", "data": {}}).encode("utf-8"),
+    ),
+)
+def test_invalid_json_or_envelope_maps_to_safe_invalid_response(body):
+    controller, _factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        HttpResponse(status=200, body=body),
+    )
+
+    result = controller.evaluate(token="caller-supplied-token")
+
+    assert result.state is FirstRunState.INVALID_RESPONSE
+    assert result.detail_code == "unexpected_daemon_response"
+    assert result.paired is False
+
+
+def test_token_never_appears_in_controller_or_result_surfaces(caplog):
+    secret = "pairing-secret-must-never-escape"
+
+    class SecretFailingClient:
+        def health(self):
+            return True
+
+        def adapter_readiness(self):
+            raise RuntimeError(f"unexpected failure involving {secret}")
+
+    class SecretFactory:
+        def __call__(self, *, token):
+            return SecretFailingClient()
+
+        def __repr__(self):
+            return f"SecretFactory(token={secret!r})"
+
+    controller = TokenPairingController(SecretFactory())
+
+    result = controller.evaluate(token=secret)
+
+    exposed_surfaces = (
+        repr(controller),
+        str(controller),
+        repr(result),
+        str(result),
+        result.state.value,
+        result.message,
+        result.detail_code,
+        caplog.text,
+    )
+    assert result.state is FirstRunState.INVALID_RESPONSE
+    assert all(secret not in surface for surface in exposed_surfaces)
+
+
+def test_token_is_not_persisted_or_read_from_files(monkeypatch, tmp_path):
+    secret = "in-memory-only-pairing-token"
+    controller, factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        HttpResponse(status=200, body=_envelope({"readiness": "ready"})),
+    )
+    monkeypatch.chdir(tmp_path)
+    before = list(tmp_path.rglob("*"))
+
+    def forbidden_open(*_args, **_kwargs):
+        raise AssertionError("pairing flow must not access files")
+
+    monkeypatch.setattr(builtins, "open", forbidden_open)
+    monkeypatch.setattr(os, "open", forbidden_open)
+    monkeypatch.setattr(Path, "open", forbidden_open)
+    monkeypatch.setattr(Path, "read_text", forbidden_open)
+    monkeypatch.setattr(Path, "read_bytes", forbidden_open)
+    monkeypatch.setattr(Path, "write_text", forbidden_open)
+    monkeypatch.setattr(Path, "write_bytes", forbidden_open)
+
+    result = controller.evaluate(token=secret)
+
+    assert result.state is FirstRunState.TOKEN_ACCEPTED
+    assert list(tmp_path.rglob("*")) == before
+    assert not hasattr(controller, "token")
+    assert not hasattr(controller, "_token")
+    assert factory.tokens == ["", secret]
+
+
+def test_pairing_flow_wires_only_health_and_adapter_readiness():
+    calls = []
+
+    class ReadOnlyFakeClient:
+        def __init__(self, token):
+            self.token = token
+
+        def health(self):
+            calls.append(("health", bool(self.token)))
+            return True
+
+        def adapter_readiness(self):
+            calls.append(("adapter_readiness", bool(self.token)))
+            return ApiResponse(
+                correlation_id="pairing-test-correlation-id",
+                result_code="ok",
+                warnings=(),
+                data={},
+            )
+
+    controller = TokenPairingController(
+        lambda *, token: ReadOnlyFakeClient(token)
+    )
+
+    result = controller.evaluate(token="explicit-token")
+
+    public_client_methods = {
+        name
+        for name, value in inspect.getmembers(LocalApiClient, inspect.isfunction)
+        if not name.startswith("_")
+    }
+    assert result.state is FirstRunState.TOKEN_ACCEPTED
+    assert calls == [("health", False), ("adapter_readiness", True)]
+    assert public_client_methods == {
+        "health",
+        "preflight_report",
+        "adapter_readiness",
+    }
+    assert public_client_methods.isdisjoint(
+        {
+            "start",
+            "stop",
+            "restart",
+            "repair",
+            "save_config",
+            "update_config",
+            "request",
+            "post",
+        }
+    )
+
+
+def test_authenticated_connection_loss_does_not_return_paired():
+    controller, _factory = _controller(
+        HttpResponse(status=200, body=b"ok\n"),
+        ConnectionFailure("connection lost"),
+    )
+
+    result = controller.evaluate(token="explicit-token")
+
+    assert result.state is FirstRunState.DAEMON_UNREACHABLE
+    assert result.paired is False


### PR DESCRIPTION
Adds the token pairing / first-run foundation for the future Flatpak control app.

What changed:
- Added `flatpak_client/pairing.py`.
- Updated `flatpak_client/__init__.py`.
- Added `tests/test_flatpak_token_pairing.py`.
- Updated `docs/FLATPAK_ARCHITECTURE_PLAN.md` to mark PR #79 as the token pairing / first-run foundation step.

Pairing states:
- `daemon_unreachable`
- `daemon_reachable_unpaired`
- `token_accepted`
- `token_rejected`
- `daemon_token_missing`
- `invalid_response`

Pairing behavior:
- Uses the existing `LocalApiClient` boundary.
- Keeps daemon access loopback-only.
- Treats `health()` as daemon reachability only, not proof of pairing.
- Validates explicit caller-supplied tokens through authenticated read-only `adapter_readiness()`.
- Maps 401/403 to `token_rejected`.
- Maps 503 / `api_token_missing` to `daemon_token_missing`.
- Maps connection failure to `daemon_unreachable`.
- Maps invalid JSON/envelope behavior to `invalid_response`.

Token/security behavior:
- Token input is explicit caller input only.
- No token discovery.
- No token persistence to disk.
- No keyring integration.
- No portal integration.
- No `/etc`, `/var/lib`, environment, or broad filesystem access.
- No token in reprs, exceptions, returned states, details, logs, or snippets.

Out of scope:
- No Flatpak packaging manifest.
- No graphical UI.
- No diagnostics/control UI.
- No daemon API behavior changes.
- No runtime behavior changes.
- No installer behavior changes.
- No CI behavior changes.
- No vendor changes.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.
- No start/stop/restart/config mutation flows.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q tests/test_flatpak_token_pairing.py tests/test_flatpak_local_api_client.py`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `31 passed` focused pairing/client tests
- `675 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-flatpak-token-pairing-final-review.md`
- SHA-256: `cbc88904202710d90ef5eafbb19f99af371bffd512ce3d347fb31e36bbd774a4`
- Verdict: approve
