### PR TITLE
Add Flatpak diagnostics control UI foundation

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,15 +1,16 @@
 # Flatpak control app architecture plan
 
-Status: PR #79 token pairing / first-run foundation; PRs #77-#78 retained
+Status: PR #80 diagnostics/control UI foundation; PRs #77-#79 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for a possible future Flatpak control
-application for VRhotspot. PR #79 adds only the testable token pairing and
-first-run state foundation described below, on top of PR #78's read-only local
-API client. It does not add a Flatpak package, manifest, desktop application,
-graphical UI, API endpoint, or runtime behavior. No Flatpak package or manifest
-exists yet, and no graphical Flatpak application exists yet.
+application for VRhotspot. PR #80 adds only the toolkit-agnostic, testable UI
+model/controller foundation described below, on top of PR #78's read-only local
+API client and PR #79's pairing state. It does not add a Flatpak package,
+manifest, desktop application, finished graphical UI, API endpoint, or runtime
+behavior. No Flatpak package or manifest exists yet, and no graphical Flatpak
+application exists yet.
 
 ## Architectural decision
 
@@ -212,6 +213,47 @@ The PR #79 foundation has these boundaries:
   recovery are represented as state only. Graphical guidance, compatibility
   UX, rotation workflows, and recovery controls remain future UI/API work.
 
+## Diagnostics/control UI foundation
+
+PR #80 adds `flatpak_client/ui.py`, a toolkit-agnostic view-model/controller
+layer for a future polished Linux VR Wi-Fi control center. It has no GTK,
+libadwaita, Qt, desktop-window, or Flatpak packaging dependency. The foundation
+projects only the existing `LocalApiClient` responses and `FirstRunResult`
+states into frozen, UI-ready models:
+
+- daemon reachability and pairing status;
+- adapter readiness summary and cards;
+- preflight summary facts, issues, and non-interactive recommended actions;
+- a visible but disabled support-bundle export affordance.
+
+The UI controller calls only `adapter_readiness()` and `preflight_report()`,
+and only after the supplied pairing result is `token_accepted`. It has no
+generic request method, lifecycle control, configuration mutation, support-
+bundle download, or export method. The support-bundle model states whether
+pairing is required or export wiring is not implemented; it performs no daemon
+request and remains disabled until bounded binary handling and a portal export
+flow receive separate review.
+
+The models use the presentation severities `ok`, `warning`, `blocked`, `error`,
+and `unknown`. Known daemon readiness states map to those values; unrecognized,
+malformed, partial, or failed responses degrade to bounded `unknown` sections
+with fixed safe copy. Adapter recommendations and Basic-mode visibility remain
+daemon-provided facts rather than client-side policy.
+
+Basic and Pro are represented as presentation modes. Basic exposes the same
+safe summary/status/card foundation with technical details hidden; Pro marks
+those already-sanitized details as displayable later. The mode field does not
+change daemon calls, authorize actions, filter adapters, or override daemon
+policy, and PR #80 adds no mode-toggle widget.
+
+Daemon content is projected through an allowlist rather than retained as raw
+response dictionaries. Collections and strings are bounded, recognized secret
+assignments and authorization credentials are redacted, unexpected secret or
+environment fields are omitted, and avoidable absolute host paths are replaced
+with a generic label. API tokens and Wi-Fi passphrases are not model fields.
+The controller copies no exception text into UI state and exposes no raw
+preflight report or response body.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -296,8 +338,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 |---|---|---|
 | PR #77 | Architecture plan only. No package, manifest, API, UI, runtime, installer, CI, or vendor change. | This document makes ownership, API/authentication, sandbox, privacy, support-bundle, distribution, and non-goal boundaries reviewable. |
 | PR #78 | Flatpak local API client prototype. Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
-| PR #79 | Token pairing and first-run foundation (current phase). Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
-| PR #80 | Flatpak diagnostics/control UI. Implement reviewed Basic/Pro views using the client contract, including daemon-owned status, lifecycle controls, diagnostics, and support-bundle export. | UI behavior is tested, sandbox permissions remain minimal, and all privileged effects are mediated by authenticated daemon calls. |
+| PR #79 | Token pairing and first-run foundation. Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
+| PR #80 | Diagnostics/control UI foundation (current phase). Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -378,14 +420,19 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #79
+## Explicit non-goals for PR #80
 
 - No Flatpak packaging, manifest, build definition, finish-args, desktop file,
   icon set, metainfo, repository submission, or release artifact.
-- No Flatpak GUI, control panel, diagnostics UI, or existing Web UI change.
+- No finished Flatpak GUI, GTK/libadwaita or Qt dependency, desktop window, or
+  existing Web UI change. PR #80 is a view-model/controller foundation only.
+- No start, stop, restart, repair, configuration, passphrase, adapter-selection,
+  or other mutation control.
+- No support-bundle download, temporary file handling, file chooser, portal
+  integration, or export implementation. The disabled model affordance is
+  non-interactive and performs no request.
 - No token discovery, persistent storage, keyring/portal integration, token
-  issuance, rotation, or daemon-side pairing endpoint. PR #79 only validates a
-  caller-supplied token and returns first-run state.
+  issuance, rotation, or daemon-side pairing endpoint.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No installer, uninstaller, systemd-unit, platform, or CI behavior change.
@@ -403,8 +450,9 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #79 authorizes only the isolated token pairing/first-run state foundation,
-its offline tests, the required exports, and this plan update. It does not
-claim that a Flatpak package or graphical UI, Steam Frame support, VR Direct
-Link support, or a known-adapter registry exists. PR #80 diagnostics/control
-UI and all other future phases remain separately approved work.
+PR #80 authorizes only the isolated toolkit-agnostic diagnostics/control UI
+model foundation, its offline tests, the required exports, and this plan
+update. It does not claim that a Flatpak package, finished graphical UI,
+support-bundle export flow, Steam Frame support, VR Direct Link support, or a
+known-adapter registry exists. Packaging, production GUI work, lifecycle
+controls, portal wiring, and all later phases remain separately approved work.

--- a/flatpak_client/__init__.py
+++ b/flatpak_client/__init__.py
@@ -26,6 +26,22 @@ from .pairing import (
     PairingClientFactory,
     TokenPairingController,
 )
+from .ui import (
+    AdapterReadinessCard,
+    AdapterReadinessModel,
+    DaemonStatusModel,
+    DiagnosticsControlUiController,
+    DiagnosticsControlUiModel,
+    DiagnosticsUiClient,
+    PairingStatusModel,
+    PreflightActionModel,
+    PreflightIssueModel,
+    PreflightSummaryModel,
+    PresentationMode,
+    StatusSeverity,
+    SummaryFact,
+    SupportBundleAffordance,
+)
 
 __all__ = [
     "DEFAULT_BASE_URL",
@@ -50,4 +66,18 @@ __all__ = [
     "PairingClient",
     "PairingClientFactory",
     "TokenPairingController",
+    "AdapterReadinessCard",
+    "AdapterReadinessModel",
+    "DaemonStatusModel",
+    "DiagnosticsControlUiController",
+    "DiagnosticsControlUiModel",
+    "DiagnosticsUiClient",
+    "PairingStatusModel",
+    "PreflightActionModel",
+    "PreflightIssueModel",
+    "PreflightSummaryModel",
+    "PresentationMode",
+    "StatusSeverity",
+    "SummaryFact",
+    "SupportBundleAffordance",
 ]

--- a/flatpak_client/ui.py
+++ b/flatpak_client/ui.py
@@ -1,0 +1,763 @@
+"""Toolkit-agnostic UI models for the future Flatpak control app."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import math
+import re
+from typing import Any, Mapping, Protocol, Sequence, Tuple
+
+from .client import ApiResponse
+from .pairing import FirstRunResult, FirstRunState
+
+
+_MAX_ADAPTER_CARDS = 12
+_MAX_REASONS_PER_ADAPTER = 6
+_MAX_PREFLIGHT_ISSUES = 16
+_MAX_PREFLIGHT_ACTIONS = 12
+_MAX_TEXT_CHARS = 240
+_MAX_CODE_CHARS = 64
+_MAX_SANITIZER_INPUT_CHARS = 4_096
+
+_SECRET_KEY_PATTERN = (
+    r"x-api-token|"
+    r"(?:api|access|auth|client|private)[_ -]?(?:token|secret|key)|"
+    r"secret[_ -]?key|token|authorization|"
+    r"wpa2?[_ -]?passphrase|passphrase|sae[_ -]?password|password|"
+    r"psk|secret|key"
+)
+_SECRET_VALUE_PATTERN = (
+    r"(?:\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^,;]+)"
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    rf"(?i)(?<![\w-])(?P<quote>[\"']?)(?P<key>{_SECRET_KEY_PATTERN})"
+    rf"(?P=quote)(?![\w-])\s*[:=]\s*(?:bearer\s+)?{_SECRET_VALUE_PATTERN}"
+)
+_SPACED_SECRET_RE = re.compile(
+    rf"(?i)(?<![\w-])(?P<key>{_SECRET_KEY_PATTERN})"
+    rf"(?![\w-])\s+(?:bearer\s+)?{_SECRET_VALUE_PATTERN}"
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
+_FILE_URI_RE = re.compile(
+    r"(?i)(?<![\w])file:(?://)?/[^\s,;!?)}\]>'\"]*"
+)
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![\w/])/(?:[^/\s]+/)*[^/\s,;:!?)}\]>'\"]*"
+)
+_SAFE_CODE_RE = re.compile(r"[^a-z0-9_.-]+")
+
+
+class StatusSeverity(str, Enum):
+    """Presentation severity shared by the future desktop UI."""
+
+    OK = "ok"
+    WARNING = "warning"
+    BLOCKED = "blocked"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+
+class PresentationMode(str, Enum):
+    """Presentation depth only; daemon policy remains authoritative."""
+
+    BASIC = "basic"
+    PRO = "pro"
+
+
+@dataclass(frozen=True)
+class DaemonStatusModel:
+    """Safe local-daemon connection status derived from pairing state."""
+
+    severity: StatusSeverity
+    reachable: bool | None
+    title: str
+    message: str
+    detail_code: str
+
+
+@dataclass(frozen=True)
+class PairingStatusModel:
+    """Safe authentication status with no credential-bearing fields."""
+
+    severity: StatusSeverity
+    paired: bool
+    title: str
+    message: str
+    detail_code: str
+
+
+@dataclass(frozen=True)
+class AdapterReadinessCard:
+    """One bounded projection of daemon-owned adapter readiness."""
+
+    interface: str
+    severity: StatusSeverity
+    readiness_label: str
+    summary: str
+    recommended: bool
+    basic_mode_recommended: bool
+    basic_mode_visible: bool | None
+    basic_mode_selectable: bool | None
+    driver: str
+    bus_type: str
+    supported_bands: Tuple[str, ...]
+    recommendation_score: int | None
+    reasons: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AdapterReadinessModel:
+    """UI-ready adapter section without client-side selection policy."""
+
+    severity: StatusSeverity
+    title: str
+    summary: str
+    recommended_interface: str
+    basic_mode_recommended_interface: str
+    cards: Tuple[AdapterReadinessCard, ...]
+
+
+@dataclass(frozen=True)
+class SummaryFact:
+    """A concise allowlisted label/value pair for a diagnostics summary."""
+
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class PreflightIssueModel:
+    """A bounded issue reported by the daemon."""
+
+    severity: StatusSeverity
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class PreflightActionModel:
+    """Non-interactive guidance; it cannot invoke a host mutation."""
+
+    code: str
+    message: str
+    interactive: bool = False
+
+
+@dataclass(frozen=True)
+class PreflightSummaryModel:
+    """Safe projection of the canonical preflight report."""
+
+    severity: StatusSeverity
+    readiness_label: str
+    summary: str
+    facts: Tuple[SummaryFact, ...]
+    issues: Tuple[PreflightIssueModel, ...]
+    actions: Tuple[PreflightActionModel, ...]
+
+
+@dataclass(frozen=True)
+class SupportBundleAffordance:
+    """Disabled export affordance for separately reviewed future wiring."""
+
+    visible: bool
+    severity: StatusSeverity
+    title: str
+    summary: str
+    action_label: str
+    availability_code: str
+    action_enabled: bool = False
+    requires_portal: bool = True
+    request_performed: bool = False
+
+
+@dataclass(frozen=True)
+class DiagnosticsControlUiModel:
+    """Complete read-only foundation consumed by a future GUI toolkit."""
+
+    mode: PresentationMode
+    show_technical_details: bool
+    daemon: DaemonStatusModel
+    pairing: PairingStatusModel
+    adapters: AdapterReadinessModel
+    preflight: PreflightSummaryModel
+    support_bundle: SupportBundleAffordance
+
+
+class DiagnosticsUiClient(Protocol):
+    """Only the existing read-only client methods needed by this foundation."""
+
+    def adapter_readiness(self) -> ApiResponse:
+        """Return the daemon-owned adapter readiness response."""
+
+    def preflight_report(self) -> ApiResponse:
+        """Return the daemon-owned canonical preflight response."""
+
+
+def _sanitize_text(
+    value: object,
+    *,
+    fallback: str,
+    limit: int = _MAX_TEXT_CHARS,
+) -> str:
+    if not isinstance(value, (str, int, float)):
+        return fallback
+    if isinstance(value, float) and not math.isfinite(value):
+        return fallback
+    text = " ".join(str(value)[:_MAX_SANITIZER_INPUT_CHARS].split())
+    if not text:
+        return fallback
+    text = _SECRET_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group('key')}=[redacted]",
+        text,
+    )
+    text = _SPACED_SECRET_RE.sub(
+        lambda match: f"{match.group('key')}=[redacted]",
+        text,
+    )
+    text = _BEARER_RE.sub("Bearer [redacted]", text)
+    text = _FILE_URI_RE.sub("[host path]", text)
+    text = _ABSOLUTE_PATH_RE.sub("[host path]", text)
+    if len(text) > limit:
+        return text[: limit - 1] + "…"
+    return text
+
+
+def _safe_code(value: object, *, fallback: str) -> str:
+    if not isinstance(value, str):
+        return fallback
+    code = _SAFE_CODE_RE.sub("_", value.strip().lower()).strip("_.-")
+    if not code:
+        return fallback
+    return code[:_MAX_CODE_CHARS]
+
+
+def _label_from_code(value: object, *, fallback: str) -> str:
+    code = _safe_code(value, fallback="")
+    if not code:
+        return fallback
+    return " ".join(part.capitalize() for part in code.replace(".", "_").split("_"))
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _records(value: object, *, limit: int) -> Tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(item for item in value[:limit] if isinstance(item, Mapping))
+
+
+def _optional_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _bounded_score(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(float(value)):
+        return None
+    return max(-1_000, min(1_000, int(value)))
+
+
+_READINESS_SEVERITIES = {
+    "ready": StatusSeverity.OK,
+    "good_for_vr": StatusSeverity.OK,
+    "warning": StatusSeverity.WARNING,
+    "usable_with_limitations": StatusSeverity.WARNING,
+    "not_recommended": StatusSeverity.WARNING,
+    "blocked": StatusSeverity.BLOCKED,
+    "unsupported": StatusSeverity.BLOCKED,
+    "error": StatusSeverity.ERROR,
+}
+
+_READINESS_LABELS = {
+    "ready": "Ready",
+    "good_for_vr": "Ready for VR",
+    "warning": "Needs attention",
+    "usable_with_limitations": "Usable with limitations",
+    "not_recommended": "Not recommended",
+    "blocked": "Blocked",
+    "unsupported": "Unsupported",
+    "error": "Error",
+}
+
+
+def _severity_for_readiness(value: object) -> StatusSeverity:
+    code = _safe_code(value, fallback="")
+    return _READINESS_SEVERITIES.get(code, StatusSeverity.UNKNOWN)
+
+
+def _readiness_label(value: object) -> str:
+    code = _safe_code(value, fallback="")
+    return _READINESS_LABELS.get(code, "Unknown")
+
+
+def _pairing_models(
+    result: FirstRunResult,
+) -> tuple[DaemonStatusModel, PairingStatusModel]:
+    state = result.state
+    if state is FirstRunState.DAEMON_UNREACHABLE:
+        return (
+            DaemonStatusModel(
+                severity=StatusSeverity.ERROR,
+                reachable=False,
+                title="Daemon unavailable",
+                message="The local VRhotspot daemon could not be reached.",
+                detail_code="connection_failed",
+            ),
+            PairingStatusModel(
+                severity=StatusSeverity.UNKNOWN,
+                paired=False,
+                title="Pairing unavailable",
+                message="Pairing cannot be checked until the daemon is reachable.",
+                detail_code="daemon_unreachable",
+            ),
+        )
+    if state is FirstRunState.DAEMON_REACHABLE_UNPAIRED:
+        return (
+            DaemonStatusModel(
+                severity=StatusSeverity.OK,
+                reachable=True,
+                title="Daemon reachable",
+                message="The local VRhotspot daemon is responding.",
+                detail_code="health_check_succeeded",
+            ),
+            PairingStatusModel(
+                severity=StatusSeverity.WARNING,
+                paired=False,
+                title="Pairing required",
+                message="Enter an API token to view authenticated diagnostics.",
+                detail_code="token_required",
+            ),
+        )
+    if state is FirstRunState.TOKEN_ACCEPTED:
+        return (
+            DaemonStatusModel(
+                severity=StatusSeverity.OK,
+                reachable=True,
+                title="Daemon connected",
+                message="The local daemon accepted authenticated read-only access.",
+                detail_code="authenticated_read_only_check_succeeded",
+            ),
+            PairingStatusModel(
+                severity=StatusSeverity.OK,
+                paired=True,
+                title="Paired",
+                message="The supplied API token was accepted.",
+                detail_code="token_accepted",
+            ),
+        )
+    if state is FirstRunState.TOKEN_REJECTED:
+        return (
+            DaemonStatusModel(
+                severity=StatusSeverity.OK,
+                reachable=True,
+                title="Daemon reachable",
+                message="The local VRhotspot daemon is responding.",
+                detail_code="health_check_succeeded",
+            ),
+            PairingStatusModel(
+                severity=StatusSeverity.ERROR,
+                paired=False,
+                title="Token rejected",
+                message="The supplied API token was rejected.",
+                detail_code="authentication_failed",
+            ),
+        )
+    if state is FirstRunState.DAEMON_TOKEN_MISSING:
+        return (
+            DaemonStatusModel(
+                severity=StatusSeverity.OK,
+                reachable=True,
+                title="Daemon reachable",
+                message="The local VRhotspot daemon is responding.",
+                detail_code="health_check_succeeded",
+            ),
+            PairingStatusModel(
+                severity=StatusSeverity.BLOCKED,
+                paired=False,
+                title="Daemon token missing",
+                message="The daemon administrator must configure API authentication.",
+                detail_code="api_token_missing",
+            ),
+        )
+    return (
+        DaemonStatusModel(
+            severity=StatusSeverity.UNKNOWN,
+            reachable=None,
+            title="Daemon status unknown",
+            message="The daemon returned an invalid or unsupported response.",
+            detail_code="unexpected_daemon_response",
+        ),
+        PairingStatusModel(
+            severity=StatusSeverity.UNKNOWN,
+            paired=False,
+            title="Pairing status unknown",
+            message="Pairing status could not be determined safely.",
+            detail_code="unexpected_daemon_response",
+        ),
+    )
+
+
+def _unknown_adapters(message: str) -> AdapterReadinessModel:
+    return AdapterReadinessModel(
+        severity=StatusSeverity.UNKNOWN,
+        title="Adapter readiness unknown",
+        summary=message,
+        recommended_interface="Not reported",
+        basic_mode_recommended_interface="Not reported",
+        cards=(),
+    )
+
+
+def _supported_bands(adapter: Mapping[str, Any]) -> Tuple[str, ...]:
+    fields = (
+        ("supports_2ghz", "2.4 GHz"),
+        ("supports_5ghz", "5 GHz"),
+        ("supports_6ghz", "6 GHz"),
+    )
+    return tuple(label for field, label in fields if adapter.get(field) is True)
+
+
+def _adapter_card(
+    adapter: Mapping[str, Any],
+    *,
+    recommended: str,
+    basic_recommended: str,
+) -> AdapterReadinessCard:
+    interface = _sanitize_text(
+        adapter.get("interface"),
+        fallback="Unknown adapter",
+        limit=80,
+    )
+    readiness = adapter.get("readiness_state")
+    visibility = _mapping(adapter.get("basic_mode_visibility"))
+    reason_codes = adapter.get("reason_codes")
+    if not isinstance(reason_codes, Sequence) or isinstance(
+        reason_codes, (str, bytes, bytearray)
+    ):
+        reason_codes = ()
+    reasons = tuple(
+        _label_from_code(reason, fallback="Unknown reason")
+        for reason in reason_codes[:_MAX_REASONS_PER_ADAPTER]
+    )
+    return AdapterReadinessCard(
+        interface=interface,
+        severity=_severity_for_readiness(readiness),
+        readiness_label=_readiness_label(readiness),
+        summary=_sanitize_text(
+            adapter.get("explanation"),
+            fallback="No readiness explanation was reported.",
+        ),
+        recommended=bool(recommended and interface == recommended),
+        basic_mode_recommended=bool(
+            basic_recommended and interface == basic_recommended
+        ),
+        basic_mode_visible=_optional_bool(visibility.get("visible")),
+        basic_mode_selectable=_optional_bool(visibility.get("selectable")),
+        driver=_sanitize_text(adapter.get("driver"), fallback="Not reported", limit=80),
+        bus_type=_label_from_code(adapter.get("bus_type"), fallback="Not reported"),
+        supported_bands=_supported_bands(adapter),
+        recommendation_score=_bounded_score(adapter.get("recommendation_score")),
+        reasons=reasons,
+    )
+
+
+def _adapter_model(response: object) -> AdapterReadinessModel:
+    if (
+        not isinstance(response, ApiResponse)
+        or response.result_code != "ok"
+        or not isinstance(response.data, Mapping)
+    ):
+        return _unknown_adapters(
+            "Adapter readiness could not be interpreted safely."
+        )
+
+    data = response.data
+    recommended = _sanitize_text(
+        data.get("recommended"),
+        fallback="",
+        limit=80,
+    )
+    basic_recommended = _sanitize_text(
+        data.get("basic_mode_recommended"),
+        fallback="",
+        limit=80,
+    )
+    cards = tuple(
+        _adapter_card(
+            adapter,
+            recommended=recommended,
+            basic_recommended=basic_recommended,
+        )
+        for adapter in _records(data.get("adapters"), limit=_MAX_ADAPTER_CARDS)
+    )
+
+    summary_data = _mapping(data.get("summary"))
+    summary_state: object = summary_data.get("readiness_state")
+    if not summary_state and recommended:
+        summary_state = next(
+            (
+                card.readiness_label
+                for card in cards
+                if card.interface == recommended
+            ),
+            "",
+        )
+    if summary_state in _READINESS_LABELS.values():
+        summary_severity = next(
+            (
+                card.severity
+                for card in cards
+                if card.interface == recommended
+            ),
+            StatusSeverity.UNKNOWN,
+        )
+        summary_label = str(summary_state)
+    else:
+        summary_severity = _severity_for_readiness(summary_state)
+        summary_label = _readiness_label(summary_state)
+
+    if not cards:
+        summary = "No adapter readiness cards were reported."
+    elif recommended:
+        summary = f"{recommended} is the daemon-recommended adapter."
+    else:
+        summary = "The daemon did not report a recommended adapter."
+
+    return AdapterReadinessModel(
+        severity=summary_severity,
+        title=f"Adapter readiness: {summary_label}",
+        summary=summary,
+        recommended_interface=recommended or "Not reported",
+        basic_mode_recommended_interface=basic_recommended or "Not reported",
+        cards=cards,
+    )
+
+
+_PREFLIGHT_LABELS = {
+    "ready": "Ready",
+    "warning": "Needs attention",
+    "blocked": "Blocked",
+    "error": "Error",
+}
+
+
+def _unknown_preflight(message: str) -> PreflightSummaryModel:
+    return PreflightSummaryModel(
+        severity=StatusSeverity.UNKNOWN,
+        readiness_label="Unknown",
+        summary=message,
+        facts=(),
+        issues=(),
+        actions=(),
+    )
+
+
+def _fact(label: str, value: object) -> SummaryFact:
+    return SummaryFact(
+        label=label,
+        value=_sanitize_text(value, fallback="Not reported"),
+    )
+
+
+def _service_status(value: object) -> str:
+    service = _mapping(value)
+    status = service.get("status")
+    if isinstance(status, str) and status.strip():
+        return _label_from_code(status, fallback="Not reported")
+    if service.get("active") is True:
+        return "Active"
+    if service.get("present") is True:
+        return "Present, inactive"
+    if service.get("present") is False:
+        return "Not installed"
+    return "Not reported"
+
+
+def _platform_summary(value: object) -> str:
+    platform = _mapping(value)
+    parts = tuple(
+        _sanitize_text(platform.get(field), fallback="", limit=80)
+        for field in ("os_name", "os_version", "host_kind")
+    )
+    reported = tuple(part for part in parts if part)
+    return " · ".join(reported) if reported else "Not reported"
+
+
+def _firewall_summary(value: object) -> str:
+    firewall = _mapping(value)
+    parts = tuple(
+        _label_from_code(firewall.get(field), fallback="")
+        for field in ("backend", "status")
+    )
+    reported = tuple(part for part in parts if part)
+    return " · ".join(reported) if reported else "Not reported"
+
+
+def _preflight_model(response: object) -> PreflightSummaryModel:
+    if (
+        not isinstance(response, ApiResponse)
+        or response.result_code != "ok"
+        or not isinstance(response.data, Mapping)
+    ):
+        return _unknown_preflight(
+            "Preflight diagnostics could not be interpreted safely."
+        )
+
+    report = response.data
+    schema_version = report.get("schema_version")
+    if isinstance(schema_version, bool) or schema_version != 1:
+        return _unknown_preflight(
+            "The daemon returned an unsupported preflight report."
+        )
+    readiness = _safe_code(report.get("overall_readiness"), fallback="")
+    if readiness not in {"ready", "warning", "blocked"}:
+        return _unknown_preflight(
+            "The daemon returned an unknown preflight readiness state."
+        )
+    if not isinstance(report.get("issues"), list) or not isinstance(
+        report.get("recommended_actions"), list
+    ):
+        return _unknown_preflight(
+            "The daemon returned a partial preflight report."
+        )
+
+    severity = _READINESS_SEVERITIES[readiness]
+    summary_messages = {
+        "ready": "The daemon reported no blocking preflight issues.",
+        "warning": "The daemon reported preflight items that need attention.",
+        "blocked": "The daemon reported issues that block hotspot readiness.",
+    }
+    platform = _mapping(report.get("platform"))
+    firewall = _mapping(report.get("firewall"))
+    services = _mapping(report.get("services"))
+    network = _mapping(report.get("network"))
+    wifi = _mapping(report.get("wifi"))
+    facts = (
+        _fact("Selected adapter", wifi.get("selected_adapter")),
+        _fact("Default route / uplink", network.get("active_uplink_interface")),
+        _fact("Platform", _platform_summary(platform)),
+        _fact("Firewall", _firewall_summary(firewall)),
+        _fact("NetworkManager", _service_status(services.get("network_manager"))),
+        _fact("iwd", _service_status(services.get("iwd"))),
+    )
+
+    issues = tuple(
+        PreflightIssueModel(
+            severity=_severity_for_readiness(issue.get("severity")),
+            code=_safe_code(issue.get("code"), fallback="unknown_issue"),
+            message=_sanitize_text(
+                issue.get("message"),
+                fallback="No issue description was reported.",
+            ),
+        )
+        for issue in _records(
+            report.get("issues"),
+            limit=_MAX_PREFLIGHT_ISSUES,
+        )
+    )
+    actions = tuple(
+        PreflightActionModel(
+            code=_safe_code(action.get("code"), fallback="recommended_action"),
+            message=_sanitize_text(
+                action.get("message"),
+                fallback="Review the daemon-reported preflight issue.",
+            ),
+        )
+        for action in _records(
+            report.get("recommended_actions"),
+            limit=_MAX_PREFLIGHT_ACTIONS,
+        )
+    )
+    return PreflightSummaryModel(
+        severity=severity,
+        readiness_label=_PREFLIGHT_LABELS[readiness],
+        summary=summary_messages[readiness],
+        facts=facts,
+        issues=issues,
+        actions=actions,
+    )
+
+
+def _support_bundle_affordance(paired: bool) -> SupportBundleAffordance:
+    if paired:
+        summary = (
+            "Daemon-produced redacted bundles will be exportable after "
+            "bounded download and portal wiring are reviewed."
+        )
+        availability_code = "export_not_implemented"
+    else:
+        summary = (
+            "Pair with the local daemon before support-bundle export can "
+            "be offered."
+        )
+        availability_code = "pairing_required"
+    return SupportBundleAffordance(
+        visible=True,
+        severity=StatusSeverity.UNKNOWN,
+        title="Support bundle",
+        summary=summary,
+        action_label="Export support bundle",
+        availability_code=availability_code,
+    )
+
+
+class DiagnosticsControlUiController:
+    """Build safe read-only UI models from pairing and local API results."""
+
+    def __init__(self, client: DiagnosticsUiClient | None = None):
+        self._client = client
+
+    def __repr__(self) -> str:
+        return (
+            "DiagnosticsControlUiController("
+            f"read_only_client_configured={self._client is not None!r})"
+        )
+
+    def build(
+        self,
+        *,
+        pairing_result: FirstRunResult,
+        mode: PresentationMode = PresentationMode.BASIC,
+    ) -> DiagnosticsControlUiModel:
+        """Collect only authenticated read-only sections after successful pairing."""
+
+        if not isinstance(mode, PresentationMode):
+            mode = PresentationMode.BASIC
+        if not isinstance(pairing_result, FirstRunResult):
+            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        daemon, pairing = _pairing_models(pairing_result)
+        adapters = _unknown_adapters(
+            "Pair with the local daemon to view adapter readiness."
+        )
+        preflight = _unknown_preflight(
+            "Pair with the local daemon to view preflight diagnostics."
+        )
+
+        if pairing.paired and self._client is not None:
+            try:
+                adapters = _adapter_model(self._client.adapter_readiness())
+            except Exception:
+                adapters = _unknown_adapters(
+                    "Adapter readiness is temporarily unavailable."
+                )
+            try:
+                preflight = _preflight_model(self._client.preflight_report())
+            except Exception:
+                preflight = _unknown_preflight(
+                    "Preflight diagnostics are temporarily unavailable."
+                )
+
+        return DiagnosticsControlUiModel(
+            mode=mode,
+            show_technical_details=mode is PresentationMode.PRO,
+            daemon=daemon,
+            pairing=pairing,
+            adapters=adapters,
+            preflight=preflight,
+            support_bundle=_support_bundle_affordance(pairing.paired),
+        )

--- a/tests/test_flatpak_diagnostics_control_ui.py
+++ b/tests/test_flatpak_diagnostics_control_ui.py
@@ -1,0 +1,558 @@
+from dataclasses import asdict
+import inspect
+from pathlib import Path
+
+import pytest
+
+from flatpak_client import (
+    ApiResponse,
+    DiagnosticsControlUiController,
+    FirstRunResult,
+    FirstRunState,
+    PresentationMode,
+    StatusSeverity,
+)
+
+
+def _response(data):
+    return ApiResponse(
+        correlation_id="ui-foundation-test",
+        result_code="ok",
+        warnings=(),
+        data=data,
+    )
+
+
+def _readiness_response(**overrides):
+    data = {
+        "recommended": "wlan1",
+        "basic_mode_recommended": "wlan1",
+        "adapters": [
+            {
+                "interface": "wlan1",
+                "driver": "mt7921u",
+                "bus_type": "usb",
+                "supports_2ghz": True,
+                "supports_5ghz": True,
+                "supports_6ghz": False,
+                "basic_mode_visibility": {
+                    "visible": True,
+                    "selectable": True,
+                },
+                "readiness_state": "good_for_vr",
+                "recommendation_score": 95,
+                "reason_codes": [
+                    "supports_ap_mode",
+                    "supports_5ghz",
+                    "supports_80mhz",
+                ],
+                "explanation": "Strong daemon-reported VR readiness.",
+            }
+        ],
+    }
+    data.update(overrides)
+    return _response(data)
+
+
+def _preflight_response(**overrides):
+    data = {
+        "schema_version": 1,
+        "overall_readiness": "ready",
+        "platform": {
+            "os_name": "Example Linux",
+            "os_version": "1",
+            "host_kind": "mutable_linux",
+        },
+        "firewall": {"backend": "nftables", "status": "available"},
+        "services": {
+            "network_manager": {"status": "active"},
+            "iwd": {"status": "not_installed"},
+        },
+        "network": {"active_uplink_interface": "enp4s0"},
+        "wifi": {"selected_adapter": "wlan1"},
+        "issues": [],
+        "recommended_actions": [],
+    }
+    data.update(overrides)
+    return _response(data)
+
+
+class FakeReadOnlyClient:
+    def __init__(self, *, readiness=None, preflight=None):
+        self.readiness = readiness or _readiness_response()
+        self.preflight = preflight or _preflight_response()
+        self.calls = []
+
+    def adapter_readiness(self):
+        self.calls.append("adapter_readiness")
+        if isinstance(self.readiness, BaseException):
+            raise self.readiness
+        return self.readiness
+
+    def preflight_report(self):
+        self.calls.append("preflight_report")
+        if isinstance(self.preflight, BaseException):
+            raise self.preflight
+        return self.preflight
+
+
+def _build(state, *, client=None, mode=PresentationMode.BASIC):
+    return DiagnosticsControlUiController(client).build(
+        pairing_result=FirstRunResult(state),
+        mode=mode,
+    )
+
+
+def test_daemon_unreachable_model_is_safe_and_does_not_query_sections():
+    client = FakeReadOnlyClient()
+
+    model = _build(FirstRunState.DAEMON_UNREACHABLE, client=client)
+
+    assert model.daemon.severity is StatusSeverity.ERROR
+    assert model.daemon.reachable is False
+    assert model.pairing.severity is StatusSeverity.UNKNOWN
+    assert model.pairing.paired is False
+    assert model.adapters.severity is StatusSeverity.UNKNOWN
+    assert model.preflight.severity is StatusSeverity.UNKNOWN
+    assert client.calls == []
+
+
+def test_reachable_without_token_is_unpaired_warning():
+    client = FakeReadOnlyClient()
+
+    model = _build(FirstRunState.DAEMON_REACHABLE_UNPAIRED, client=client)
+
+    assert model.daemon.severity is StatusSeverity.OK
+    assert model.daemon.reachable is True
+    assert model.pairing.severity is StatusSeverity.WARNING
+    assert model.pairing.title == "Pairing required"
+    assert model.pairing.paired is False
+    assert client.calls == []
+
+
+def test_accepted_token_loads_only_authenticated_read_only_sections():
+    client = FakeReadOnlyClient()
+
+    model = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+
+    assert model.daemon.severity is StatusSeverity.OK
+    assert model.pairing.severity is StatusSeverity.OK
+    assert model.pairing.paired is True
+    assert model.adapters.severity is StatusSeverity.OK
+    assert model.preflight.severity is StatusSeverity.OK
+    assert client.calls == ["adapter_readiness", "preflight_report"]
+
+
+def test_rejected_token_is_an_error_without_authenticated_queries():
+    client = FakeReadOnlyClient()
+
+    model = _build(FirstRunState.TOKEN_REJECTED, client=client)
+
+    assert model.daemon.severity is StatusSeverity.OK
+    assert model.pairing.severity is StatusSeverity.ERROR
+    assert model.pairing.title == "Token rejected"
+    assert model.pairing.detail_code == "authentication_failed"
+    assert client.calls == []
+
+
+def test_missing_daemon_token_is_a_blocked_pairing_state():
+    client = FakeReadOnlyClient()
+
+    model = _build(FirstRunState.DAEMON_TOKEN_MISSING, client=client)
+
+    assert model.daemon.severity is StatusSeverity.OK
+    assert model.pairing.severity is StatusSeverity.BLOCKED
+    assert model.pairing.title == "Daemon token missing"
+    assert model.pairing.detail_code == "api_token_missing"
+    assert client.calls == []
+
+
+def test_adapter_readiness_cards_preserve_daemon_recommendation_and_basic_fields():
+    readiness = _readiness_response(
+        adapters=[
+            {
+                "interface": "wlan1",
+                "driver": "mt7921u",
+                "bus_type": "usb",
+                "supports_2ghz": True,
+                "supports_5ghz": True,
+                "supports_6ghz": False,
+                "basic_mode_visibility": {
+                    "visible": True,
+                    "selectable": True,
+                },
+                "readiness_state": "good_for_vr",
+                "recommendation_score": 92,
+                "reason_codes": ["supports_ap_mode", "supports_80mhz"],
+                "explanation": "Recommended by the daemon.",
+            },
+            {
+                "interface": "wlan0",
+                "driver": "iwlwifi",
+                "bus_type": "pci",
+                "supports_2ghz": True,
+                "supports_5ghz": True,
+                "supports_6ghz": False,
+                "basic_mode_visibility": {
+                    "visible": False,
+                    "selectable": False,
+                },
+                "readiness_state": "not_recommended",
+                "recommendation_score": 40,
+                "reason_codes": ["wlan0_deprioritized"],
+                "explanation": "Internal adapter is deprioritized.",
+            },
+        ]
+    )
+    client = FakeReadOnlyClient(readiness=readiness)
+
+    model = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+
+    assert model.adapters.recommended_interface == "wlan1"
+    assert model.adapters.basic_mode_recommended_interface == "wlan1"
+    assert len(model.adapters.cards) == 2
+    recommended, internal = model.adapters.cards
+    assert recommended.interface == "wlan1"
+    assert recommended.severity is StatusSeverity.OK
+    assert recommended.recommended is True
+    assert recommended.basic_mode_recommended is True
+    assert recommended.basic_mode_visible is True
+    assert recommended.basic_mode_selectable is True
+    assert recommended.supported_bands == ("2.4 GHz", "5 GHz")
+    assert recommended.reasons == ("Supports Ap Mode", "Supports 80mhz")
+    assert internal.severity is StatusSeverity.WARNING
+    assert internal.recommended is False
+    assert internal.basic_mode_visible is False
+    assert internal.basic_mode_selectable is False
+
+
+def test_preflight_summary_issues_and_actions_have_ui_severity_mapping():
+    preflight = _preflight_response(
+        overall_readiness="blocked",
+        issues=[
+            {
+                "severity": "blocked",
+                "code": "no_ap_capable_adapter",
+                "message": "No AP-capable adapter was found.",
+            },
+            {
+                "severity": "warning",
+                "code": "regdom_unknown",
+                "message": "Regulatory domain is unknown.",
+            },
+            {
+                "severity": "error",
+                "code": "probe_failed",
+                "message": "A read-only probe failed.",
+            },
+            {
+                "severity": "future_state",
+                "code": "future_issue",
+                "message": "A future issue type was reported.",
+            },
+        ],
+        recommended_actions=[
+            {
+                "code": "no_ap_capable_adapter",
+                "message": "Connect an AP-capable Wi-Fi adapter.",
+            }
+        ],
+    )
+    client = FakeReadOnlyClient(preflight=preflight)
+
+    model = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+
+    assert model.preflight.severity is StatusSeverity.BLOCKED
+    assert model.preflight.readiness_label == "Blocked"
+    assert [issue.severity for issue in model.preflight.issues] == [
+        StatusSeverity.BLOCKED,
+        StatusSeverity.WARNING,
+        StatusSeverity.ERROR,
+        StatusSeverity.UNKNOWN,
+    ]
+    assert model.preflight.actions[0].interactive is False
+    facts = {fact.label: fact.value for fact in model.preflight.facts}
+    assert facts["Selected adapter"] == "wlan1"
+    assert facts["Default route / uplink"] == "enp4s0"
+    assert facts["Firewall"] == "Nftables · Available"
+    assert facts["NetworkManager"] == "Active"
+
+
+def test_support_bundle_affordance_is_present_but_never_performs_a_request():
+    client = FakeReadOnlyClient()
+
+    paired = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+    unpaired = _build(FirstRunState.DAEMON_REACHABLE_UNPAIRED, client=client)
+
+    assert paired.support_bundle.visible is True
+    assert paired.support_bundle.action_label == "Export support bundle"
+    assert paired.support_bundle.availability_code == "export_not_implemented"
+    assert paired.support_bundle.action_enabled is False
+    assert paired.support_bundle.requires_portal is True
+    assert paired.support_bundle.request_performed is False
+    assert unpaired.support_bundle.availability_code == "pairing_required"
+    assert client.calls == ["adapter_readiness", "preflight_report"]
+
+
+def test_secret_fields_assignments_and_absolute_paths_do_not_enter_ui_models():
+    secret_token = "ui-model-secret-token"
+    wifi_secret = "ui-model-wifi-passphrase"
+    readiness = _readiness_response(
+        api_token=secret_token,
+        wpa2_passphrase=wifi_secret,
+        adapters=[
+            {
+                "interface": "wlan1",
+                "driver": "mt7921u",
+                "bus_type": "usb",
+                "readiness_state": "good_for_vr",
+                "api_token": secret_token,
+                "wpa2_passphrase": wifi_secret,
+                "explanation": (
+                    f"API token={secret_token}; passphrase={wifi_secret}; "
+                    "details in /etc/vr-hotspot/env"
+                ),
+            }
+        ],
+    )
+    preflight = _preflight_response(
+        api_token=secret_token,
+        environment={"VR_HOTSPOTD_API_TOKEN": secret_token},
+        wifi={
+            "selected_adapter": "wlan1",
+            "wpa2_passphrase": wifi_secret,
+        },
+        issues=[
+            {
+                "severity": "warning",
+                "code": "secret_test",
+                "message": (
+                    f"Authorization: Bearer {secret_token}; "
+                    f"password={wifi_secret}; see /var/lib/vr-hotspot/state.json"
+                ),
+                "raw_environment": {"TOKEN": secret_token},
+            }
+        ],
+        recommended_actions=[],
+    )
+    controller = DiagnosticsControlUiController(
+        FakeReadOnlyClient(readiness=readiness, preflight=preflight)
+    )
+
+    model = controller.build(
+        pairing_result=FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+    )
+    exposed = repr(asdict(model)) + repr(model) + repr(controller)
+
+    assert secret_token not in exposed
+    assert wifi_secret not in exposed
+    assert "/etc/vr-hotspot/env" not in exposed
+    assert "/var/lib/vr-hotspot/state.json" not in exposed
+    assert "[redacted]" in exposed
+    assert "[host path]" in exposed
+    assert "raw_environment" not in exposed
+
+
+@pytest.mark.parametrize(
+    ("daemon_text", "forbidden_fragments"),
+    [
+        (
+            "token abc123",
+            ("abc123",),
+        ),
+        (
+            "passphrase correct horse battery staple",
+            ("correct", "horse", "battery", "staple"),
+        ),
+        (
+            '"token": "json-token-value"',
+            ("json-token-value",),
+        ),
+        (
+            '"password": "json password value"',
+            ("json", "password value"),
+        ),
+        (
+            "password: hunter2",
+            ("hunter2",),
+        ),
+        (
+            "psk = wifi-psk-value",
+            ("wifi-psk-value",),
+        ),
+        (
+            "secret=private-secret-value; key: private-key-value",
+            ("private-secret-value", "private-key-value"),
+        ),
+        (
+            "secret open sesame; key private material",
+            ("open", "sesame", "private material"),
+        ),
+        (
+            "Open file:///home/example-user/private/config.json",
+            ("file://", "/home/", "example-user", "config.json"),
+        ),
+        (
+            "Read /etc/vr-hotspot/env and /tmp/vr-hotspot-debug.log",
+            ("/etc/", "/tmp/", "vr-hotspot-debug.log"),
+        ),
+        (
+            "state:/var/lib/vr-hotspot/state.json; socket:/run/vr-hotspotd.sock",
+            ("/var/lib/", "/run/", "state.json", "vr-hotspotd.sock"),
+        ),
+        (
+            "password mixed secret words; inspect file:///var/lib/private/state.json",
+            ("mixed", "secret words", "file://", "/var/lib/", "state.json"),
+        ),
+    ],
+)
+def test_blocker_secret_and_host_path_forms_are_fully_sanitized(
+    daemon_text,
+    forbidden_fragments,
+):
+    client = FakeReadOnlyClient(
+        preflight=_preflight_response(
+            overall_readiness="warning",
+            issues=[
+                {
+                    "severity": "warning",
+                    "code": "sanitizer_test",
+                    "message": daemon_text,
+                }
+            ],
+        )
+    )
+
+    model = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+    sanitized = model.preflight.issues[0].message
+
+    assert all(fragment not in sanitized for fragment in forbidden_fragments)
+    assert "[redacted]" in sanitized or "[host path]" in sanitized
+
+
+def test_malformed_partial_and_failed_daemon_responses_degrade_to_unknown():
+    secret = "must-not-escape-from-error"
+    malformed = FakeReadOnlyClient(
+        readiness={"adapters": [{"interface": "wlan1"}]},
+        preflight=_response(
+            {
+                "schema_version": 1,
+                "overall_readiness": "ready",
+                "issues": [],
+            }
+        ),
+    )
+    failed = FakeReadOnlyClient(
+        readiness=RuntimeError(f"readiness failed with {secret}"),
+        preflight=RuntimeError(f"preflight failed with {secret}"),
+    )
+
+    malformed_model = _build(FirstRunState.TOKEN_ACCEPTED, client=malformed)
+    failed_model = _build(FirstRunState.TOKEN_ACCEPTED, client=failed)
+
+    assert malformed_model.adapters.severity is StatusSeverity.UNKNOWN
+    assert malformed_model.adapters.cards == ()
+    assert malformed_model.preflight.severity is StatusSeverity.UNKNOWN
+    assert malformed_model.preflight.issues == ()
+    assert malformed_model.preflight.actions == ()
+    assert failed_model.adapters.severity is StatusSeverity.UNKNOWN
+    assert failed_model.preflight.severity is StatusSeverity.UNKNOWN
+    assert secret not in repr(failed_model)
+
+
+def test_daemon_content_and_collections_are_bounded():
+    long_text = "x" * 1_000
+    adapters = [
+        {
+            "interface": f"wlan{index}",
+            "readiness_state": "warning",
+            "reason_codes": [f"reason_{reason}" for reason in range(20)],
+            "explanation": long_text,
+        }
+        for index in range(30)
+    ]
+    issues = [
+        {"severity": "warning", "code": f"issue_{index}", "message": long_text}
+        for index in range(30)
+    ]
+    actions = [
+        {"code": f"action_{index}", "message": long_text}
+        for index in range(30)
+    ]
+    client = FakeReadOnlyClient(
+        readiness=_readiness_response(adapters=adapters),
+        preflight=_preflight_response(
+            overall_readiness="warning",
+            issues=issues,
+            recommended_actions=actions,
+        ),
+    )
+
+    model = _build(FirstRunState.TOKEN_ACCEPTED, client=client)
+
+    assert len(model.adapters.cards) == 12
+    assert len(model.adapters.cards[0].reasons) == 6
+    assert len(model.adapters.cards[0].summary) == 240
+    assert model.adapters.cards[0].summary.endswith("…")
+    assert len(model.preflight.issues) == 16
+    assert len(model.preflight.actions) == 12
+    assert len(model.preflight.issues[0].message) == 240
+    assert len(model.preflight.actions[0].message) == 240
+
+
+def test_basic_and_pro_modes_change_presentation_depth_not_daemon_policy():
+    basic = _build(FirstRunState.DAEMON_REACHABLE_UNPAIRED)
+    pro = _build(
+        FirstRunState.DAEMON_REACHABLE_UNPAIRED,
+        mode=PresentationMode.PRO,
+    )
+
+    assert basic.mode is PresentationMode.BASIC
+    assert basic.show_technical_details is False
+    assert pro.mode is PresentationMode.PRO
+    assert pro.show_technical_details is True
+    assert basic.pairing == pro.pairing
+    assert basic.adapters == pro.adapters
+    assert basic.preflight == pro.preflight
+
+
+def test_controller_exposes_no_mutation_or_generic_request_methods():
+    public_methods = {
+        name
+        for name, value in inspect.getmembers(
+            DiagnosticsControlUiController,
+            inspect.isfunction,
+        )
+        if not name.startswith("_")
+    }
+
+    assert public_methods == {"build"}
+    assert public_methods.isdisjoint(
+        {
+            "start",
+            "stop",
+            "restart",
+            "repair",
+            "save_config",
+            "update_config",
+            "request",
+            "post",
+            "support_bundle",
+            "export",
+        }
+    )
+
+
+def test_ui_foundation_has_no_direct_network_host_or_secret_source_access():
+    source = Path("flatpak_client/ui.py").read_text(encoding="utf-8")
+
+    for forbidden in (
+        "import os",
+        "import socket",
+        "import subprocess",
+        "import urllib",
+        "import requests",
+        "os.environ",
+        "Path(",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
Adds the toolkit-agnostic diagnostics/control UI foundation for the future Flatpak control app.

What changed:
- Added `flatpak_client/ui.py`.
- Updated `flatpak_client/__init__.py`.
- Added `tests/test_flatpak_diagnostics_control_ui.py`.
- Updated `docs/FLATPAK_ARCHITECTURE_PLAN.md` to mark PR #80 as the diagnostics/control UI foundation step.

UI foundation:
- Toolkit-agnostic.
- Read-only.
- No finished graphical UI.
- No Flatpak package or manifest.
- Builds safe UI-ready models for:
  - daemon status
  - pairing status
  - adapter readiness/cards
  - preflight facts/issues/actions
  - support-bundle affordance
  - presentation mode
  - aggregate diagnostics/control state

Read-only sections represented:
- daemon reachability/authentication
- pairing
- adapter readiness
- canonical preflight diagnostics
- disabled support-bundle export affordance

Severity/status mapping:
- `ok`
- `warning`
- `blocked`
- `error`
- `unknown`

Safety behavior:
- Malformed or unrecognized states degrade to `unknown`.
- Projection is allowlisted and bounded.
- Raw daemon responses are not exposed.
- Raw exception text is not exposed.
- No mutation controls or methods are wired.

Secret/path sanitization:
- Covers spaced secrets.
- Covers JSON-style assignments.
- Covers colon/equal assignments.
- Covers Bearer/API tokens.
- Covers passphrase/password/PSK/secret/key values.
- Covers file URIs.
- Covers Linux absolute host paths.
- Covers mixed secret/path text.

Basic/Pro handling:
- Presentation-only mode fields.
- Mode does not alter API calls.
- Mode does not alter policy.
- Mode does not alter recommendations.
- Mode does not alter authorization.

Out of scope:
- No Flatpak packaging.
- No finished GUI/toolkit implementation.
- No daemon API behavior changes.
- No runtime behavior changes.
- No installer behavior changes.
- No CI behavior changes.
- No vendor changes.
- No existing WebUI changes.
- No Steam Frame or VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- `python -m json.tool backend/vendor/VENDOR_MANIFEST.json`
- `python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json`
- `python -m json.tool /tmp/vrhotspot-vendor-sbom.json`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `bash -n backend/scripts/install.sh`
- `bash -n backend/scripts/uninstall.sh`
- `tools/ci/install_matrix_check.sh`
- `.venv/bin/python -m pytest -q tests/test_flatpak_diagnostics_control_ui.py tests/test_flatpak_local_api_client.py tests/test_flatpak_token_pairing.py`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Result:
- `57 passed` focused UI/client/pairing tests
- `701 passed, 4 subtests passed` full suite

Review:
- `/tmp/vrhotspot-flatpak-diagnostics-control-ui-final-review-v2.md`
- SHA-256: `7a391817dae910613bcecefd35f6a74d214ad4d8f5ab9dba5abced9c3444a9de`
- Verdict: approve
