### PR TITLE
Add Flatpak app shell prototype

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,16 +1,16 @@
 # Flatpak control app architecture plan
 
-Status: PR #80 diagnostics/control UI foundation; PRs #77-#79 retained
+Status: PR #81 Flatpak packaging/app shell prototype; PRs #77-#80 retained
 
 Date: 2026-07-23
 
-This document defines the boundary for a possible future Flatpak control
-application for VRhotspot. PR #80 adds only the toolkit-agnostic, testable UI
-model/controller foundation described below, on top of PR #78's read-only local
-API client and PR #79's pairing state. It does not add a Flatpak package,
-manifest, desktop application, finished graphical UI, API endpoint, or runtime
-behavior. No Flatpak package or manifest exists yet, and no graphical Flatpak
-application exists yet.
+This document defines the boundary for the VRhotspot Flatpak control
+application. PR #81 adds the first rough installable and testable Flatpak app
+shell on top of PR #78's read-only local API client, PR #79's pairing state, and
+PR #80's toolkit-agnostic UI model/controller foundation. It proves packaging,
+launching, a deterministic standard-library smoke path, and a lazy GTK 4
+placeholder window. It is not a finished production UI and adds no daemon API,
+daemon runtime, installer, privileged action, or credential-storage behavior.
 
 ## Architectural decision
 
@@ -254,6 +254,54 @@ with a generic label. API tokens and Wi-Fi passphrases are not model fields.
 The controller copies no exception text into UI state and exposes no raw
 preflight report or response body.
 
+## PR #81 packaging and app shell prototype
+
+PR #81 adds `flatpak_app/` and the JSON manifest
+`packaging/flatpak/io.github.josethevrtech.VRhotspot.json` for application ID
+`io.github.josethevrtech.VRhotspot`. The manifest installs only the app shell,
+the existing `flatpak_client` prototype, and simple static desktop metadata and
+icon assets. It does not include the daemon package, privileged networking
+code, systemd units, installers, or `backend/vendor/` payload.
+
+The default launcher opens a rough GTK 4 placeholder when the selected GNOME
+runtime supplies GTK and PyGObject. Toolkit loading is lazy, so importing the
+shell and running repository tests do not require GTK on the development host.
+The window is display-only: it starts from a safe offline/unpaired Basic-mode
+model, does not contact the daemon, and contains no lifecycle, repair,
+configuration, adapter-selection, or other privileged action.
+
+The standard-library smoke path is:
+
+```bash
+python -m flatpak_app --smoke-json
+```
+
+It prints one bounded JSON document built from the existing pairing and
+diagnostics/control UI concepts. It performs no network request, credential
+discovery, host-file access, portal call, or persistence.
+
+With the required Flatpak tooling and GNOME runtime available, a developer can
+build, install, and launch the prototype from the repository root:
+
+```bash
+flatpak-builder --user --install --force-clean build-dir \
+  packaging/flatpak/io.github.josethevrtech.VRhotspot.json
+flatpak run io.github.josethevrtech.VRhotspot
+```
+
+The manifest grants ordinary network sharing only because Flatpak has no
+loopback-only network permission and the existing client must eventually reach
+the pinned local HTTP API. The client still permits only literal HTTP loopback
+origins. The remaining finish arguments provide Wayland and fallback X11
+display access. There is no filesystem permission, system-bus access, session-
+bus name ownership, device permission, or host networking authority.
+
+Real credential entry UI and live authenticated daemon wiring are not included.
+The shell does not discover or persist credentials through files, environment,
+keyrings, portals, or daemon configuration. Support-bundle export remains a
+disabled placeholder; portal export and bounded download handling require
+separate review.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -339,7 +387,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #77 | Architecture plan only. No package, manifest, API, UI, runtime, installer, CI, or vendor change. | This document makes ownership, API/authentication, sandbox, privacy, support-bundle, distribution, and non-goal boundaries reviewable. |
 | PR #78 | Flatpak local API client prototype. Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
 | PR #79 | Token pairing and first-run foundation. Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
-| PR #80 | Diagnostics/control UI foundation (current phase). Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
+| PR #80 | Diagnostics/control UI foundation. Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
+| PR #81 | Flatpak packaging/app shell prototype (current phase). Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -352,19 +401,19 @@ a production Flatpak release:
 
 | Question | Required decision |
 |---|---|
-| Application ID | Select a stable reverse-DNS ID and confirm naming/ownership before creating manifests or published metadata. |
-| Permissions | Document the minimum finish-args and portals, the practical breadth of network sharing, and the reason for every exception. |
-| Runtime and SDK | Select supported versions, update cadence, end-of-life policy, architecture targets, and reproducible/offline build expectations. |
-| Desktop file | Define name, categories, startup behavior, actions, and whether any URL scheme is justified. |
-| Icons and metainfo | Produce reviewed icon sizes and AppStream/metainfo with accurate screenshots, releases, licenses, privacy statements, and no unsupported feature claims. Existing Web UI assets are not automatically release-ready desktop metadata. |
+| Application ID | PR #81 uses `io.github.josethevrtech.VRhotspot`; confirm naming and publication ownership before a store submission. |
+| Permissions | PR #81 documents its prototype finish-args; reassess network breadth, display compatibility, and any future portal before production. |
+| Runtime and SDK | PR #81 selects GNOME 50 for the prototype; define update cadence, end-of-life policy, architecture targets, and reproducible/offline release expectations. |
+| Desktop file | PR #81 provides a minimal launcher entry with no desktop actions or URL scheme; review production naming and startup behavior. |
+| Icons and metainfo | PR #81 provides simple prototype SVG and AppStream metadata; production artwork, screenshots, releases, privacy copy, and store polish remain unresolved. Existing Web UI assets are not automatically release-ready desktop metadata. |
 | Local daemon discovery | Decide how to detect an installed/compatible daemon without broad filesystem access, service-manager control, or token leakage. |
 | Offline/local-first behavior | Confirm that installed control functions need no cloud service; define behavior when the internet is unavailable and distinguish that from daemon unavailability. |
 | Versioning and compatibility | Define client, API, and daemon compatibility ranges, upgrade ordering, unsupported-version messaging, and rollback expectations. |
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-No candidate answer in this table is a packaging implementation or permission
-approval.
+PR #81's prototype choices are not blanket approval for production packaging
+or additional permissions.
 
 ## Future test and validation expectations
 
@@ -420,12 +469,12 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #80
+## Explicit non-goals for PR #81
 
-- No Flatpak packaging, manifest, build definition, finish-args, desktop file,
-  icon set, metainfo, repository submission, or release artifact.
-- No finished Flatpak GUI, GTK/libadwaita or Qt dependency, desktop window, or
-  existing Web UI change. PR #80 is a view-model/controller foundation only.
+- No finished production UI or existing Web UI change. The GTK window is a
+  rough display-only placeholder, not a production control surface.
+- No Flathub submission, release artifact, production metadata polish,
+  screenshots, signing, or distribution automation.
 - No start, stop, restart, repair, configuration, passphrase, adapter-selection,
   or other mutation control.
 - No support-bundle download, temporary file handling, file chooser, portal
@@ -450,9 +499,10 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #80 authorizes only the isolated toolkit-agnostic diagnostics/control UI
-model foundation, its offline tests, the required exports, and this plan
-update. It does not claim that a Flatpak package, finished graphical UI,
-support-bundle export flow, Steam Frame support, VR Direct Link support, or a
-known-adapter registry exists. Packaging, production GUI work, lifecycle
-controls, portal wiring, and all later phases remain separately approved work.
+PR #81 authorizes only the isolated Flatpak packaging/app shell prototype, its
+lazy GTK placeholder, static metadata, offline tests, and this plan update. It
+does not claim that a finished graphical UI, credential-entry flow,
+support-bundle portal export, Flathub-polished release, Steam Frame support, VR
+Direct Link support, or a known-adapter registry exists. Production UI work,
+credential entry, portal export, Flathub polish, Steam Frame, VR Direct Link,
+adapter registry work, and all later phases remain separately approved work.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -1,0 +1,21 @@
+"""Minimal unprivileged application shell for the VRhotspot Flatpak."""
+
+from .app import (
+    APP_ID,
+    APP_NAME,
+    MAX_SMOKE_JSON_BYTES,
+    build_initial_model,
+    build_smoke_payload,
+    main,
+    render_smoke_json,
+)
+
+__all__ = [
+    "APP_ID",
+    "APP_NAME",
+    "MAX_SMOKE_JSON_BYTES",
+    "build_initial_model",
+    "build_smoke_payload",
+    "main",
+    "render_smoke_json",
+]

--- a/flatpak_app/__main__.py
+++ b/flatpak_app/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for the VRhotspot Flatpak shell."""
+
+from .app import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -1,0 +1,193 @@
+"""Launchable, read-only Flatpak application shell prototype."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+import sys
+from typing import Any, Sequence
+
+from flatpak_client import (
+    DiagnosticsControlUiController,
+    DiagnosticsControlUiModel,
+    FirstRunResult,
+    FirstRunState,
+    PresentationMode,
+)
+
+
+APP_ID = "io.github.josethevrtech.VRhotspot"
+APP_NAME = "VR Hotspot"
+MAX_SMOKE_JSON_BYTES = 8_192
+
+
+class GuiUnavailableError(RuntimeError):
+    """GTK 4 or PyGObject is unavailable for the graphical shell."""
+
+
+def build_initial_model() -> DiagnosticsControlUiModel:
+    """Build a deterministic offline/unpaired model without daemon access."""
+
+    return DiagnosticsControlUiController().build(
+        pairing_result=FirstRunResult(FirstRunState.INVALID_RESPONSE),
+        mode=PresentationMode.BASIC,
+    )
+
+
+def build_smoke_payload() -> dict[str, Any]:
+    """Return a bounded, non-secret description of the initial shell."""
+
+    model = build_initial_model()
+    return {
+        "application": {
+            "id": APP_ID,
+            "name": APP_NAME,
+            "prototype": True,
+        },
+        "controls": {
+            "mutation_actions": [],
+            "support_bundle_export_enabled": False,
+        },
+        "shell": {
+            "graphical_shell": "gtk4_placeholder",
+            "state": "offline_unpaired",
+        },
+        "ui": asdict(model),
+    }
+
+
+def render_smoke_json() -> str:
+    """Serialize the deterministic smoke payload and enforce its size bound."""
+
+    rendered = json.dumps(
+        build_smoke_payload(),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(rendered.encode("utf-8")) > MAX_SMOKE_JSON_BYTES:
+        raise RuntimeError("The Flatpak shell smoke payload exceeded its size limit.")
+    return rendered
+
+
+def _load_gtk():
+    """Import GTK only when the graphical entry point is launched."""
+
+    try:
+        import gi
+
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+    except (ImportError, ValueError):
+        raise GuiUnavailableError(
+            "GTK 4 and PyGObject are required for the graphical shell."
+        ) from None
+    return Gtk
+
+
+def _add_text_label(Gtk, container, text: str, *, css_class: str | None = None) -> None:
+    label = Gtk.Label(label=text)
+    label.set_wrap(True)
+    label.set_xalign(0.0)
+    if css_class:
+        label.add_css_class(css_class)
+    container.append(label)
+
+
+def run_gui() -> int:
+    """Run the rough GTK window without contacting the host daemon."""
+
+    Gtk = _load_gtk()
+    model = build_initial_model()
+    application = Gtk.Application(application_id=APP_ID)
+
+    def on_activate(app) -> None:
+        window = Gtk.ApplicationWindow(application=app)
+        window.set_title(APP_NAME)
+        window.set_default_size(560, 420)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=14)
+        content.set_margin_top(24)
+        content.set_margin_bottom(24)
+        content.set_margin_start(24)
+        content.set_margin_end(24)
+
+        _add_text_label(Gtk, content, APP_NAME, css_class="title-1")
+        _add_text_label(
+            Gtk,
+            content,
+            "Flatpak app shell prototype",
+            css_class="title-3",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            "This rough shell is intentionally offline and unpaired. "
+            "Credential entry and live daemon wiring remain future work.",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            f"Presentation mode: {model.mode.value.capitalize()}",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            f"Daemon: {model.daemon.title}",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            f"Pairing: {model.pairing.title}",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            "Support-bundle export is visible as a disabled placeholder; "
+            "no portal or file access is wired.",
+        )
+        _add_text_label(
+            Gtk,
+            content,
+            "No lifecycle or configuration controls are available.",
+            css_class="dim-label",
+        )
+
+        window.set_child(content)
+        window.present()
+
+    application.connect("activate", on_activate)
+    return int(application.run([]))
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vrhotspot-flatpak",
+        description="VR Hotspot Flatpak app shell prototype",
+    )
+    parser.add_argument(
+        "--smoke-json",
+        action="store_true",
+        help="print a bounded offline shell model as JSON and exit",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the deterministic smoke path or launch the GTK placeholder."""
+
+    args = _argument_parser().parse_args(argv)
+    if args.smoke_json:
+        print(render_smoke_json())
+        return 0
+
+    try:
+        return run_gui()
+    except GuiUnavailableError:
+        print(
+            "The graphical prototype requires GTK 4 and PyGObject. "
+            "Use --smoke-json for the offline shell check.",
+            file=sys.stderr,
+        )
+        return 2

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.desktop
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=VR Hotspot
+Comment=Launch the VR Hotspot Flatpak shell prototype
+Exec=vrhotspot-flatpak
+Icon=io.github.josethevrtech.VRhotspot
+Terminal=false
+Categories=Network;
+StartupNotify=true

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.json
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.json
@@ -1,0 +1,81 @@
+{
+  "app-id": "io.github.josethevrtech.VRhotspot",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
+  "command": "vrhotspot-flatpak",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=wayland",
+    "--socket=fallback-x11"
+  ],
+  "modules": [
+    {
+      "name": "vrhotspot-flatpak-shell",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -d /app/lib/vrhotspot/flatpak_app /app/lib/vrhotspot/flatpak_client",
+        "install -m 0644 flatpak_app/__init__.py flatpak_app/__main__.py flatpak_app/app.py /app/lib/vrhotspot/flatpak_app/",
+        "install -m 0644 flatpak_client/__init__.py flatpak_client/client.py flatpak_client/pairing.py flatpak_client/ui.py /app/lib/vrhotspot/flatpak_client/",
+        "install -Dm755 vrhotspot-flatpak /app/bin/vrhotspot-flatpak",
+        "install -Dm644 io.github.josethevrtech.VRhotspot.desktop /app/share/applications/io.github.josethevrtech.VRhotspot.desktop",
+        "install -Dm644 io.github.josethevrtech.VRhotspot.metainfo.xml /app/share/metainfo/io.github.josethevrtech.VRhotspot.metainfo.xml",
+        "install -Dm644 io.github.josethevrtech.VRhotspot.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot.svg"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "../../flatpak_app/__init__.py",
+          "dest": "flatpak_app"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_app/__main__.py",
+          "dest": "flatpak_app"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_app/app.py",
+          "dest": "flatpak_app"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_client/__init__.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_client/client.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_client/pairing.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_client/ui.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
+          "path": "vrhotspot-flatpak"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot.desktop"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot.metainfo.xml"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot.svg"
+        }
+      ]
+    }
+  ]
+}

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.metainfo.xml
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.josethevrtech.VRhotspot</id>
+  <name>VR Hotspot</name>
+  <summary>Prototype control shell for a host-installed VRhotspot daemon</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="io.github.josethevrtech">
+    <name>VRhotspot contributors</name>
+  </developer>
+  <description>
+    <p>
+      VR Hotspot is an early Flatpak app shell for the separately installed
+      VRhotspot daemon. This prototype launches an offline, unpaired status
+      window and does not provide hotspot lifecycle or configuration controls.
+    </p>
+    <p>
+      The privileged daemon and its host installer remain separate from this
+      unprivileged application.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/josethevrtech/VRhotspot</url>
+  <launchable type="desktop-id">io.github.josethevrtech.VRhotspot.desktop</launchable>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.1.0" date="2026-07-23">
+      <description>
+        <p>First rough installable and testable Flatpak shell prototype.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.svg
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6d4aff"/>
+      <stop offset="1" stop-color="#1466cc"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#background)"/>
+  <path
+    d="M30 50c19-18 49-18 68 0M40 63c13-12 35-12 48 0M52 76c7-6 17-6 24 0"
+    fill="none"
+    stroke="#fff"
+    stroke-linecap="round"
+    stroke-width="9"
+  />
+  <circle cx="64" cy="91" r="7" fill="#fff"/>
+</svg>

--- a/packaging/flatpak/vrhotspot-flatpak
+++ b/packaging/flatpak/vrhotspot-flatpak
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+PYTHONPATH=/app/lib/vrhotspot
+export PYTHONPATH
+
+exec python3 -m flatpak_app "$@"

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -1,0 +1,251 @@
+import configparser
+import importlib
+import inspect
+import json
+from pathlib import Path
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+APP_ID = "io.github.josethevrtech.VRhotspot"
+APP_NAME = "VR Hotspot"
+MANIFEST_PATH = Path("packaging/flatpak") / f"{APP_ID}.json"
+DESKTOP_PATH = Path("packaging/flatpak") / f"{APP_ID}.desktop"
+METAINFO_PATH = Path("packaging/flatpak") / f"{APP_ID}.metainfo.xml"
+LAUNCHER_PATH = Path("packaging/flatpak/vrhotspot-flatpak")
+
+
+def _manifest():
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _smoke():
+    return subprocess.run(
+        [sys.executable, "-m", "flatpak_app", "--smoke-json"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_app_shell_imports_without_importing_gtk(monkeypatch):
+    monkeypatch.setitem(sys.modules, "gi", None)
+    for module_name in tuple(sys.modules):
+        if module_name == "flatpak_app" or module_name.startswith("flatpak_app."):
+            del sys.modules[module_name]
+
+    module = importlib.import_module("flatpak_app")
+
+    assert module.APP_ID == APP_ID
+    assert sys.modules.get("gi") is None
+
+
+def test_smoke_json_exits_successfully_is_bounded_and_has_expected_sections():
+    from flatpak_app import MAX_SMOKE_JSON_BYTES
+
+    result = _smoke()
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert len(result.stdout.encode("utf-8")) <= MAX_SMOKE_JSON_BYTES + 1
+    assert set(payload) == {"application", "controls", "shell", "ui"}
+    assert payload["application"] == {
+        "id": APP_ID,
+        "name": APP_NAME,
+        "prototype": True,
+    }
+    assert payload["shell"] == {
+        "graphical_shell": "gtk4_placeholder",
+        "state": "offline_unpaired",
+    }
+    assert set(payload["ui"]) == {
+        "mode",
+        "show_technical_details",
+        "daemon",
+        "pairing",
+        "adapters",
+        "preflight",
+        "support_bundle",
+    }
+
+
+def test_smoke_json_contains_no_secret_or_host_path_leak_markers():
+    result = _smoke()
+    rendered = result.stdout.lower()
+
+    assert result.returncode == 0
+    for forbidden in (
+        "token",
+        "passphrase",
+        "password",
+        "psk",
+        "bearer",
+        "file://",
+        "/etc/",
+        "/home/",
+        "/run/",
+        "/tmp/",
+        "/var/",
+    ):
+        assert forbidden not in rendered
+
+
+def test_shell_exposes_no_mutation_controls_or_actions():
+    from flatpak_app import build_smoke_payload
+    from flatpak_app import app
+
+    payload = build_smoke_payload()
+    public_methods = {
+        name
+        for name, value in inspect.getmembers(app, inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+    assert payload["controls"]["mutation_actions"] == []
+    assert payload["controls"]["support_bundle_export_enabled"] is False
+    assert payload["ui"]["support_bundle"]["action_enabled"] is False
+    assert public_methods.isdisjoint(
+        {
+            "start",
+            "stop",
+            "restart",
+            "repair",
+            "save_config",
+            "update_config",
+            "request",
+            "post",
+            "export",
+        }
+    )
+
+
+def test_app_shell_has_no_direct_host_secret_or_network_access():
+    source = Path("flatpak_app/app.py").read_text(encoding="utf-8")
+
+    for forbidden in (
+        "import os",
+        "import pathlib",
+        "import socket",
+        "import subprocess",
+        "import urllib",
+        "import requests",
+        "os.environ",
+        "LocalApiClient(",
+        "TokenPairingController(",
+        "/etc/",
+        "/var/lib/",
+        "systemctl",
+        "nmcli",
+        "hostapd",
+        "dnsmasq",
+        "firewall",
+    ):
+        assert forbidden not in source
+
+
+def test_manifest_is_valid_json_and_matches_app_id_command_and_runtime():
+    manifest = _manifest()
+
+    assert manifest["app-id"] == APP_ID
+    assert manifest["command"] == LAUNCHER_PATH.name
+    assert manifest["runtime"] == "org.gnome.Platform"
+    assert manifest["sdk"] == "org.gnome.Sdk"
+    assert manifest["runtime-version"]
+
+
+def test_manifest_has_only_minimal_display_and_loopback_client_permissions():
+    finish_args = set(_manifest()["finish-args"])
+
+    assert finish_args == {
+        "--share=network",
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+    }
+    assert not any("filesystem=" in argument for argument in finish_args)
+    assert not any("system-bus" in argument for argument in finish_args)
+    assert not any("session-bus" in argument for argument in finish_args)
+    assert not any("talk-name" in argument for argument in finish_args)
+    assert "--filesystem=host" not in finish_args
+    assert "--device=all" not in finish_args
+    assert "--socket=system-bus" not in finish_args
+
+
+def test_manifest_packages_only_shell_client_and_static_desktop_assets():
+    manifest_text = MANIFEST_PATH.read_text(encoding="utf-8")
+    sources = _manifest()["modules"][0]["sources"]
+    paths = {source["path"] for source in sources}
+
+    assert all(source["type"] == "file" for source in sources)
+    assert paths
+    assert all(
+        path.startswith("../../flatpak_app/")
+        or path.startswith("../../flatpak_client/")
+        or "/" not in path
+        for path in paths
+    )
+    for forbidden in (
+        "backend/",
+        "backend/vendor",
+        "vr_hotspotd",
+        "install.sh",
+        "uninstall.sh",
+        "systemd",
+    ):
+        assert forbidden not in manifest_text
+
+
+def test_desktop_file_matches_app_id_name_and_launcher():
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.optionxform = str
+    assert DESKTOP_PATH.exists()
+    parser.read(DESKTOP_PATH, encoding="utf-8")
+    entry = parser["Desktop Entry"]
+
+    assert DESKTOP_PATH.stem == APP_ID
+    assert entry["Type"] == "Application"
+    assert entry["Name"] == APP_NAME
+    assert entry["Exec"] == LAUNCHER_PATH.name
+    assert entry["Icon"] == APP_ID
+    assert entry["Terminal"] == "false"
+    assert not any(key.startswith("Actions") for key in entry)
+
+
+def test_metainfo_xml_parses_and_matches_app_and_desktop_ids():
+    assert METAINFO_PATH.exists()
+    root = ET.parse(METAINFO_PATH).getroot()
+
+    assert root.tag == "component"
+    assert root.attrib["type"] == "desktop-application"
+    assert root.findtext("id") == APP_ID
+    assert root.findtext("name") == APP_NAME
+    launchable = root.find("launchable")
+    assert launchable is not None
+    assert launchable.attrib["type"] == "desktop-id"
+    assert launchable.text == DESKTOP_PATH.name
+
+
+def test_launcher_is_executable_static_and_safe():
+    assert LAUNCHER_PATH.exists()
+    assert LAUNCHER_PATH.stat().st_mode & 0o111
+    source = LAUNCHER_PATH.read_text(encoding="utf-8")
+
+    assert source.startswith("#!/bin/sh\n")
+    assert "exec python3 -m flatpak_app" in source
+    assert len(source.encode("utf-8")) < 512
+    for forbidden in (
+        "sudo",
+        "pkexec",
+        "curl",
+        "wget",
+        "systemctl",
+        "dbus-send",
+        "/etc/",
+        "/var/lib/",
+        "VR_HOTSPOTD_API_TOKEN",
+        "backend/vendor",
+    ):
+        assert forbidden not in source


### PR DESCRIPTION
Adds the first rough installable/testable Flatpak app shell prototype.

What changed:
- Added `flatpak_app`.
- Added Flatpak manifest, desktop file, metainfo, icon, and launcher under `packaging/flatpak`.
- Added offline deterministic app-shell/manifest tests.
- Updated `docs/FLATPAK_ARCHITECTURE_PLAN.md` for PR #81.

App:
- App ID: `io.github.josethevrtech.VRhotspot`
- Launcher: `vrhotspot-flatpak`
- Installed launch: `flatpak run io.github.josethevrtech.VRhotspot`
- Smoke mode: `python -m flatpak_app --smoke-json`
- Flatpak smoke: `flatpak run io.github.josethevrtech.VRhotspot --smoke-json`

Prototype behavior:
- GTK 4 placeholder window.
- GTK import is lazy/optional.
- Smoke JSON works without GTK.
- Offline/unpaired initial state.
- No token persistence.
- No token discovery from disk, environment, keyring, portal, or daemon config.
- No start/stop/restart/config mutation controls.
- Support-bundle export remains disabled/placeholder.

Manifest permissions:
- `--share=network`
- `--share=ipc`
- `--socket=wayland`
- `--socket=fallback-x11`

No broad access:
- No filesystem permission.
- No system bus permission.
- No session bus talk/name permission.
- No device permission.
- No privileged host access.

Out of scope:
- No production UI.
- No token entry UI.
- No portal export.
- No Flathub polish.
- No backend daemon/runtime changes.
- No installer changes.
- No CI changes.
- No vendor changes.
- No WebUI changes.
- No Steam Frame work.
- No VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- Static review: approve
- Review file: `/tmp/vrhotspot-flatpak-app-shell-prototype-final-review.md`
- Review SHA-256: `048938053347b198afa05c005e09555cc7019b736cb50be13de8c54501843d22`
- Focused tests: `68 passed`
- Full suite: `712 passed, 4 subtests passed`
- Vendor manifest/SBOM/SHA validation: passed
- Installer shell syntax checks: passed
- Install matrix: passed
- Manifest JSON, AppStream XML, desktop file, launcher syntax: passed
- `git diff --check`: passed

Real Flatpak validation:
- Installed `flatpak-builder`.
- Added Flathub user remote.
- Built and installed with:

  `flatpak-builder --user --install --force-clean --install-deps-from=flathub .flatpak-test-build packaging/flatpak/io.github.josethevrtech.VRhotspot.json`

- Build result: passed.
- App install result: passed.
- Smoke command result: passed.
- GTK placeholder launch result: passed.
- Observed non-blocking EGL/Mesa warnings during GTK launch; window still opened successfully.

Result:
- First rough testable Flatpak prototype is available.
