### PR TITLE
Add Flatpak token entry UI prototype

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,16 +1,16 @@
 # Flatpak control app architecture plan
 
-Status: PR #81 Flatpak packaging/app shell prototype; PRs #77-#80 retained
+Status: PR #82 first-run/token entry UI prototype; PRs #77-#81 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #81 adds the first rough installable and testable Flatpak app
-shell on top of PR #78's read-only local API client, PR #79's pairing state, and
-PR #80's toolkit-agnostic UI model/controller foundation. It proves packaging,
-launching, a deterministic standard-library smoke path, and a lazy GTK 4
-placeholder window. It is not a finished production UI and adds no daemon API,
-daemon runtime, installer, privileged action, or credential-storage behavior.
+application. PR #82 adds an in-memory first-run token entry flow to PR #81's
+rough installable and testable Flatpak shell. It uses PR #78's read-only local
+API client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
+model/controller foundation. It is not a finished production UI and adds no
+daemon API, daemon runtime, installer, privileged action, token persistence, or
+credential-storage behavior.
 
 ## Architectural decision
 
@@ -296,11 +296,74 @@ origins. The remaining finish arguments provide Wayland and fallback X11
 display access. There is no filesystem permission, system-bus access, session-
 bus name ownership, device permission, or host networking authority.
 
-Real credential entry UI and live authenticated daemon wiring are not included.
-The shell does not discover or persist credentials through files, environment,
-keyrings, portals, or daemon configuration. Support-bundle export remains a
-disabled placeholder; portal export and bounded download handling require
-separate review.
+PR #81 did not include credential entry or live authenticated daemon wiring.
+The shell did not discover or persist credentials through files, environment,
+keyrings, portals, or daemon configuration. Support-bundle export remained a
+disabled placeholder; portal export and bounded download handling still
+require separate review.
+
+## PR #82 first-run/token entry UI prototype
+
+PR #82 adds one intentional credential input to the GTK shell: a hidden
+password-style entry and a `Connect / Validate token` button. The button gives
+the caller-provided text to a shell-level `FirstRunTokenEntryController`, which
+uses the existing `TokenPairingController` and its loopback-only
+`LocalApiClient` factory. When pairing succeeds, a short-lived client is passed
+to the existing `DiagnosticsControlUiController` to build the display model.
+There is no network call outside `LocalApiClient`.
+
+The entered token exists only in process memory for the current validation and
+model-build call. The GTK entry is cleared as soon as the click is handled, the
+shell controller has no token field, and the temporary token-bearing client is
+discarded after the model is built. The token is not written, logged, placed in
+a process argument, copied into the model, or included in smoke JSON,
+representations, exceptions, diagnostics, or window labels. This prototype
+does not discover tokens from environment variables, files, keyrings, portals,
+daemon configuration, `/etc`, `/var/lib`, or any other host location.
+
+The GTK shell renders only the existing bounded display models:
+
+- daemon status and safe reachability state;
+- pairing accepted, rejected, unavailable, missing-daemon-token, or unknown
+  state;
+- daemon-provided adapter readiness summary and cards after successful
+  validation;
+- daemon-provided preflight summary, facts, issues, and non-interactive
+  guidance after successful validation; and
+- the existing disabled support-bundle affordance.
+
+Rejected tokens never enter the result text. Connection failure renders an
+offline/unreachable state, the daemon's fail-closed
+`503`/`api_token_missing` response renders a missing-token state, and malformed
+or unsupported responses degrade to unknown. The UI has no start, stop,
+restart, repair, configuration, adapter-selection, or other mutation action.
+Support-bundle portal export remains future work and its placeholder remains
+disabled.
+
+GTK loading remains lazy. Importing `flatpak_app` and running the deterministic
+smoke mode still require neither PyGObject nor a token, make no API request,
+and perform no credential discovery:
+
+```bash
+python -m flatpak_app --smoke-json
+```
+
+PR #82 does not change the Flatpak permissions. A developer can force a clean
+rebuild, install, and run the current repository checkout with:
+
+```bash
+rm -rf .flatpak-test-build .flatpak-builder
+flatpak-builder --user --install --force-clean \
+  --install-deps-from=flathub .flatpak-test-build \
+  packaging/flatpak/io.github.josethevrtech.VRhotspot.json
+flatpak run io.github.josethevrtech.VRhotspot
+rm -rf .flatpak-test-build .flatpak-builder
+```
+
+Token persistence and keyring integration remain separately reviewed future
+work. Lifecycle/configuration controls, start/stop actions, support-bundle
+portal export, production UI polish, Flathub polish, Steam Frame, VR Direct
+Link, and adapter-registry work also remain separate future phases.
 
 ## Sandbox and portal expectations
 
@@ -388,7 +451,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #78 | Flatpak local API client prototype. Add the small `flatpak_client/` layer against an injectable fake transport, with explicit loopback pinning, authentication-header handling, redirect rejection, bounded timeouts, compatibility/error mapping, and no host command execution. | Unit tests demonstrate safe request construction and failure handling without privileged host mutation. No Flatpak package or manifest exists; exact packaging scope requires separate approval. |
 | PR #79 | Token pairing and first-run foundation. Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
 | PR #80 | Diagnostics/control UI foundation. Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
-| PR #81 | Flatpak packaging/app shell prototype (current phase). Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
+| PR #81 | Flatpak packaging/app shell prototype. Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
+| PR #82 | First-run/token entry UI prototype (current phase). Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -412,7 +476,7 @@ a production Flatpak release:
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #81's prototype choices are not blanket approval for production packaging
+PR #82's prototype choices are not blanket approval for production packaging
 or additional permissions.
 
 ## Future test and validation expectations
@@ -469,10 +533,10 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #81
+## Explicit non-goals for PR #82
 
 - No finished production UI or existing Web UI change. The GTK window is a
-  rough display-only placeholder, not a production control surface.
+  rough first-run and display-only prototype, not a production control surface.
 - No Flathub submission, release artifact, production metadata polish,
   screenshots, signing, or distribution automation.
 - No start, stop, restart, repair, configuration, passphrase, adapter-selection,
@@ -481,7 +545,8 @@ reporting. Flatpak work must not weaken or bypass those controls.
   integration, or export implementation. The disabled model affordance is
   non-interactive and performs no request.
 - No token discovery, persistent storage, keyring/portal integration, token
-  issuance, rotation, or daemon-side pairing endpoint.
+  issuance, rotation, or daemon-side pairing endpoint. The only token source is
+  intentional entry in the hidden GTK field for the current in-memory call.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No installer, uninstaller, systemd-unit, platform, or CI behavior change.
@@ -499,10 +564,11 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #81 authorizes only the isolated Flatpak packaging/app shell prototype, its
-lazy GTK placeholder, static metadata, offline tests, and this plan update. It
-does not claim that a finished graphical UI, credential-entry flow,
-support-bundle portal export, Flathub-polished release, Steam Frame support, VR
-Direct Link support, or a known-adapter registry exists. Production UI work,
-credential entry, portal export, Flathub polish, Steam Frame, VR Direct Link,
-adapter registry work, and all later phases remain separately approved work.
+PR #82 authorizes only the isolated in-memory token entry and display-model
+wiring in the existing Flatpak GTK shell, its offline tests, and this plan
+update. It does not claim token persistence, keyring integration, lifecycle or
+configuration controls, support-bundle portal export, a Flathub-polished
+release, Steam Frame support, VR Direct Link support, or a known-adapter
+registry. Production UI work, persistence, portal export, Flathub polish,
+Steam Frame, VR Direct Link, adapter registry work, and all later phases remain
+separately approved work.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -3,6 +3,7 @@
 from .app import (
     APP_ID,
     APP_NAME,
+    FirstRunTokenEntryController,
     MAX_SMOKE_JSON_BYTES,
     build_initial_model,
     build_smoke_payload,
@@ -13,6 +14,7 @@ from .app import (
 __all__ = [
     "APP_ID",
     "APP_NAME",
+    "FirstRunTokenEntryController",
     "MAX_SMOKE_JSON_BYTES",
     "build_initial_model",
     "build_smoke_payload",

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -13,7 +13,9 @@ from flatpak_client import (
     DiagnosticsControlUiModel,
     FirstRunResult,
     FirstRunState,
+    LocalApiClient,
     PresentationMode,
+    TokenPairingController,
 )
 
 
@@ -24,6 +26,49 @@ MAX_SMOKE_JSON_BYTES = 8_192
 
 class GuiUnavailableError(RuntimeError):
     """GTK 4 or PyGObject is unavailable for the graphical shell."""
+
+
+class FirstRunTokenEntryController:
+    """Build one token-free display model from an explicitly supplied token."""
+
+    def __init__(self, *, client_factory=LocalApiClient, pairing_controller=None):
+        self._client_factory = client_factory
+        self._pairing_controller = (
+            pairing_controller
+            if pairing_controller is not None
+            else TokenPairingController(client_factory)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "FirstRunTokenEntryController("
+            "client_factory_configured=True, pairing_controller_configured=True)"
+        )
+
+    def connect(self, *, token: str) -> DiagnosticsControlUiModel:
+        """Validate caller-provided text and build read-only UI state in memory."""
+
+        try:
+            pairing_result = self._pairing_controller.evaluate(token=token)
+        except Exception:
+            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+        if not isinstance(pairing_result, FirstRunResult):
+            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        client = None
+        if pairing_result.state is FirstRunState.TOKEN_ACCEPTED:
+            try:
+                client = self._client_factory(token=token)
+            except Exception:
+                pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+        try:
+            return DiagnosticsControlUiController(client).build(
+                pairing_result=pairing_result,
+                mode=PresentationMode.BASIC,
+            )
+        finally:
+            client = None
 
 
 def build_initial_model() -> DiagnosticsControlUiModel:
@@ -86,26 +131,118 @@ def _load_gtk():
     return Gtk
 
 
-def _add_text_label(Gtk, container, text: str, *, css_class: str | None = None) -> None:
+def _add_text_label(Gtk, container, text: str, *, css_class: str | None = None):
     label = Gtk.Label(label=text)
     label.set_wrap(True)
     label.set_xalign(0.0)
     if css_class:
         label.add_css_class(css_class)
     container.append(label)
+    return label
+
+
+def _clear_box(container) -> None:
+    child = container.get_first_child()
+    while child is not None:
+        next_child = child.get_next_sibling()
+        container.remove(child)
+        child = next_child
+
+
+def _add_section_heading(Gtk, container, text: str) -> None:
+    _add_text_label(Gtk, container, text, css_class="heading")
+
+
+def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> None:
+    """Render only bounded, token-free fields from the existing UI model."""
+
+    _clear_box(container)
+
+    _add_section_heading(Gtk, container, "Daemon status")
+    _add_text_label(Gtk, container, model.daemon.title, css_class="title-4")
+    _add_text_label(Gtk, container, model.daemon.message)
+
+    _add_section_heading(Gtk, container, "Pairing status")
+    _add_text_label(Gtk, container, model.pairing.title, css_class="title-4")
+    _add_text_label(Gtk, container, model.pairing.message)
+
+    _add_section_heading(Gtk, container, "Adapter readiness")
+    _add_text_label(Gtk, container, model.adapters.title, css_class="title-4")
+    _add_text_label(Gtk, container, model.adapters.summary)
+    if model.adapters.cards:
+        for card in model.adapters.cards:
+            bands = ", ".join(card.supported_bands) or "Bands not reported"
+            recommendation = " · Recommended" if card.recommended else ""
+            _add_text_label(
+                Gtk,
+                container,
+                f"{card.interface}: {card.readiness_label}{recommendation}",
+                css_class="heading",
+            )
+            _add_text_label(Gtk, container, f"{bands} · {card.summary}")
+    else:
+        _add_text_label(
+            Gtk,
+            container,
+            "No adapter cards are available.",
+            css_class="dim-label",
+        )
+
+    _add_section_heading(Gtk, container, "Preflight")
+    _add_text_label(
+        Gtk,
+        container,
+        f"{model.preflight.readiness_label}: {model.preflight.summary}",
+        css_class="title-4",
+    )
+    for fact in model.preflight.facts:
+        _add_text_label(Gtk, container, f"{fact.label}: {fact.value}")
+    for issue in model.preflight.issues:
+        _add_text_label(
+            Gtk,
+            container,
+            f"Issue ({issue.severity.value}): {issue.message}",
+        )
+    for action in model.preflight.actions:
+        _add_text_label(
+            Gtk,
+            container,
+            f"Guidance (display only): {action.message}",
+        )
+    if not (
+        model.preflight.facts
+        or model.preflight.issues
+        or model.preflight.actions
+    ):
+        _add_text_label(
+            Gtk,
+            container,
+            "No preflight details are available.",
+            css_class="dim-label",
+        )
+
+    _add_section_heading(Gtk, container, model.support_bundle.title)
+    _add_text_label(Gtk, container, model.support_bundle.summary)
+    export_button = Gtk.Button(label=model.support_bundle.action_label)
+    export_button.set_sensitive(model.support_bundle.action_enabled)
+    container.append(export_button)
 
 
 def run_gui() -> int:
-    """Run the rough GTK window without contacting the host daemon."""
+    """Run the first-run GTK prototype against the read-only local API client."""
 
     Gtk = _load_gtk()
     model = build_initial_model()
+    token_entry_controller = FirstRunTokenEntryController()
     application = Gtk.Application(application_id=APP_ID)
 
     def on_activate(app) -> None:
         window = Gtk.ApplicationWindow(application=app)
         window.set_title(APP_NAME)
-        window.set_default_size(560, 420)
+        window.set_default_size(680, 760)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=14)
         content.set_margin_top(24)
@@ -117,44 +254,55 @@ def run_gui() -> int:
         _add_text_label(
             Gtk,
             content,
-            "Flatpak app shell prototype",
+            "First-run connection prototype",
             css_class="title-3",
         )
         _add_text_label(
             Gtk,
             content,
-            "This rough shell is intentionally offline and unpaired. "
-            "Credential entry and live daemon wiring remain future work.",
+            "Enter the API token configured for the local VRhotspot daemon. "
+            "The token is used in memory for this validation only and is not saved.",
         )
+
+        token_entry = Gtk.PasswordEntry()
+        token_entry.set_placeholder_text("API token")
+        token_entry.set_show_peek_icon(True)
+        content.append(token_entry)
+
+        connect_button = Gtk.Button(label="Connect / Validate token")
+        content.append(connect_button)
+
+        display_sections = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=8,
+        )
+        content.append(display_sections)
+        _render_display_model(Gtk, display_sections, model)
+
+        def on_connect(_widget) -> None:
+            token = token_entry.get_text()
+            token_entry.set_text("")
+            connect_button.set_sensitive(False)
+            try:
+                updated_model = token_entry_controller.connect(token=token)
+                _render_display_model(Gtk, display_sections, updated_model)
+            finally:
+                token = ""
+                connect_button.set_sensitive(True)
+
+        connect_button.connect("clicked", on_connect)
+        token_entry.connect("activate", on_connect)
+
         _add_text_label(
             Gtk,
             content,
-            f"Presentation mode: {model.mode.value.capitalize()}",
-        )
-        _add_text_label(
-            Gtk,
-            content,
-            f"Daemon: {model.daemon.title}",
-        )
-        _add_text_label(
-            Gtk,
-            content,
-            f"Pairing: {model.pairing.title}",
-        )
-        _add_text_label(
-            Gtk,
-            content,
-            "Support-bundle export is visible as a disabled placeholder; "
-            "no portal or file access is wired.",
-        )
-        _add_text_label(
-            Gtk,
-            content,
-            "No lifecycle or configuration controls are available.",
+            "Support-bundle export remains disabled. No lifecycle or "
+            "configuration controls are available.",
             css_class="dim-label",
         )
 
-        window.set_child(content)
+        scroller.set_child(content)
+        window.set_child(scroller)
         window.present()
 
     application.connect("activate", on_activate)

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -1,4 +1,5 @@
 import configparser
+from dataclasses import asdict
 import importlib
 import inspect
 import json
@@ -7,6 +8,8 @@ import subprocess
 import sys
 import xml.etree.ElementTree as ET
 
+import pytest
+
 
 APP_ID = "io.github.josethevrtech.VRhotspot"
 APP_NAME = "VR Hotspot"
@@ -14,6 +17,102 @@ MANIFEST_PATH = Path("packaging/flatpak") / f"{APP_ID}.json"
 DESKTOP_PATH = Path("packaging/flatpak") / f"{APP_ID}.desktop"
 METAINFO_PATH = Path("packaging/flatpak") / f"{APP_ID}.metainfo.xml"
 LAUNCHER_PATH = Path("packaging/flatpak/vrhotspot-flatpak")
+
+
+def _api_response(data):
+    from flatpak_client import ApiResponse
+
+    return ApiResponse(
+        correlation_id="token-entry-ui-test",
+        result_code="ok",
+        warnings=(),
+        data=data,
+    )
+
+
+def _readiness_response():
+    return _api_response(
+        {
+            "recommended": "wlan1",
+            "basic_mode_recommended": "wlan1",
+            "adapters": [
+                {
+                    "interface": "wlan1",
+                    "driver": "example",
+                    "bus_type": "usb",
+                    "supports_5ghz": True,
+                    "readiness_state": "ready",
+                    "explanation": "Ready for display-only diagnostics.",
+                }
+            ],
+        }
+    )
+
+
+def _preflight_response():
+    return _api_response(
+        {
+            "schema_version": 1,
+            "overall_readiness": "warning",
+            "platform": {},
+            "firewall": {},
+            "services": {},
+            "network": {},
+            "wifi": {"selected_adapter": "wlan1"},
+            "issues": [
+                {
+                    "severity": "warning",
+                    "code": "review_example",
+                    "message": "Review the daemon-reported readiness.",
+                }
+            ],
+            "recommended_actions": [
+                {
+                    "code": "review_example",
+                    "message": "Review this display-only guidance.",
+                }
+            ],
+        }
+    )
+
+
+class ScriptedReadOnlyClientFactory:
+    def __init__(
+        self,
+        *,
+        health_result=True,
+        readiness_result=None,
+        preflight_result=None,
+    ):
+        self.health_result = health_result
+        self.readiness_result = readiness_result or _readiness_response()
+        self.preflight_result = preflight_result or _preflight_response()
+        self.token_presence = []
+
+    def __repr__(self):
+        return "ScriptedReadOnlyClientFactory(token_storage=False)"
+
+    def __call__(self, *, token):
+        self.token_presence.append(bool(token))
+        factory = self
+
+        class Client:
+            def health(self):
+                if isinstance(factory.health_result, BaseException):
+                    raise factory.health_result
+                return factory.health_result
+
+            def adapter_readiness(self):
+                if isinstance(factory.readiness_result, BaseException):
+                    raise factory.readiness_result
+                return factory.readiness_result
+
+            def preflight_report(self):
+                if isinstance(factory.preflight_result, BaseException):
+                    raise factory.preflight_result
+                return factory.preflight_result
+
+        return Client()
 
 
 def _manifest():
@@ -93,6 +192,153 @@ def test_smoke_json_contains_no_secret_or_host_path_leak_markers():
         assert forbidden not in rendered
 
 
+def test_token_entry_requires_only_a_caller_supplied_token():
+    from flatpak_app import FirstRunTokenEntryController
+
+    factory = ScriptedReadOnlyClientFactory()
+    controller = FirstRunTokenEntryController(client_factory=factory)
+
+    with pytest.raises(TypeError):
+        controller.connect()
+
+    model = controller.connect(token="caller-provided-value")
+
+    assert model.pairing.paired is True
+    assert factory.token_presence == [False, True, True]
+    assert not hasattr(controller, "token")
+    assert not hasattr(controller, "_token")
+
+
+def test_successful_token_validation_updates_all_display_only_sections():
+    from flatpak_app import FirstRunTokenEntryController
+
+    controller = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory()
+    )
+
+    model = controller.connect(token="accepted-in-memory-value")
+
+    assert model.daemon.title == "Daemon connected"
+    assert model.pairing.title == "Paired"
+    assert model.adapters.recommended_interface == "wlan1"
+    assert [card.interface for card in model.adapters.cards] == ["wlan1"]
+    assert model.preflight.readiness_label == "Needs attention"
+    assert [issue.code for issue in model.preflight.issues] == ["review_example"]
+    assert [action.code for action in model.preflight.actions] == ["review_example"]
+    assert model.preflight.actions[0].interactive is False
+    assert model.support_bundle.action_enabled is False
+    assert model.support_bundle.request_performed is False
+
+
+def test_rejected_token_is_safe_and_never_enters_output_or_logs(caplog):
+    from flatpak_app import FirstRunTokenEntryController
+    from flatpak_client import AuthenticationError
+
+    secret = "rejected-ui-value-must-not-escape"
+    controller = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory(
+            readiness_result=AuthenticationError(401)
+        )
+    )
+
+    model = controller.connect(token=secret)
+    exposed = repr(model) + repr(asdict(model)) + repr(controller) + caplog.text
+
+    assert model.daemon.reachable is True
+    assert model.pairing.title == "Token rejected"
+    assert model.pairing.paired is False
+    assert secret not in exposed
+
+
+def test_unreachable_daemon_updates_the_safe_offline_display_state():
+    from flatpak_app import FirstRunTokenEntryController
+    from flatpak_client import ConnectionFailure
+
+    controller = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory(
+            health_result=ConnectionFailure("offline")
+        )
+    )
+
+    model = controller.connect(token="in-memory-offline-value")
+
+    assert model.daemon.title == "Daemon unavailable"
+    assert model.daemon.reachable is False
+    assert model.pairing.title == "Pairing unavailable"
+    assert model.adapters.cards == ()
+    assert model.preflight.issues == ()
+
+
+def test_missing_daemon_token_updates_the_safe_blocked_display_state():
+    from flatpak_app import FirstRunTokenEntryController
+    from flatpak_client import DaemonTokenMissingError
+
+    controller = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory(
+            readiness_result=DaemonTokenMissingError()
+        )
+    )
+
+    model = controller.connect(token="caller-provided-missing-config-value")
+
+    assert model.daemon.reachable is True
+    assert model.pairing.title == "Daemon token missing"
+    assert model.pairing.detail_code == "api_token_missing"
+    assert model.pairing.paired is False
+
+
+def test_malformed_pairing_response_degrades_the_entire_display_to_unknown():
+    from flatpak_app import FirstRunTokenEntryController
+    from flatpak_client import StatusSeverity
+
+    controller = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory(
+            readiness_result={"unexpected": "response"}
+        )
+    )
+
+    model = controller.connect(token="caller-provided-malformed-value")
+
+    assert model.daemon.severity is StatusSeverity.UNKNOWN
+    assert model.pairing.severity is StatusSeverity.UNKNOWN
+    assert model.adapters.severity is StatusSeverity.UNKNOWN
+    assert model.preflight.severity is StatusSeverity.UNKNOWN
+
+
+def test_token_entry_flow_does_not_retain_persist_log_or_emit_token(
+    caplog,
+    monkeypatch,
+    tmp_path,
+):
+    from flatpak_app import (
+        FirstRunTokenEntryController,
+        build_smoke_payload,
+        render_smoke_json,
+    )
+
+    secret = "ephemeral-ui-value-never-persist"
+    factory = ScriptedReadOnlyClientFactory()
+    controller = FirstRunTokenEntryController(client_factory=factory)
+    monkeypatch.chdir(tmp_path)
+    before = tuple(tmp_path.rglob("*"))
+
+    model = controller.connect(token=secret)
+    exposed = (
+        repr(controller)
+        + repr(model)
+        + repr(asdict(model))
+        + repr(build_smoke_payload())
+        + render_smoke_json()
+        + caplog.text
+    )
+
+    assert tuple(tmp_path.rglob("*")) == before
+    assert secret not in exposed
+    assert secret not in repr(vars(controller))
+    assert not hasattr(controller, "token")
+    assert not hasattr(controller, "_token")
+
+
 def test_shell_exposes_no_mutation_controls_or_actions():
     from flatpak_app import build_smoke_payload
     from flatpak_app import app
@@ -133,10 +379,13 @@ def test_app_shell_has_no_direct_host_secret_or_network_access():
         "import urllib",
         "import requests",
         "os.environ",
-        "LocalApiClient(",
-        "TokenPairingController(",
+        "getenv(",
+        "keyring",
+        "SecretService",
+        "portal",
         "/etc/",
         "/var/lib/",
+        "VR_HOTSPOTD_API_TOKEN",
         "systemctl",
         "nmcli",
         "hostapd",
@@ -144,6 +393,25 @@ def test_app_shell_has_no_direct_host_secret_or_network_access():
         "firewall",
     ):
         assert forbidden not in source
+
+
+def test_shell_has_no_token_cli_argument_or_discovery_source():
+    from flatpak_app import app
+
+    parser = app._argument_parser()
+    option_strings = {
+        option
+        for action in parser._actions
+        for option in action.option_strings
+    }
+    source = Path("flatpak_app/app.py").read_text(encoding="utf-8")
+
+    assert "--token" not in option_strings
+    assert "--api-token" not in option_strings
+    assert "FirstRunTokenEntryController" in source
+    assert "LocalApiClient" in source
+    assert "TokenPairingController" in source
+    assert "DiagnosticsControlUiController" in source
 
 
 def test_manifest_is_valid_json_and_matches_app_id_command_and_runtime():


### PR DESCRIPTION
Adds the Flatpak first-run/token entry UI prototype.

What changed:
- Added hidden token entry to the GTK Flatpak shell.
- Added Connect/Validate action.
- Added Enter-key validation behavior.
- Updated display-only daemon, pairing, adapter, preflight, and support-bundle placeholder state.
- Updated Flatpak architecture docs for PR #82.
- Added deterministic app-shell tests for token-entry behavior.

Token handling:
- Token is caller-provided only.
- Token is in-memory only.
- Token entry clears before validation.
- No token persistence.
- No keyring storage.
- No token discovery from disk, environment, portal, daemon config, `/etc`, `/var/lib`, or any filesystem location.
- No token logging.
- No token in CLI arguments.
- No token in smoke JSON, labels, reprs, exceptions, diagnostics, models, or test output.

Security boundaries:
- Uses existing loopback-only `LocalApiClient`.
- Uses existing `TokenPairingController`.
- Uses existing `DiagnosticsControlUiController`.
- No direct network calls outside `LocalApiClient`.
- No direct daemon file access.
- No systemd, NetworkManager, iwd, hostapd, dnsmasq, firewall, route, or kernel-networking access.
- Manifest permissions unchanged.

UI behavior:
- Password-style token entry.
- Validation requires explicit click or Enter.
- Successful validation updates display-only UI state.
- Invalid token shows safe rejected state.
- Unreachable daemon shows safe offline state.
- Missing daemon token state is safe.
- Malformed daemon response degrades safely to unknown.
- Support-bundle export remains disabled/placeholder.
- No start/stop/restart/config mutation controls.

Out of scope:
- No token persistence.
- No keyring integration.
- No daemon API changes.
- No daemon runtime changes.
- No installer changes.
- No CI changes.
- No vendor changes.
- No existing WebUI changes.
- No lifecycle/config mutation flows.
- No support-bundle portal export.
- No Flathub polish.
- No Steam Frame work.
- No VR Direct Link work.
- No adapter registry work.
- No HostFactsSnapshot work.

Validation:
- Review: approve
- Review file: `/tmp/vrhotspot-flatpak-token-entry-ui-prototype-final-review.md`
- Review SHA-256: `7ff26d811e3e84c2e1c27bcd69bf1eff7dca5cf6a83c4222323c8cc3378c31b4`
- Focused tests: `76 passed`
- Full suite: `720 passed, 4 subtests passed`
- Vendor manifest/SBOM/SHA validation: passed
- Installer syntax checks: passed
- Install matrix: passed
- Manifest JSON validation: passed
- App shell py_compile: passed
- Launcher syntax: passed
- Smoke JSON: passed
- git diff --check: passed
- Real Flatpak build/install/smoke: passed

Notes:
- Live daemon pairing was not tested and is not claimed as passing.
- Synchronous GTK validation is acceptable for this prototype.
- Python/GTK cannot guarantee secure zeroization of immutable strings; this is documented and bounded for prototype scope.
