### PR TITLE
Add Flatpak live daemon pairing smoke path

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,13 +1,14 @@
 # Flatpak control app architecture plan
 
-Status: PR #82 first-run/token entry UI prototype; PRs #77-#81 retained
+Status: PR #83 live daemon pairing smoke path; PRs #77-#82 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #82 adds an in-memory first-run token entry flow to PR #81's
-rough installable and testable Flatpak shell. It uses PR #78's read-only local
-API client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
+application. PR #83 adds an explicit terminal-only live daemon pairing smoke
+path to PR #82's in-memory first-run token entry flow and PR #81's rough
+installable and testable Flatpak shell. It uses PR #78's read-only local API
+client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
 model/controller foundation. It is not a finished production UI and adds no
 daemon API, daemon runtime, installer, privileged action, token persistence, or
 credential-storage behavior.
@@ -365,6 +366,67 @@ work. Lifecycle/configuration controls, start/stop actions, support-bundle
 portal export, production UI polish, Flathub polish, Steam Frame, VR Direct
 Link, and adapter-registry work also remain separate future phases.
 
+## PR #83 live daemon pairing smoke path
+
+PR #83 adds a terminal-only developer command for exercising the installed
+Flatpak against an already-running host-installed `vr-hotspotd`:
+
+```bash
+flatpak run io.github.josethevrtech.VRhotspot \
+  --live-pairing-smoke-json
+```
+
+The command is explicit and opt-in. It requires an interactive terminal and
+manual token entry through a hidden prompt. If standard input is not a TTY, if
+hidden input is unavailable, if the prompt would fall back to echoed input, or
+if the user enters no token, the command fails safely before creating a client.
+The token remains in process memory only for the current validation/model-build
+call and is then discarded. It is not persisted, logged, echoed, accepted as a
+command-line argument, or discovered from environment variables, files,
+keyrings, portals, daemon configuration, `/etc`, `/var/lib`, or any other
+filesystem location.
+
+The entered token flows through the existing `TokenPairingController` and
+loopback-only `LocalApiClient`. After the daemon accepts the token, the existing
+`DiagnosticsControlUiController` builds the adapter-readiness and preflight
+models. There is no direct network request outside `LocalApiClient`, and the
+client's loopback-only origin, proxy bypass, redirect rejection, response
+bounds, and sanitized error mapping remain unchanged.
+
+The command prints one bounded sanitized JSON object containing the application
+ID, a fixed live-smoke status, daemon and pairing status models, adapter
+readiness, preflight state, the disabled support-bundle affordance, and an empty
+`controls.mutation_actions` list. It succeeds only when pairing is accepted and
+both authenticated read-only sections produce recognized UI models. It returns
+nonzero with fixed, token-free output for these safe states:
+
+- `interactive_input_required` when standard input is not interactive;
+- `token_input_empty` or `token_input_cancelled` when hidden input is not
+  safely available;
+- `token_rejected` for `401` or `403`;
+- `daemon_unreachable` for connection failure;
+- `daemon_token_missing` for the daemon's fail-closed
+  `503` / `api_token_missing` result; and
+- `invalid_response` for malformed, unsupported, partial, or otherwise unknown
+  authenticated output.
+
+This path does not require GTK and does not install, start, stop, restart,
+repair, configure, or otherwise mutate the daemon or host. The existing
+`--smoke-json` path remains deterministic, offline, token-free, and unchanged.
+The Flatpak manifest permissions are unchanged.
+
+The command requires a separately installed and running `vr-hotspotd` and the
+administrator-configured token to be entered manually. Automated fake-based
+tests prove the command's offline contracts, but live daemon pairing is claimed
+only after a developer runs this exact installed-Flatpak command against a real
+daemon and records the result. If no daemon is installed or running, live
+validation is not run rather than treated as an automated-test failure.
+
+Support-bundle portal export, token persistence and keyring storage,
+lifecycle/configuration controls, production and Flathub polish, Steam Frame,
+VR Direct Link, and adapter-registry work remain separately reviewed future
+work.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -452,7 +514,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #79 | Token pairing and first-run foundation. Add deterministic model/controller state that probes public health for reachability and validates an explicitly supplied token through the existing authenticated, read-only client contract. Add no daemon endpoint, storage backend, packaging, or graphical UI. | The six first-run states are covered offline; health alone never means paired; `401`, fail-closed `503/api_token_missing`, connection failure, and invalid responses map safely; tokens do not enter results, exceptions, logs, files, or controller state. |
 | PR #80 | Diagnostics/control UI foundation. Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
 | PR #81 | Flatpak packaging/app shell prototype. Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
-| PR #82 | First-run/token entry UI prototype (current phase). Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
+| PR #82 | First-run/token entry UI prototype. Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
+| PR #83 | Live daemon pairing smoke path (current phase). Add an explicit terminal-only installed-Flatpak command with strict hidden manual token entry and bounded sanitized JSON assembled through the existing pairing, local-client, and diagnostics UI boundaries. Add no token argument or discovery/storage path, mutation control, daemon/installer behavior, or permission. | Offline tests cover TTY and hidden-input refusal, success, token rejection, daemon unreachability, missing daemon token, malformed data, output bounds and redaction, unchanged offline/GUI behavior, and the absence of discovery or mutation controls. A real-daemon run of the documented command is required before live pairing is claimed. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -476,7 +539,7 @@ a production Flatpak release:
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #82's prototype choices are not blanket approval for production packaging
+PR #83's prototype choices are not blanket approval for production packaging
 or additional permissions.
 
 ## Future test and validation expectations
@@ -533,7 +596,7 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #82
+## Explicit non-goals for PR #83
 
 - No finished production UI or existing Web UI change. The GTK window is a
   rough first-run and display-only prototype, not a production control surface.
@@ -546,7 +609,8 @@ reporting. Flatpak work must not weaken or bypass those controls.
   non-interactive and performs no request.
 - No token discovery, persistent storage, keyring/portal integration, token
   issuance, rotation, or daemon-side pairing endpoint. The only token source is
-  intentional entry in the hidden GTK field for the current in-memory call.
+  intentional entry in the hidden GTK field or strict hidden terminal prompt
+  for the current in-memory call.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No installer, uninstaller, systemd-unit, platform, or CI behavior change.
@@ -564,11 +628,12 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #82 authorizes only the isolated in-memory token entry and display-model
-wiring in the existing Flatpak GTK shell, its offline tests, and this plan
-update. It does not claim token persistence, keyring integration, lifecycle or
+PR #83 authorizes only the explicit terminal live-pairing smoke orchestration in
+the existing Flatpak shell, its offline tests, and this plan update. It does not
+claim live pairing until the documented command succeeds against a real daemon.
+It does not claim token persistence, keyring integration, lifecycle or
 configuration controls, support-bundle portal export, a Flathub-polished
 release, Steam Frame support, VR Direct Link support, or a known-adapter
-registry. Production UI work, persistence, portal export, Flathub polish,
-Steam Frame, VR Direct Link, adapter registry work, and all later phases remain
+registry. Production UI work, persistence, portal export, Flathub polish, Steam
+Frame, VR Direct Link, adapter registry work, and all later phases remain
 separately approved work.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -4,20 +4,24 @@ from .app import (
     APP_ID,
     APP_NAME,
     FirstRunTokenEntryController,
+    MAX_LIVE_SMOKE_JSON_BYTES,
     MAX_SMOKE_JSON_BYTES,
     build_initial_model,
     build_smoke_payload,
     main,
     render_smoke_json,
+    run_live_pairing_smoke_json,
 )
 
 __all__ = [
     "APP_ID",
     "APP_NAME",
     "FirstRunTokenEntryController",
+    "MAX_LIVE_SMOKE_JSON_BYTES",
     "MAX_SMOKE_JSON_BYTES",
     "build_initial_model",
     "build_smoke_payload",
     "main",
     "render_smoke_json",
+    "run_live_pairing_smoke_json",
 ]

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict
+import getpass
 import json
 import sys
 from typing import Any, Sequence
+import warnings
 
 from flatpak_client import (
     DiagnosticsControlUiController,
@@ -15,6 +17,7 @@ from flatpak_client import (
     FirstRunState,
     LocalApiClient,
     PresentationMode,
+    StatusSeverity,
     TokenPairingController,
 )
 
@@ -22,6 +25,15 @@ from flatpak_client import (
 APP_ID = "io.github.josethevrtech.VRhotspot"
 APP_NAME = "VR Hotspot"
 MAX_SMOKE_JSON_BYTES = 8_192
+MAX_LIVE_SMOKE_JSON_BYTES = 65_536
+
+_LIVE_SMOKE_SUCCESS = "success"
+_LIVE_SMOKE_INVALID_RESPONSE = "invalid_response"
+_LIVE_SMOKE_INTERACTIVE_INPUT_REQUIRED = "interactive_input_required"
+_LIVE_SMOKE_TOKEN_INPUT_EMPTY = "token_input_empty"
+_LIVE_SMOKE_TOKEN_INPUT_CANCELLED = "token_input_cancelled"
+_LIVE_SMOKE_FAILURE_EXIT = 1
+_LIVE_SMOKE_INPUT_EXIT = 2
 
 
 class GuiUnavailableError(RuntimeError):
@@ -114,6 +126,159 @@ def render_smoke_json() -> str:
     if len(rendered.encode("utf-8")) > MAX_SMOKE_JSON_BYTES:
         raise RuntimeError("The Flatpak shell smoke payload exceeded its size limit.")
     return rendered
+
+
+def _build_live_smoke_payload(
+    *,
+    model: DiagnosticsControlUiModel,
+    status: str,
+) -> dict[str, Any]:
+    """Build one bounded-model live smoke result without credential fields."""
+
+    return {
+        "application": {
+            "id": APP_ID,
+            "name": APP_NAME,
+        },
+        "live_smoke": {
+            "status": status,
+        },
+        "daemon": asdict(model.daemon),
+        "pairing": asdict(model.pairing),
+        "adapter_readiness": asdict(model.adapters),
+        "preflight": asdict(model.preflight),
+        "support_bundle": asdict(model.support_bundle),
+        "controls": {
+            "mutation_actions": [],
+            "support_bundle_export_enabled": False,
+        },
+    }
+
+
+def _render_live_smoke_json(
+    *,
+    model: DiagnosticsControlUiModel,
+    status: str,
+) -> str:
+    """Serialize a sanitized live smoke model under a fixed output bound."""
+
+    rendered = json.dumps(
+        _build_live_smoke_payload(model=model, status=status),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(rendered.encode("utf-8")) > MAX_LIVE_SMOKE_JSON_BYTES:
+        raise RuntimeError("The Flatpak live smoke payload exceeded its size limit.")
+    return rendered
+
+
+def _live_smoke_status(model: DiagnosticsControlUiModel) -> str:
+    if model.pairing.paired:
+        if (
+            model.adapters.severity is StatusSeverity.UNKNOWN
+            or model.preflight.severity is StatusSeverity.UNKNOWN
+        ):
+            return _LIVE_SMOKE_INVALID_RESPONSE
+        return _LIVE_SMOKE_SUCCESS
+
+    statuses = {
+        "authentication_failed": "token_rejected",
+        "daemon_unreachable": "daemon_unreachable",
+        "api_token_missing": "daemon_token_missing",
+        "unexpected_daemon_response": _LIVE_SMOKE_INVALID_RESPONSE,
+    }
+    return statuses.get(
+        model.pairing.detail_code,
+        _LIVE_SMOKE_INVALID_RESPONSE,
+    )
+
+
+def _emit_live_smoke(
+    *,
+    model: DiagnosticsControlUiModel,
+    status: str,
+    exit_code: int,
+) -> int:
+    try:
+        rendered = _render_live_smoke_json(model=model, status=status)
+    except Exception:
+        model = build_initial_model()
+        status = _LIVE_SMOKE_INVALID_RESPONSE
+        exit_code = _LIVE_SMOKE_FAILURE_EXIT
+        rendered = _render_live_smoke_json(model=model, status=status)
+    print(rendered)
+    return exit_code
+
+
+def run_live_pairing_smoke_json(
+    *,
+    input_stream=None,
+    token_prompt=None,
+    client_factory=None,
+) -> int:
+    """Prompt for one in-memory token and render authenticated read-only state."""
+
+    stream = sys.stdin if input_stream is None else input_stream
+    try:
+        interactive = stream.isatty() is True
+    except Exception:
+        interactive = False
+    if not interactive:
+        return _emit_live_smoke(
+            model=build_initial_model(),
+            status=_LIVE_SMOKE_INTERACTIVE_INPUT_REQUIRED,
+            exit_code=_LIVE_SMOKE_INPUT_EXIT,
+        )
+
+    prompt = getpass.getpass if token_prompt is None else token_prompt
+    token = ""
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", getpass.GetPassWarning)
+            token = prompt("VRhotspot daemon API token: ")
+    except KeyboardInterrupt:
+        return _emit_live_smoke(
+            model=build_initial_model(),
+            status=_LIVE_SMOKE_TOKEN_INPUT_CANCELLED,
+            exit_code=_LIVE_SMOKE_INPUT_EXIT,
+        )
+    except Exception:
+        return _emit_live_smoke(
+            model=build_initial_model(),
+            status=_LIVE_SMOKE_TOKEN_INPUT_CANCELLED,
+            exit_code=_LIVE_SMOKE_INPUT_EXIT,
+        )
+
+    if not isinstance(token, str) or token == "":
+        token = ""
+        return _emit_live_smoke(
+            model=build_initial_model(),
+            status=_LIVE_SMOKE_TOKEN_INPUT_EMPTY,
+            exit_code=_LIVE_SMOKE_INPUT_EXIT,
+        )
+
+    factory = LocalApiClient if client_factory is None else client_factory
+    try:
+        try:
+            model = FirstRunTokenEntryController(client_factory=factory).connect(
+                token=token
+            )
+        except KeyboardInterrupt:
+            model = build_initial_model()
+        except Exception:
+            model = build_initial_model()
+    finally:
+        token = ""
+
+    status = _live_smoke_status(model)
+    return _emit_live_smoke(
+        model=model,
+        status=status,
+        exit_code=(
+            0 if status == _LIVE_SMOKE_SUCCESS else _LIVE_SMOKE_FAILURE_EXIT
+        ),
+    )
 
 
 def _load_gtk():
@@ -319,6 +484,14 @@ def _argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="print a bounded offline shell model as JSON and exit",
     )
+    parser.add_argument(
+        "--live-pairing-smoke-json",
+        action="store_true",
+        help=(
+            "prompt interactively for an in-memory daemon token, print bounded "
+            "authenticated read-only state as JSON, and exit"
+        ),
+    )
     return parser
 
 
@@ -329,6 +502,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.smoke_json:
         print(render_smoke_json())
         return 0
+    if args.live_pairing_smoke_json:
+        return run_live_pairing_smoke_json()
 
     try:
         return run_gui()

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -6,9 +6,16 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import warnings
 import xml.etree.ElementTree as ET
 
 import pytest
+
+from flatpak_client import (
+    AuthenticationError,
+    ConnectionFailure,
+    DaemonTokenMissingError,
+)
 
 
 APP_ID = "io.github.josethevrtech.VRhotspot"
@@ -115,6 +122,14 @@ class ScriptedReadOnlyClientFactory:
         return Client()
 
 
+class FakeInputStream:
+    def __init__(self, *, interactive):
+        self.interactive = interactive
+
+    def isatty(self):
+        return self.interactive
+
+
 def _manifest():
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
@@ -190,6 +205,341 @@ def test_smoke_json_contains_no_secret_or_host_path_leak_markers():
         "/var/",
     ):
         assert forbidden not in rendered
+
+
+def test_live_pairing_smoke_command_dispatches_without_importing_gtk(monkeypatch):
+    from flatpak_app import app
+
+    calls = []
+
+    def fake_live_smoke():
+        calls.append("live_smoke")
+        return 17
+
+    monkeypatch.setattr(app, "run_live_pairing_smoke_json", fake_live_smoke)
+    monkeypatch.setitem(sys.modules, "gi", None)
+
+    assert app.main(["--live-pairing-smoke-json"]) == 17
+    assert calls == ["live_smoke"]
+    assert sys.modules.get("gi") is None
+
+
+def test_live_smoke_refuses_noninteractive_input_with_token_free_json(capsys):
+    from flatpak_app import app
+
+    def forbidden_prompt(_prompt):
+        raise AssertionError("noninteractive smoke must not prompt")
+
+    def forbidden_factory(*, token):
+        raise AssertionError("noninteractive smoke must not create a client")
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=False),
+        token_prompt=forbidden_prompt,
+        client_factory=forbidden_factory,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert captured.err == ""
+    assert payload["live_smoke"]["status"] == "interactive_input_required"
+    assert payload["daemon"]["reachable"] is None
+    assert payload["pairing"]["paired"] is False
+    assert payload["controls"]["mutation_actions"] == []
+    assert payload["support_bundle"]["action_enabled"] is False
+
+
+def test_live_smoke_success_returns_bounded_sanitized_ui_ready_json(capsys):
+    from flatpak_app import MAX_LIVE_SMOKE_JSON_BYTES
+    from flatpak_app import app
+
+    secret = "live-smoke-success-value-must-not-escape"
+    prompts = []
+    factory = ScriptedReadOnlyClientFactory()
+
+    def hidden_prompt(prompt):
+        prompts.append(prompt)
+        return secret
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=hidden_prompt,
+        client_factory=factory,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert prompts == ["VRhotspot daemon API token: "]
+    assert len(captured.out.encode("utf-8")) <= MAX_LIVE_SMOKE_JSON_BYTES + 1
+    assert set(payload) == {
+        "application",
+        "live_smoke",
+        "daemon",
+        "pairing",
+        "adapter_readiness",
+        "preflight",
+        "support_bundle",
+        "controls",
+    }
+    assert payload["application"] == {"id": APP_ID, "name": APP_NAME}
+    assert payload["live_smoke"]["status"] == "success"
+    assert payload["daemon"]["reachable"] is True
+    assert payload["pairing"]["paired"] is True
+    assert payload["adapter_readiness"]["recommended_interface"] == "wlan1"
+    assert payload["preflight"]["readiness_label"] == "Needs attention"
+    assert payload["support_bundle"]["action_enabled"] is False
+    assert payload["support_bundle"]["request_performed"] is False
+    assert payload["controls"] == {
+        "mutation_actions": [],
+        "support_bundle_export_enabled": False,
+    }
+    assert factory.token_presence == [False, True, True]
+    assert secret not in captured.out
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_status", "daemon_reachable", "pairing_title"),
+    [
+        (
+            ScriptedReadOnlyClientFactory(
+                readiness_result=AuthenticationError(401)
+            ),
+            "token_rejected",
+            True,
+            "Token rejected",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                health_result=ConnectionFailure("offline")
+            ),
+            "daemon_unreachable",
+            False,
+            "Pairing unavailable",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                readiness_result=DaemonTokenMissingError()
+            ),
+            "daemon_token_missing",
+            True,
+            "Daemon token missing",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                readiness_result={"unexpected": "response"}
+            ),
+            "invalid_response",
+            None,
+            "Pairing status unknown",
+        ),
+    ],
+    ids=(
+        "token-rejected",
+        "daemon-unreachable",
+        "daemon-token-missing",
+        "malformed-pairing-response",
+    ),
+)
+def test_live_smoke_failures_are_nonzero_and_token_free(
+    capsys,
+    factory,
+    expected_status,
+    daemon_reachable,
+    pairing_title,
+):
+    from flatpak_app import app
+
+    secret = f"live-smoke-{expected_status}-must-not-escape"
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=lambda _prompt: secret,
+        client_factory=factory,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 1
+    assert captured.err == ""
+    assert payload["live_smoke"]["status"] == expected_status
+    assert payload["daemon"]["reachable"] is daemon_reachable
+    assert payload["pairing"]["title"] == pairing_title
+    assert payload["pairing"]["paired"] is False
+    assert payload["controls"]["mutation_actions"] == []
+    assert payload["support_bundle"]["action_enabled"] is False
+    assert secret not in captured.out
+
+
+def test_live_smoke_malformed_preflight_is_unknown_and_nonzero(capsys):
+    from flatpak_app import app
+
+    secret = "live-smoke-malformed-preflight-must-not-escape"
+    factory = ScriptedReadOnlyClientFactory(
+        preflight_result=_api_response(
+            {
+                "schema_version": 99,
+                "overall_readiness": "future",
+            }
+        )
+    )
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=lambda _prompt: secret,
+        client_factory=factory,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 1
+    assert payload["live_smoke"]["status"] == "invalid_response"
+    assert payload["pairing"]["paired"] is True
+    assert payload["preflight"]["severity"] == "unknown"
+    assert payload["controls"]["mutation_actions"] == []
+    assert secret not in captured.out
+
+
+def test_live_smoke_drops_secret_and_host_path_values_from_json(capsys):
+    from flatpak_app import app
+
+    entered_token = "entered-live-token-value-must-not-escape"
+    api_token_value = "daemon-api-token-value-must-not-escape"
+    passphrase_value = "wifi-passphrase-value-must-not-escape"
+    password_value = "daemon-password-value-must-not-escape"
+    psk_value = "wifi-psk-value-must-not-escape"
+    bearer_value = "bearer-value-must-not-escape"
+    host_path = "/var/lib/vr-hotspot/private-state.json"
+    factory = ScriptedReadOnlyClientFactory(
+        readiness_result=_api_response(
+            {
+                "recommended": "wlan1",
+                "basic_mode_recommended": "wlan1",
+                "summary": {"readiness_state": "ready"},
+                "adapters": [
+                    {
+                        "interface": "wlan1",
+                        "readiness_state": "ready",
+                        "explanation": (
+                            f"token={api_token_value}; "
+                            f"passphrase={passphrase_value}; "
+                            f"password={password_value}; psk={psk_value}"
+                        ),
+                    }
+                ],
+            }
+        ),
+        preflight_result=_api_response(
+            {
+                "schema_version": 1,
+                "overall_readiness": "warning",
+                "platform": {},
+                "firewall": {},
+                "services": {},
+                "network": {},
+                "wifi": {},
+                "issues": [
+                    {
+                        "severity": "warning",
+                        "code": "redaction_check",
+                        "message": (
+                            f"Authorization: Bearer {bearer_value}; "
+                            f"inspect {host_path}"
+                        ),
+                    }
+                ],
+                "recommended_actions": [],
+            }
+        ),
+    )
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=lambda _prompt: entered_token,
+        client_factory=factory,
+    )
+    captured = capsys.readouterr()
+    rendered = captured.out
+
+    assert exit_code == 0
+    for forbidden_value in (
+        entered_token,
+        api_token_value,
+        passphrase_value,
+        password_value,
+        psk_value,
+        bearer_value,
+        host_path,
+    ):
+        assert forbidden_value not in rendered
+    assert "[redacted]" in rendered
+    assert "[host path]" in rendered
+
+
+def test_live_smoke_rejects_empty_or_unavailable_hidden_input_without_a_client(
+    capsys,
+):
+    from flatpak_app import app
+
+    client_calls = []
+
+    def forbidden_factory(*, token):
+        client_calls.append(token)
+        raise AssertionError("empty or unavailable input must not create a client")
+
+    empty_exit = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=lambda _prompt: "",
+        client_factory=forbidden_factory,
+    )
+    empty_payload = json.loads(capsys.readouterr().out)
+
+    def failed_prompt(_prompt):
+        raise OSError("terminal input unavailable")
+
+    cancelled_exit = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=failed_prompt,
+        client_factory=forbidden_factory,
+    )
+    cancelled_payload = json.loads(capsys.readouterr().out)
+
+    assert empty_exit == 2
+    assert empty_payload["live_smoke"]["status"] == "token_input_empty"
+    assert cancelled_exit == 2
+    assert cancelled_payload["live_smoke"]["status"] == "token_input_cancelled"
+    assert client_calls == []
+
+
+def test_live_smoke_rejects_getpass_echo_fallback_before_reading_input(capsys):
+    from flatpak_app import app
+
+    secret = "fallback-must-not-read-or-echo-this-value"
+    client_calls = []
+
+    def fallback_prompt(_prompt):
+        warnings.warn("hidden input unavailable", app.getpass.GetPassWarning)
+        return secret
+
+    def forbidden_factory(*, token):
+        client_calls.append(token)
+        raise AssertionError("unsafe prompt fallback must not create a client")
+
+    exit_code = app.run_live_pairing_smoke_json(
+        input_stream=FakeInputStream(interactive=True),
+        token_prompt=fallback_prompt,
+        client_factory=forbidden_factory,
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert captured.err == ""
+    assert payload["live_smoke"]["status"] == "token_input_cancelled"
+    assert secret not in captured.out
+    assert client_calls == []
 
 
 def test_token_entry_requires_only_a_caller_supplied_token():
@@ -408,6 +758,9 @@ def test_shell_has_no_token_cli_argument_or_discovery_source():
 
     assert "--token" not in option_strings
     assert "--api-token" not in option_strings
+    assert "--live-pairing-smoke-json" in option_strings
+    assert "getpass.getpass" in source
+    assert "isatty()" in source
     assert "FirstRunTokenEntryController" in source
     assert "LocalApiClient" in source
     assert "TokenPairingController" in source


### PR DESCRIPTION
# Summary
- Add explicit Flatpak live daemon pairing smoke command: `--live-pairing-smoke-json`.
- Validate real daemon pairing path through existing TokenPairingController, loopback-only LocalApiClient, and DiagnosticsControlUiController.
- Keep token input hidden, interactive-only, in-memory-only, and never accepted through CLI/env/disk/keyring/portal/config discovery.
- Keep support-bundle export disabled and mutation actions empty.

# Boundaries
- No token persistence or keyring storage.
- No CLI token argument.
- No daemon/runtime/installer/vendor/CI/WebUI behavior changes.
- No lifecycle/config/start/stop/restart controls.
- No Flatpak permission expansion.
- No Steam Frame, VR Direct Link, adapter registry, or HostFactsSnapshot work.

# Validation
- Vendor manifest/SBOM/SHA validation passed.
- Installer shell syntax and install matrix passed.
- Flatpak manifest JSON, Python compilation, launcher syntax, and smoke JSON passed.
- Focused tests: 87 passed.
- Full suite: 731 passed, 4 subtests passed.
- Real Flatpak build/install/smoke passed.
- Installed live command safely refused noninteractive input.
- Live daemon pairing validation: not run; vr-hotspotd.service was not found/inactive.

# Review
- Final review verdict: approve; no blockers.
- Review file: `/tmp/vrhotspot-flatpak-live-daemon-pairing-smoke-final-review.md`
- Review SHA-256: `733852e176e667daf0c72a4802789d1b5fdf42787f031fb575113415b3a63032`
