### PR TITLE
Add optional Flatpak companion installer prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,39 @@ curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install
 sudo bash /tmp/vrhotspot-install.sh --non-interactive
 ```
 
+### Optional prototype Flatpak companion
+
+The guided installer asks `Install the Flatpak companion app?` and defaults to
+No while the companion and its local packaging mature. Choosing No leaves the
+existing daemon installation unchanged. Choosing Yes makes a best-effort,
+user-scoped build/install from
+`packaging/flatpak/io.github.josethevrtech.VRhotspot.json`.
+
+Unattended installs do not install the companion by default. Explicitly opt in
+with:
+
+```bash
+sudo bash /tmp/vrhotspot-install.sh --non-interactive \
+  --install-flatpak-companion
+```
+
+The optional path requires `flatpak`, `flatpak-builder`, and the GNOME 50
+runtime/SDK to already be available. It does not add Flathub or another Flatpak
+remote. Missing prerequisites or a failed build are reported clearly, temporary
+build files are removed, and the daemon install continues.
+
+After installation, launch the companion and enter the existing daemon API
+token manually in its hidden token field. The installer does not read, pass,
+copy, or store the daemon token for the Flatpak. Token persistence/keyring
+storage, lifecycle/configuration controls, support-bundle portal export,
+Flathub polish, Steam Frame, VR Direct Link, and adapter-registry work remain
+future work.
+
 **Other Linux distributions**
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh | sudo bash
+curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh -o /tmp/vrhotspot-install.sh
+sudo bash /tmp/vrhotspot-install.sh
 ```
 
 **Bazzite support policy**
@@ -60,7 +89,15 @@ reboot the system automatically.
 **To uninstall:**
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/uninstall.sh | sudo bash
+curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/uninstall.sh -o /tmp/vrhotspot-uninstall.sh
+sudo bash /tmp/vrhotspot-uninstall.sh
+```
+
+The daemon uninstaller leaves any user-scoped Flatpak companion and configured
+Flatpak remotes untouched. Remove only this companion explicitly, if desired:
+
+```bash
+flatpak uninstall --user io.github.josethevrtech.VRhotspot
 ```
 
 ---

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,17 +1,18 @@
 # Flatpak control app architecture plan
 
-Status: PR #83 live daemon pairing smoke path; PRs #77-#82 retained
+Status: PR #84 optional installer companion prompt; PRs #77-#83 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #83 adds an explicit terminal-only live daemon pairing smoke
-path to PR #82's in-memory first-run token entry flow and PR #81's rough
-installable and testable Flatpak shell. It uses PR #78's read-only local API
-client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
-model/controller foundation. It is not a finished production UI and adds no
-daemon API, daemon runtime, installer, privileged action, token persistence, or
-credential-storage behavior.
+application. PR #84 adds an optional, best-effort installer prompt for PR #81's
+rough installable and testable Flatpak shell. PR #83's explicit terminal-only
+live daemon pairing smoke path and PR #82's in-memory first-run token entry flow
+remain unchanged. The shell uses PR #78's read-only local API client, PR #79's
+pairing state, and PR #80's toolkit-agnostic UI model/controller foundation. It
+is not a finished production UI. PR #84 changes only the top-level guided
+installer path; it adds no daemon API/runtime behavior, privileged Flatpak
+action, token persistence, or credential-storage behavior.
 
 ## Architectural decision
 
@@ -427,6 +428,48 @@ lifecycle/configuration controls, production and Flathub polish, Steam Frame,
 VR Direct Link, and adapter-registry work remain separately reviewed future
 work.
 
+## PR #84 optional installer companion prompt
+
+PR #84 adds one guided question to the existing top-level installer:
+`Install the Flatpak companion app?` The default is No while the companion
+remains a prototype with local repository packaging. A No answer preserves the
+existing daemon install path. Noninteractive installs also default to no
+companion; `--install-flatpak-companion` is the only explicit unattended opt-in.
+
+When selected, the installer checks for `flatpak` and `flatpak-builder`, resolves
+the non-root user who invoked the root installer through `sudo`, and attempts a
+user-scoped build/install from
+`packaging/flatpak/io.github.josethevrtech.VRhotspot.json`. Build and state
+directories use a private cleanup-safe temporary directory outside the tracked
+tree. Builder output is captured and only a bounded tail is shown on failure.
+The installer uses already available runtimes and SDKs; it does not add Flathub,
+install another remote, or make a system-wide Flatpak change.
+
+The companion is optional and best-effort. Missing tools, an unavailable GNOME
+50 runtime/SDK, or another build/install failure is explained, temporary build
+state is removed, and the completed daemon install remains successful. PR #84
+does not add a strict companion-failure mode. The installer does not run either
+Flatpak smoke command or attempt live daemon pairing.
+
+The installer never supplies a daemon API token to the Flatpak build or app. It
+does not read daemon credentials from environment variables, files, keyrings,
+portals, daemon configuration, `/etc`, `/var/lib`, or another filesystem
+location. Known daemon-token environment variable names are removed from the
+builder process environment without inspecting their values. After install, the
+user pairs manually by entering the existing daemon token in the companion's
+hidden field; the existing in-memory-only handling remains unchanged.
+
+Daemon uninstallers do not automatically remove the user-owned companion or any
+Flatpak remote. A user may separately remove only this app with:
+
+```bash
+flatpak uninstall --user io.github.josethevrtech.VRhotspot
+```
+
+Token persistence/keyring storage, lifecycle/configuration controls,
+support-bundle portal export, Flathub production polish, Steam Frame, VR Direct
+Link, and adapter-registry work remain separately reviewed future work.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -515,7 +558,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #80 | Diagnostics/control UI foundation. Add toolkit-agnostic, bounded UI models for daemon/pairing status, adapter readiness, preflight diagnostics, Basic/Pro presentation depth, and a disabled support-bundle affordance. Add no lifecycle control, support-bundle download/export wiring, GUI toolkit, desktop window, package, or manifest. | Offline behavior tests cover connection/authentication states, safe response projection, severity mapping, malformed-data fallback, Basic/Pro presentation fields, secret/path sanitization, output bounds, and the absence of mutation methods. |
 | PR #81 | Flatpak packaging/app shell prototype. Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
 | PR #82 | First-run/token entry UI prototype. Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
-| PR #83 | Live daemon pairing smoke path (current phase). Add an explicit terminal-only installed-Flatpak command with strict hidden manual token entry and bounded sanitized JSON assembled through the existing pairing, local-client, and diagnostics UI boundaries. Add no token argument or discovery/storage path, mutation control, daemon/installer behavior, or permission. | Offline tests cover TTY and hidden-input refusal, success, token rejection, daemon unreachability, missing daemon token, malformed data, output bounds and redaction, unchanged offline/GUI behavior, and the absence of discovery or mutation controls. A real-daemon run of the documented command is required before live pairing is claimed. |
+| PR #83 | Live daemon pairing smoke path. Add an explicit terminal-only installed-Flatpak command with strict hidden manual token entry and bounded sanitized JSON assembled through the existing pairing, local-client, and diagnostics UI boundaries. Add no token argument or discovery/storage path, mutation control, daemon/installer behavior, or permission. | Offline tests cover TTY and hidden-input refusal, success, token rejection, daemon unreachability, missing daemon token, malformed data, output bounds and redaction, unchanged offline/GUI behavior, and the absence of discovery or mutation controls. A real-daemon run of the documented command is required before live pairing is claimed. |
+| PR #84 | Optional installer companion prompt (current phase). Add a default-No guided choice and an explicit `--install-flatpak-companion` unattended opt-in for a best-effort user-scoped local build/install. Add no remote configuration, token transfer/storage, smoke execution, daemon/runtime behavior, uninstaller mutation, or permission change. | Deterministic installer tests cover guided No/Yes, unattended default/opt-in, missing tools, bounded build failure, cleanup, credential-environment scrubbing, unchanged manifest permissions, and non-destructive uninstall boundaries. Existing Flatpak tests and real packaging validation remain required. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -539,7 +583,7 @@ a production Flatpak release:
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #83's prototype choices are not blanket approval for production packaging
+PR #84's prototype choices are not blanket approval for production packaging
 or additional permissions.
 
 ## Future test and validation expectations
@@ -596,7 +640,7 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #83
+## Explicit non-goals for PR #84
 
 - No finished production UI or existing Web UI change. The GTK window is a
   rough first-run and display-only prototype, not a production control surface.
@@ -613,7 +657,9 @@ reporting. Flatpak work must not weaken or bypass those controls.
   for the current in-memory call.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
-- No installer, uninstaller, systemd-unit, platform, or CI behavior change.
+- No backend installer, uninstaller, systemd-unit, platform matrix, or CI-script
+  behavior change. PR #84 changes only the top-level optional installer path and
+  adds deterministic tests for it.
 - No privileged networking in the Flatpak.
 - No direct Flatpak control of firewall rules, NetworkManager, iwd, hostapd,
   dnsmasq, systemd units, kernel or network namespaces, interfaces, routes,
@@ -628,12 +674,12 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #83 authorizes only the explicit terminal live-pairing smoke orchestration in
-the existing Flatpak shell, its offline tests, and this plan update. It does not
-claim live pairing until the documented command succeeds against a real daemon.
-It does not claim token persistence, keyring integration, lifecycle or
-configuration controls, support-bundle portal export, a Flathub-polished
-release, Steam Frame support, VR Direct Link support, or a known-adapter
-registry. Production UI work, persistence, portal export, Flathub polish, Steam
-Frame, VR Direct Link, adapter registry work, and all later phases remain
-separately approved work.
+PR #84 authorizes only the default-No guided choice, the explicit unattended
+opt-in, the best-effort user-scoped local build/install helper, its deterministic
+tests, and documentation updates. PR #83's live-pairing validation remains the
+recorded manual result; the installer does not repeat it. PR #84 does not claim
+token persistence, keyring integration, lifecycle/configuration controls,
+support-bundle portal export, a Flathub-polished release, Steam Frame support,
+VR Direct Link support, or a known-adapter registry. Production UI work,
+persistence, portal export, Flathub polish, Steam Frame, VR Direct Link, adapter
+registry work, and all later phases remain separately approved work.

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ FIREWALL_LEDGER="$INSTALL_ROOT/firewall-rules.json"
 CONFIG_DIR="/etc/vr-hotspot"
 ENV_FILE="$CONFIG_DIR/env"
 SYSTEMD_DIR="/etc/systemd/system"
+FLATPAK_COMPANION_APP_ID="io.github.josethevrtech.VRhotspot"
+FLATPAK_COMPANION_MANIFEST_RELATIVE="packaging/flatpak/io.github.josethevrtech.VRhotspot.json"
 
 # --- Colors and Formatting ---
 RED='\033[0;31m'
@@ -380,12 +382,15 @@ VR Hotspot Installer
 
 Usage:
   sudo ./install.sh [options]
-  curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh | sudo bash
+  curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install.sh -o /tmp/vrhotspot-install.sh
+  sudo bash /tmp/vrhotspot-install.sh [options]
 
 Options:
   --interactive       Prompt for installer choices when a real TTY is available
   --non-interactive   Disable prompts and use safe defaults
   --yes, -y           Alias for --non-interactive
+  --install-flatpak-companion
+                      Build and install the prototype Flatpak companion for the invoking user
   --check-os          Detect OS and print dependency plan only
   --no-clear          Do not clear the terminal before output
   -h, --help          Show this help
@@ -477,6 +482,179 @@ prompt_yes_no() {
                 ;;
         esac
     done
+}
+
+# --- Optional Flatpak Companion ---
+configure_flatpak_companion_install() {
+    INSTALL_FLATPAK_COMPANION="n"
+
+    if [ "${FLATPAK_COMPANION_OPT_IN:-0}" -eq 1 ]; then
+        INSTALL_FLATPAK_COMPANION="y"
+        print_info "Flatpak companion install explicitly requested."
+    elif [ "$INTERACTIVE" -eq 1 ]; then
+        if prompt_yes_no "Install the Flatpak companion app? (y/N) " "n"; then
+            INSTALL_FLATPAK_COMPANION="y"
+        else
+            print_info "Flatpak companion app install skipped."
+        fi
+    else
+        print_info "Flatpak companion app install skipped (default: No)."
+    fi
+}
+
+resolve_flatpak_companion_user() {
+    local candidate current_uid candidate_uid candidate_gid
+    current_uid="$(id -u)"
+
+    if [ "$current_uid" -eq 0 ]; then
+        candidate="${SUDO_USER:-}"
+        if [ -z "$candidate" ] || [ "$candidate" = "root" ]; then
+            print_warning "Cannot determine a non-root invoking user for the user-scoped Flatpak install."
+            print_info "Run the installer through sudo from the desktop user that should own the companion app."
+            return 1
+        fi
+    else
+        candidate="$(id -un)"
+    fi
+
+    if ! candidate_uid="$(id -u "$candidate" 2>/dev/null)" ||
+       ! candidate_gid="$(id -g "$candidate" 2>/dev/null)"; then
+        print_warning "Cannot resolve the Flatpak companion install user '$candidate'."
+        return 1
+    fi
+    if [ "$candidate_uid" -eq 0 ]; then
+        print_warning "Refusing to install the user-scoped Flatpak companion for root."
+        return 1
+    fi
+
+    FLATPAK_COMPANION_USER="$candidate"
+    FLATPAK_COMPANION_UID="$candidate_uid"
+    FLATPAK_COMPANION_GID="$candidate_gid"
+}
+
+run_flatpak_companion_as_user() {
+    local current_uid
+    current_uid="$(id -u)"
+
+    # Remove daemon credential variables without inspecting their values.
+    if [ "$current_uid" -eq "$FLATPAK_COMPANION_UID" ]; then
+        env -u VR_HOTSPOTD_API_TOKEN -u API_TOKEN "$@"
+    else
+        sudo -H -u "$FLATPAK_COMPANION_USER" -- \
+            env -u VR_HOTSPOTD_API_TOKEN -u API_TOKEN "$@"
+    fi
+}
+
+check_flatpak_companion_prerequisites() {
+    local -a missing_tools=()
+
+    command -v flatpak >/dev/null 2>&1 || missing_tools+=("flatpak")
+    if command -v flatpak-builder >/dev/null 2>&1; then
+        FLATPAK_BUILDER_BIN="$(command -v flatpak-builder)"
+    else
+        missing_tools+=("flatpak-builder")
+    fi
+
+    if [ "${#missing_tools[@]}" -gt 0 ]; then
+        print_warning "Flatpak companion install skipped; missing required tool(s): ${missing_tools[*]}."
+        print_info "Install the missing tools and the GNOME 50 runtime/SDK, then rerun with --install-flatpak-companion."
+        return 1
+    fi
+
+    FLATPAK_COMPANION_MANIFEST="$TEMP_INSTALL_DIR/$FLATPAK_COMPANION_MANIFEST_RELATIVE"
+    if [ ! -f "$FLATPAK_COMPANION_MANIFEST" ]; then
+        print_warning "Flatpak companion install skipped; manifest not found at $FLATPAK_COMPANION_MANIFEST."
+        return 1
+    fi
+
+    if ! resolve_flatpak_companion_user; then
+        return 1
+    fi
+
+    if [ "$(id -u)" -ne "$FLATPAK_COMPANION_UID" ] &&
+       ! command -v sudo >/dev/null 2>&1; then
+        print_warning "Flatpak companion install skipped; sudo is required to install for $FLATPAK_COMPANION_USER."
+        return 1
+    fi
+}
+
+cleanup_flatpak_companion_build_root() {
+    local build_root="$1"
+
+    case "$build_root" in
+        /tmp/vrhotspot-flatpak-companion.*)
+            rm -rf -- "$build_root"
+            ;;
+        *)
+            print_warning "Refusing to clean unexpected Flatpak companion build path: $build_root"
+            return 1
+            ;;
+    esac
+}
+
+build_and_install_flatpak_companion() {
+    local build_root build_dir state_dir build_log current_uid build_status
+
+    if ! build_root="$(mktemp -d /tmp/vrhotspot-flatpak-companion.XXXXXX)"; then
+        print_warning "Could not create a temporary Flatpak companion build directory."
+        return 1
+    fi
+    build_dir="$build_root/build"
+    state_dir="$build_root/state"
+    build_log="$build_root/flatpak-builder.log"
+    current_uid="$(id -u)"
+
+    chmod 700 "$build_root"
+    if [ "$current_uid" -ne "$FLATPAK_COMPANION_UID" ] &&
+       ! chown "$FLATPAK_COMPANION_UID:$FLATPAK_COMPANION_GID" "$build_root"; then
+        print_warning "Could not prepare the Flatpak companion build directory for $FLATPAK_COMPANION_USER."
+        cleanup_flatpak_companion_build_root "$build_root"
+        return 1
+    fi
+
+    print_step "Building and installing the Flatpak companion app for $FLATPAK_COMPANION_USER..."
+    build_status=0
+    if run_flatpak_companion_as_user \
+        "$FLATPAK_BUILDER_BIN" \
+        --user \
+        --install \
+        --assumeyes \
+        --force-clean \
+        --delete-build-dirs \
+        --state-dir="$state_dir" \
+        "$build_dir" \
+        "$FLATPAK_COMPANION_MANIFEST" >"$build_log" 2>&1; then
+        print_success "Flatpak companion app ($FLATPAK_COMPANION_APP_ID) installed for $FLATPAK_COMPANION_USER."
+    else
+        build_status=$?
+        print_warning "Flatpak companion build/install failed (exit $build_status)."
+        if [ -s "$build_log" ]; then
+            print_info "Last Flatpak builder messages:"
+            tail -n 20 "$build_log" | cut -c 1-500
+        fi
+        print_info "The daemon installation remains complete. This installer does not add Flatpak remotes."
+        print_info "Install the GNOME 50 runtime/SDK from a trusted configured source, then retry with --install-flatpak-companion."
+    fi
+
+    if ! cleanup_flatpak_companion_build_root "$build_root"; then
+        print_warning "Temporary Flatpak companion build files may remain at $build_root."
+    fi
+    return "$build_status"
+}
+
+install_flatpak_companion_if_requested() {
+    if [ "${INSTALL_FLATPAK_COMPANION:-n}" != "y" ]; then
+        return 0
+    fi
+
+    if ! check_flatpak_companion_prerequisites; then
+        print_warning "Continuing without the optional Flatpak companion app."
+        return 0
+    fi
+    if ! build_and_install_flatpak_companion; then
+        print_warning "Continuing without the optional Flatpak companion app."
+    fi
+    return 0
 }
 
 _fix_apt_code_repo_signedby_conflict() {
@@ -885,6 +1063,7 @@ configure_install() {
         ENABLE_AUTOSTART="n"
         ENABLE_REMOTE="n"
     fi
+    configure_flatpak_companion_install
 
     BIND_IP="127.0.0.1"
     if [ "$ENABLE_REMOTE" == "y" ]; then
@@ -1041,6 +1220,8 @@ main() {
     CHECK_ONLY=0
     SKIP_CLEAR=0
     REQUESTED_INTERACTIVE_MODE="auto"
+    FLATPAK_COMPANION_OPT_IN=0
+    INSTALL_FLATPAK_COMPANION="n"
 
     for arg in "$@"; do
         case "$arg" in
@@ -1049,6 +1230,9 @@ main() {
                 ;;
             --non-interactive|--yes|-y)
                 REQUESTED_INTERACTIVE_MODE="non-interactive"
+                ;;
+            --install-flatpak-companion)
+                FLATPAK_COMPANION_OPT_IN=1
                 ;;
             --check-os)
                 CHECK_ONLY=1
@@ -1101,6 +1285,7 @@ main() {
     if [[ "$OS_ID" == "steamos" || "$OS_ID" == "bazzite" || "$OS_ID" == "fedora" || "$OS_ID" == "endeavouros" || "$OS_ID_LIKE" == *"fedora"* ]]; then
         enable_firewalld_uplink_forwarding
     fi
+    install_flatpak_companion_if_requested
     
     show_completion
 

--- a/tests/test_installer_flatpak_companion.py
+++ b/tests/test_installer_flatpak_companion.py
@@ -1,0 +1,364 @@
+import json
+import os
+from pathlib import Path
+import shlex
+import stat
+import subprocess
+from typing import Optional
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+TOP_UNINSTALLER = ROOT / "uninstall.sh"
+BACKEND_UNINSTALLER = ROOT / "backend" / "scripts" / "uninstall.sh"
+FLATPAK_MANIFEST = (
+    ROOT / "packaging" / "flatpak" / "io.github.josethevrtech.VRhotspot.json"
+)
+
+
+def make_executable(path: Path, contents: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def run_bash(
+    script: str, *, env: Optional[dict[str, str]] = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def selection_script(response: str, interactive: int = 1) -> str:
+    return f"""
+    source {shlex.quote(str(INSTALLER))}
+    INTERACTIVE={interactive}
+    FLATPAK_COMPANION_OPT_IN=0
+    interactive_read() {{
+        printf 'prompt=%s\\ndefault=%s\\n' "$3" n
+        printf -v "$4" '%s' {shlex.quote(response)}
+    }}
+    configure_flatpak_companion_install
+    check_flatpak_companion_prerequisites() {{
+        echo companion-prerequisites-called
+    }}
+    build_and_install_flatpak_companion() {{
+        echo companion-build-called
+    }}
+    install_flatpak_companion_if_requested
+    echo "selected=$INSTALL_FLATPAK_COMPANION"
+    """
+
+
+def test_guided_default_no_does_not_attempt_flatpak_companion_install():
+    result = run_bash(selection_script(""))
+
+    assert result.returncode == 0, result.stderr
+    assert "prompt=Install the Flatpak companion app? (y/N) " in result.stdout
+    assert "default=n" in result.stdout
+    assert "selected=n" in result.stdout
+    assert "companion-prerequisites-called" not in result.stdout
+    assert "companion-build-called" not in result.stdout
+
+
+def test_guided_yes_attempts_flatpak_companion_install():
+    result = run_bash(selection_script("yes"))
+
+    assert result.returncode == 0, result.stderr
+    assert "prompt=Install the Flatpak companion app? (y/N) " in result.stdout
+    assert "selected=y" in result.stdout
+    assert "companion-prerequisites-called" in result.stdout
+    assert "companion-build-called" in result.stdout
+
+
+def test_noninteractive_default_does_not_prompt_or_install_companion():
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        INTERACTIVE=0
+        FLATPAK_COMPANION_OPT_IN=0
+        prompt_yes_no() {{
+            echo forbidden-prompt
+            return 99
+        }}
+        configure_flatpak_companion_install
+        check_flatpak_companion_prerequisites() {{
+            echo forbidden-prerequisite-check
+        }}
+        install_flatpak_companion_if_requested
+        echo "selected=$INSTALL_FLATPAK_COMPANION"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "selected=n" in result.stdout
+    assert "default: No" in result.stdout
+    assert "forbidden-prompt" not in result.stdout
+    assert "forbidden-prerequisite-check" not in result.stdout
+
+
+def test_explicit_noninteractive_flag_opts_in_and_attempts_install():
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        INTERACTIVE=0
+        FLATPAK_COMPANION_OPT_IN=1
+        prompt_yes_no() {{
+            echo forbidden-prompt
+            return 99
+        }}
+        configure_flatpak_companion_install
+        check_flatpak_companion_prerequisites() {{
+            echo companion-prerequisites-called
+        }}
+        build_and_install_flatpak_companion() {{
+            echo companion-build-called
+        }}
+        install_flatpak_companion_if_requested
+        echo "selected=$INSTALL_FLATPAK_COMPANION"
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "selected=y" in result.stdout
+    assert "explicitly requested" in result.stdout
+    assert "companion-prerequisites-called" in result.stdout
+    assert "companion-build-called" in result.stdout
+    assert "forbidden-prompt" not in result.stdout
+
+
+def test_main_parses_explicit_noninteractive_companion_opt_in():
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        check_root() {{ :; }}
+        cleanup_previous_install() {{ :; }}
+        detect_os() {{
+            OS_ID=ubuntu
+            OS_ID_LIKE=
+            OS_NAME=Ubuntu
+            PKG_MANAGER=apt
+        }}
+        install_dependencies() {{ :; }}
+        get_source_files() {{ TEMP_INSTALL_DIR="$PWD"; }}
+        validate_endeavouros_runtime_dependencies() {{ :; }}
+        configure_install() {{ configure_flatpak_companion_install; }}
+        install_daemon() {{ :; }}
+        install_flatpak_companion_if_requested() {{
+            echo "main-selected=$INSTALL_FLATPAK_COMPANION"
+        }}
+        show_completion() {{ :; }}
+        main --non-interactive --install-flatpak-companion --no-clear
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "main-selected=y" in result.stdout
+    assert "Flatpak companion install explicitly requested" in result.stdout
+
+
+@pytest.mark.parametrize("missing_tool", ["flatpak", "flatpak-builder"])
+def test_missing_flatpak_prerequisite_is_clear_and_nonfatal(tmp_path, missing_tool):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    available_tool = (
+        "flatpak-builder" if missing_tool == "flatpak" else "flatpak"
+    )
+    make_executable(fake_bin / available_tool)
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        INSTALL_FLATPAK_COMPANION=y
+        TEMP_INSTALL_DIR={shlex.quote(str(ROOT))}
+        install_flatpak_companion_if_requested
+        echo daemon-install-continues
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"missing required tool(s): {missing_tool}" in result.stdout
+    assert "Continuing without the optional Flatpak companion app" in result.stdout
+    assert "daemon-install-continues" in result.stdout
+
+
+def test_flatpak_build_failure_is_bounded_nonfatal_and_cleans_temp_dir(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    builder_args = tmp_path / "flatpak-builder.args"
+    credential_state = tmp_path / "flatpak-builder.credentials"
+    make_executable(fake_bin / "flatpak")
+    make_executable(
+        fake_bin / "flatpak-builder",
+        """#!/bin/sh
+printf '%s\n' "$@" > "$FAKE_FLATPAK_BUILDER_ARGS"
+if [ "${VR_HOTSPOTD_API_TOKEN+x}" = x ] || [ "${API_TOKEN+x}" = x ]; then
+    echo present > "$FAKE_FLATPAK_CREDENTIAL_STATE"
+else
+    echo absent > "$FAKE_FLATPAK_CREDENTIAL_STATE"
+fi
+i=1
+while [ "$i" -le 40 ]; do
+    echo "builder-line-$i"
+    i=$((i + 1))
+done
+echo "deterministic fake builder failure"
+exit 23
+""",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "FAKE_FLATPAK_BUILDER_ARGS": str(builder_args),
+            "FAKE_FLATPAK_CREDENTIAL_STATE": str(credential_state),
+            "VR_HOTSPOTD_API_TOKEN": "must-not-reach-flatpak-builder",
+            "API_TOKEN": "must-not-reach-flatpak-builder-either",
+        }
+    )
+
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        INSTALL_FLATPAK_COMPANION=y
+        TEMP_INSTALL_DIR={shlex.quote(str(ROOT))}
+        resolve_flatpak_companion_user() {{
+            FLATPAK_COMPANION_USER="$(id -un)"
+            FLATPAK_COMPANION_UID="$(id -u)"
+            FLATPAK_COMPANION_GID="$(id -g)"
+        }}
+        install_flatpak_companion_if_requested
+        echo daemon-install-continues
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "failed (exit 23)" in result.stdout
+    assert "deterministic fake builder failure" in result.stdout
+    assert "Continuing without the optional Flatpak companion app" in result.stdout
+    assert "daemon-install-continues" in result.stdout
+    assert "must-not-reach-flatpak-builder" not in result.stdout
+    output_lines = result.stdout.splitlines()
+    assert "builder-line-1" not in output_lines
+    assert "builder-line-21" not in output_lines
+    assert "builder-line-22" in output_lines
+    assert "builder-line-40" in output_lines
+    assert credential_state.read_text(encoding="utf-8").strip() == "absent"
+
+    args = builder_args.read_text(encoding="utf-8").splitlines()
+    assert "--user" in args
+    assert "--install" in args
+    assert "--assumeyes" in args
+    assert "--force-clean" in args
+    assert "--delete-build-dirs" in args
+    assert not any(argument.startswith("--install-deps-from") for argument in args)
+    assert "flathub" not in args
+    assert args[-1] == str(FLATPAK_MANIFEST)
+    state_arg = next(argument for argument in args if argument.startswith("--state-dir="))
+    build_root = Path(state_arg.removeprefix("--state-dir=")).parent
+    assert build_root.name.startswith("vrhotspot-flatpak-companion.")
+    assert not build_root.exists()
+
+
+def test_flatpak_builder_success_is_reported_as_user_scoped(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    make_executable(fake_bin / "flatpak")
+    make_executable(fake_bin / "flatpak-builder")
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        TEMP_INSTALL_DIR={shlex.quote(str(ROOT))}
+        resolve_flatpak_companion_user() {{
+            FLATPAK_COMPANION_USER=test-desktop-user
+            FLATPAK_COMPANION_UID="$(id -u)"
+            FLATPAK_COMPANION_GID="$(id -g)"
+        }}
+        check_flatpak_companion_prerequisites
+        build_and_install_flatpak_companion
+        """,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "io.github.josethevrtech.VRhotspot) installed for test-desktop-user"
+        in result.stdout
+    )
+
+
+def test_installer_companion_boundary_does_not_read_or_forward_daemon_tokens():
+    installer = INSTALLER.read_text(encoding="utf-8")
+    start = installer.index("# --- Optional Flatpak Companion ---")
+    end = installer.index("\n_fix_apt_code_repo_signedby_conflict()", start)
+    companion = installer[start:end]
+
+    assert "${VR_HOTSPOTD_API_TOKEN" not in companion
+    assert "$VR_HOTSPOTD_API_TOKEN" not in companion
+    assert "${API_TOKEN" not in companion
+    assert "$API_TOKEN" not in companion
+    assert "/etc/" not in companion
+    assert "/var/lib/" not in companion
+    assert "keyring" not in companion.lower()
+    assert "portal" not in companion.lower()
+    assert "--token" not in companion
+    assert "--live-pairing-smoke-json" not in companion
+    assert companion.count(
+        "env -u VR_HOTSPOTD_API_TOKEN -u API_TOKEN"
+    ) == 2
+
+
+def test_no_installer_token_cli_argument_and_companion_flag_is_documented():
+    result = subprocess.run(
+        ["/bin/bash", str(INSTALLER), "--help"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--install-flatpak-companion" in result.stdout
+    assert "--token" not in result.stdout
+    assert "--api-token" not in result.stdout
+
+
+def test_flatpak_manifest_permissions_remain_minimal_and_unchanged():
+    manifest = json.loads(FLATPAK_MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["finish-args"] == [
+        "--share=network",
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+    ]
+    assert not any(
+        argument.startswith("--filesystem=")
+        or "system-bus" in argument
+        or "talk-name" in argument
+        or argument.startswith("--device=")
+        for argument in manifest["finish-args"]
+    )
+
+
+def test_daemon_uninstallers_do_not_remove_user_flatpaks_or_remotes():
+    for path in (TOP_UNINSTALLER, BACKEND_UNINSTALLER):
+        uninstaller = path.read_text(encoding="utf-8")
+        assert "flatpak uninstall" not in uninstaller
+        assert "flatpak remote" not in uninstaller
+        assert "io.github.josethevrtech.VRhotspot" not in uninstaller


### PR DESCRIPTION
# Summary
- Add optional guided installer prompt: `Install the Flatpak companion app? (y/N)`.
- Default guided behavior is No.
- Noninteractive installs do not install the companion unless explicitly opted in with `--install-flatpak-companion`.
- Build/install the existing Flatpak companion only when explicitly selected.

# Boundaries
- No daemon API token is read, copied, passed, persisted, discovered, or injected into Flatpak.
- No token persistence or keyring storage.
- No lifecycle/config/start/stop/restart controls.
- No Flatpak permission expansion.
- No daemon/runtime/WebUI/vendor/CI behavior changes.
- Uninstallers do not remove unrelated Flatpaks or remotes.

# Validation
- Focused installer tests: 13 passed.
- Combined Flatpak boundary tests: 100 passed.
- Full suite: 744 passed, 4 subtests passed.
- Vendor manifest/SBOM/SHA validation passed.
- Installer syntax and install matrix passed.
- Real user-Flatpak build/install and offline smoke passed.
- Noninteractive live smoke safely refused input with `interactive_input_required`.
- Real daemon/token pairing not run for this PR.

# Review
- Final review verdict: approve; no blockers.
- Review file: `/tmp/vrhotspot-installer-flatpak-companion-prompt-final-review.md`
- Review SHA-256: `1e9211acb5bb0788016cdb0bf6a056ff40bfd7e2f1aa375480b5b4b830b41c5a`
