### PR TITLE
Add Flatpak native dashboard foundation

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,18 +1,19 @@
 # Flatpak control app architecture plan
 
-Status: PR #84 optional installer companion prompt; PRs #77-#83 retained
+Status: PR #85 native dashboard foundation; PRs #77-#84 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #84 adds an optional, best-effort installer prompt for PR #81's
-rough installable and testable Flatpak shell. PR #83's explicit terminal-only
-live daemon pairing smoke path and PR #82's in-memory first-run token entry flow
-remain unchanged. The shell uses PR #78's read-only local API client, PR #79's
-pairing state, and PR #80's toolkit-agnostic UI model/controller foundation. It
-is not a finished production UI. PR #84 changes only the top-level guided
-installer path; it adds no daemon API/runtime behavior, privileged Flatpak
-action, token persistence, or credential-storage behavior.
+application. PR #85 converts PR #81's installable GTK shell into a native
+read-only dashboard foundation while retaining PR #82's in-memory first-run
+token entry, PR #83's explicit terminal-only live daemon pairing smoke path,
+and PR #84's optional installer prompt. The dashboard uses PR #78's read-only
+local API client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
+model/controller foundation. It mirrors selected Web UI information only at a
+safe read-only level and is not a finished production UI. PR #85 adds no daemon
+API/runtime behavior, privileged Flatpak action, permission expansion, token
+persistence, or credential-storage behavior.
 
 ## Architectural decision
 
@@ -470,6 +471,48 @@ Token persistence/keyring storage, lifecycle/configuration controls,
 support-bundle portal export, Flathub production polish, Steam Frame, VR Direct
 Link, and adapter-registry work remain separately reviewed future work.
 
+## PR #85 native dashboard foundation
+
+PR #85 replaces the GTK window's linear placeholder presentation with a native
+GTK 4 read-only dashboard. The existing hidden token entry remains the only
+graphical credential source. After the daemon accepts the caller-entered token,
+the app renders the already-sanitized `DiagnosticsControlUiModel` as a clear
+two-column card layout containing:
+
+- daemon status;
+- pairing status;
+- adapter readiness, including the daemon-recommended interface, bounded card
+  list, readiness labels, severities, summaries, supported bands, and reported
+  reasons;
+- canonical preflight readiness, severity, summary, facts, issues, and
+  noninteractive display-only guidance;
+- the visible but disabled support-bundle placeholder; and
+- a visible controls boundary with an empty mutation-action list.
+
+The same dashboard surface safely renders unpaired, rejected, unreachable, and
+malformed-response states without copying raw response bodies or exception
+text. It mirrors information available in the Web UI only at a safe read-only
+level; it does not copy Web UI implementation code or attempt full visual
+parity. Responsive refinement, accessibility review, theme polish, and full
+visual parity remain future work.
+
+PR #85 adds no refresh action. The dashboard is populated by the existing
+validation/model-build call, so the temporary token-bearing client is still
+discarded after that call. Any future refresh behavior must be separately
+reviewed and must use only the authenticated read-only
+`TokenPairingController` / `LocalApiClient` /
+`DiagnosticsControlUiController` path without token persistence or direct
+networking.
+
+The support-bundle button remains insensitive and performs no daemon request,
+download, filesystem write, chooser, or portal operation. The controls card
+contains no buttons and no callable lifecycle or configuration action. Token
+persistence and keyring storage, lifecycle/configuration controls,
+support-bundle portal export, and full visual polish all remain future work.
+The `--smoke-json` and `--live-pairing-smoke-json` command contracts remain
+unchanged, GTK loading remains lazy, and the Flatpak manifest permissions are
+not expanded.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -559,7 +602,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #81 | Flatpak packaging/app shell prototype. Add the first rough installable/testable Flatpak shell, JSON manifest, lazy GTK 4 placeholder window, standard-library smoke mode, and static desktop metadata. Add no production control UI, credential entry, portal export, lifecycle/configuration action, daemon or installer behavior, or privileged host integration. | Offline tests prove import without GTK, bounded safe smoke JSON, metadata/ID consistency, minimal manifest permissions and package scope, safe launcher behavior, and the absence of mutation controls. |
 | PR #82 | First-run/token entry UI prototype. Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
 | PR #83 | Live daemon pairing smoke path. Add an explicit terminal-only installed-Flatpak command with strict hidden manual token entry and bounded sanitized JSON assembled through the existing pairing, local-client, and diagnostics UI boundaries. Add no token argument or discovery/storage path, mutation control, daemon/installer behavior, or permission. | Offline tests cover TTY and hidden-input refusal, success, token rejection, daemon unreachability, missing daemon token, malformed data, output bounds and redaction, unchanged offline/GUI behavior, and the absence of discovery or mutation controls. A real-daemon run of the documented command is required before live pairing is claimed. |
-| PR #84 | Optional installer companion prompt (current phase). Add a default-No guided choice and an explicit `--install-flatpak-companion` unattended opt-in for a best-effort user-scoped local build/install. Add no remote configuration, token transfer/storage, smoke execution, daemon/runtime behavior, uninstaller mutation, or permission change. | Deterministic installer tests cover guided No/Yes, unattended default/opt-in, missing tools, bounded build failure, cleanup, credential-environment scrubbing, unchanged manifest permissions, and non-destructive uninstall boundaries. Existing Flatpak tests and real packaging validation remain required. |
+| PR #84 | Optional installer companion prompt. Add a default-No guided choice and an explicit `--install-flatpak-companion` unattended opt-in for a best-effort user-scoped local build/install. Add no remote configuration, token transfer/storage, smoke execution, daemon/runtime behavior, uninstaller mutation, or permission change. | Deterministic installer tests cover guided No/Yes, unattended default/opt-in, missing tools, bounded build failure, cleanup, credential-environment scrubbing, unchanged manifest permissions, and non-destructive uninstall boundaries. Existing Flatpak tests and real packaging validation remain required. |
+| PR #85 | Native dashboard foundation (current phase). Replace the linear GTK placeholder presentation with a two-column read-only dashboard that renders the existing safe daemon, pairing, adapter-readiness, preflight, disabled support-bundle, and empty controls models after pairing. Add no refresh, token retention/storage, mutation control, portal behavior, direct networking, or permission. | Deterministic tests prove all six cards render, token input clears before validation, adapter and preflight detail remains bounded and sanitized, rejected/unreachable/malformed states remain safe, support export stays disabled, mutation actions stay empty, GTK remains optional, both smoke commands remain compatible, and the manifest permissions remain unchanged. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -583,7 +627,7 @@ a production Flatpak release:
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #84's prototype choices are not blanket approval for production packaging
+PR #85's dashboard choices are not blanket approval for production packaging
 or additional permissions.
 
 ## Future test and validation expectations
@@ -640,10 +684,11 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #84
+## Explicit non-goals for PR #85
 
-- No finished production UI or existing Web UI change. The GTK window is a
-  rough first-run and display-only prototype, not a production control surface.
+- No finished production UI, full visual parity, or existing Web UI change.
+  The GTK window is a native read-only dashboard foundation, not a production
+  control surface.
 - No Flathub submission, release artifact, production metadata polish,
   screenshots, signing, or distribution automation.
 - No start, stop, restart, repair, configuration, passphrase, adapter-selection,
@@ -657,9 +702,9 @@ reporting. Flatpak work must not weaken or bypass those controls.
   for the current in-memory call.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
-- No backend installer, uninstaller, systemd-unit, platform matrix, or CI-script
-  behavior change. PR #84 changes only the top-level optional installer path and
-  adds deterministic tests for it.
+- No top-level or backend installer, uninstaller, systemd-unit, platform matrix,
+  or CI-script behavior change. PR #84's optional companion prompt remains
+  unchanged.
 - No privileged networking in the Flatpak.
 - No direct Flatpak control of firewall rules, NetworkManager, iwd, hostapd,
   dnsmasq, systemd units, kernel or network namespaces, interfaces, routes,
@@ -674,12 +719,13 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #84 authorizes only the default-No guided choice, the explicit unattended
-opt-in, the best-effort user-scoped local build/install helper, its deterministic
-tests, and documentation updates. PR #83's live-pairing validation remains the
-recorded manual result; the installer does not repeat it. PR #84 does not claim
-token persistence, keyring integration, lifecycle/configuration controls,
-support-bundle portal export, a Flathub-polished release, Steam Frame support,
-VR Direct Link support, or a known-adapter registry. Production UI work,
-persistence, portal export, Flathub polish, Steam Frame, VR Direct Link, adapter
-registry work, and all later phases remain separately approved work.
+PR #85 authorizes only the native read-only dashboard layout, its deterministic
+GTK-independent behavior tests, and documentation updates. PR #83's recorded
+manual live-pairing validation remains historical evidence; PR #85 does not run
+or claim a new real-daemon pairing result. PR #85 does not claim token
+persistence, keyring integration, lifecycle/configuration controls,
+support-bundle portal export, full Web UI visual parity, a Flathub-polished
+release, Steam Frame support, VR Direct Link support, or a known-adapter
+registry. Production UI polish, persistence, portal export, Flathub polish,
+Steam Frame, VR Direct Link, adapter registry work, and all later phases remain
+separately approved work.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -1,11 +1,14 @@
-"""Minimal unprivileged application shell for the VRhotspot Flatpak."""
+"""Minimal unprivileged native dashboard for the VRhotspot Flatpak."""
 
 from .app import (
     APP_ID,
     APP_NAME,
+    DashboardControlsBoundary,
     FirstRunTokenEntryController,
     MAX_LIVE_SMOKE_JSON_BYTES,
     MAX_SMOKE_JSON_BYTES,
+    NativeDashboardModel,
+    build_dashboard_model,
     build_initial_model,
     build_smoke_payload,
     main,
@@ -16,9 +19,12 @@ from .app import (
 __all__ = [
     "APP_ID",
     "APP_NAME",
+    "DashboardControlsBoundary",
     "FirstRunTokenEntryController",
     "MAX_LIVE_SMOKE_JSON_BYTES",
     "MAX_SMOKE_JSON_BYTES",
+    "NativeDashboardModel",
+    "build_dashboard_model",
     "build_initial_model",
     "build_smoke_payload",
     "main",

--- a/flatpak_app/__main__.py
+++ b/flatpak_app/__main__.py
@@ -1,4 +1,4 @@
-"""Module entry point for the VRhotspot Flatpak shell."""
+"""Module entry point for the VRhotspot Flatpak native dashboard."""
 
 from .app import main
 

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -1,9 +1,9 @@
-"""Launchable, read-only Flatpak application shell prototype."""
+"""Launchable, read-only Flatpak native dashboard foundation."""
 
 from __future__ import annotations
 
 import argparse
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 import getpass
 import json
 import sys
@@ -11,13 +11,18 @@ from typing import Any, Sequence
 import warnings
 
 from flatpak_client import (
+    AdapterReadinessModel,
+    DaemonStatusModel,
     DiagnosticsControlUiController,
     DiagnosticsControlUiModel,
     FirstRunResult,
     FirstRunState,
     LocalApiClient,
+    PairingStatusModel,
+    PreflightSummaryModel,
     PresentationMode,
     StatusSeverity,
+    SupportBundleAffordance,
     TokenPairingController,
 )
 
@@ -38,6 +43,31 @@ _LIVE_SMOKE_INPUT_EXIT = 2
 
 class GuiUnavailableError(RuntimeError):
     """GTK 4 or PyGObject is unavailable for the graphical shell."""
+
+
+@dataclass(frozen=True)
+class DashboardControlsBoundary:
+    """Visible proof that this dashboard has no mutation surface."""
+
+    visible: bool
+    severity: StatusSeverity
+    title: str
+    readiness_label: str
+    summary: str
+    mutation_actions: tuple[str, ...] = ()
+    action_enabled: bool = False
+
+
+@dataclass(frozen=True)
+class NativeDashboardModel:
+    """Safe sections consumed by the native GTK dashboard."""
+
+    daemon: DaemonStatusModel
+    pairing: PairingStatusModel
+    adapter_readiness: AdapterReadinessModel
+    preflight: PreflightSummaryModel
+    support_bundle: SupportBundleAffordance
+    controls: DashboardControlsBoundary
 
 
 class FirstRunTokenEntryController:
@@ -89,6 +119,32 @@ def build_initial_model() -> DiagnosticsControlUiModel:
     return DiagnosticsControlUiController().build(
         pairing_result=FirstRunResult(FirstRunState.INVALID_RESPONSE),
         mode=PresentationMode.BASIC,
+    )
+
+
+def build_dashboard_model(
+    model: DiagnosticsControlUiModel,
+) -> NativeDashboardModel:
+    """Project the existing safe UI model into the native dashboard sections."""
+
+    if not isinstance(model, DiagnosticsControlUiModel):
+        model = build_initial_model()
+    return NativeDashboardModel(
+        daemon=model.daemon,
+        pairing=model.pairing,
+        adapter_readiness=model.adapters,
+        preflight=model.preflight,
+        support_bundle=model.support_bundle,
+        controls=DashboardControlsBoundary(
+            visible=True,
+            severity=StatusSeverity.UNKNOWN,
+            title="Controls boundary",
+            readiness_label="Unavailable",
+            summary=(
+                "This foundation is read-only. Lifecycle and configuration "
+                "actions are not available."
+            ),
+        ),
     )
 
 
@@ -314,37 +370,120 @@ def _clear_box(container) -> None:
         child = next_child
 
 
-def _add_section_heading(Gtk, container, text: str) -> None:
-    _add_text_label(Gtk, container, text, css_class="heading")
+def _severity_text(severity: StatusSeverity) -> str:
+    if not isinstance(severity, StatusSeverity):
+        severity = StatusSeverity.UNKNOWN
+    return severity.value.replace("_", " ").upper()
 
 
-def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> None:
-    """Render only bounded, token-free fields from the existing UI model."""
+def _severity_css_class(severity: StatusSeverity) -> str:
+    return {
+        StatusSeverity.OK: "success",
+        StatusSeverity.WARNING: "warning",
+        StatusSeverity.BLOCKED: "error",
+        StatusSeverity.ERROR: "error",
+        StatusSeverity.UNKNOWN: "dim-label",
+    }.get(severity, "dim-label")
 
-    _clear_box(container)
 
-    _add_section_heading(Gtk, container, "Daemon status")
-    _add_text_label(Gtk, container, model.daemon.title, css_class="title-4")
-    _add_text_label(Gtk, container, model.daemon.message)
+def _new_card(Gtk, *, title: str, severity: StatusSeverity):
+    frame = Gtk.Frame()
+    frame.add_css_class("card")
+    frame.set_hexpand(True)
 
-    _add_section_heading(Gtk, container, "Pairing status")
-    _add_text_label(Gtk, container, model.pairing.title, css_class="title-4")
-    _add_text_label(Gtk, container, model.pairing.message)
+    body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+    body.set_margin_top(16)
+    body.set_margin_bottom(16)
+    body.set_margin_start(16)
+    body.set_margin_end(16)
 
-    _add_section_heading(Gtk, container, "Adapter readiness")
-    _add_text_label(Gtk, container, model.adapters.title, css_class="title-4")
-    _add_text_label(Gtk, container, model.adapters.summary)
-    if model.adapters.cards:
-        for card in model.adapters.cards:
-            bands = ", ".join(card.supported_bands) or "Bands not reported"
-            recommendation = " · Recommended" if card.recommended else ""
-            _add_text_label(
-                Gtk,
-                container,
-                f"{card.interface}: {card.readiness_label}{recommendation}",
-                css_class="heading",
-            )
-            _add_text_label(Gtk, container, f"{bands} · {card.summary}")
+    heading = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+    title_label = _add_text_label(
+        Gtk,
+        heading,
+        title,
+        css_class="title-3",
+    )
+    title_label.set_hexpand(True)
+    status_label = _add_text_label(
+        Gtk,
+        heading,
+        _severity_text(severity),
+        css_class=_severity_css_class(severity),
+    )
+    status_label.set_xalign(1.0)
+    body.append(heading)
+    frame.set_child(body)
+    return frame, body
+
+
+def _add_adapter_card(Gtk, container, card) -> None:
+    frame = Gtk.Frame()
+    frame.add_css_class("card")
+    frame.set_hexpand(True)
+    body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+    body.set_margin_top(12)
+    body.set_margin_bottom(12)
+    body.set_margin_start(12)
+    body.set_margin_end(12)
+
+    recommendation = " · Recommended" if card.recommended else ""
+    _add_text_label(
+        Gtk,
+        body,
+        f"{card.interface}{recommendation}",
+        css_class="title-4",
+    )
+    _add_text_label(
+        Gtk,
+        body,
+        f"Readiness: {card.readiness_label}",
+        css_class=_severity_css_class(card.severity),
+    )
+    _add_text_label(Gtk, body, f"Severity: {_severity_text(card.severity)}")
+    _add_text_label(Gtk, body, card.summary)
+    bands = ", ".join(card.supported_bands) or "Not reported"
+    _add_text_label(Gtk, body, f"Supported bands: {bands}")
+    _add_text_label(Gtk, body, f"Driver: {card.driver} · Bus: {card.bus_type}")
+    if card.reasons:
+        _add_text_label(Gtk, body, "Reasons", css_class="heading")
+        for reason in card.reasons:
+            _add_text_label(Gtk, body, f"• {reason}")
+    else:
+        _add_text_label(
+            Gtk,
+            body,
+            "No readiness reasons were reported.",
+            css_class="dim-label",
+        )
+
+    frame.set_child(body)
+    container.append(frame)
+
+
+def _populate_daemon_card(Gtk, container, dashboard: NativeDashboardModel) -> None:
+    _add_text_label(Gtk, container, dashboard.daemon.title, css_class="title-4")
+    _add_text_label(Gtk, container, dashboard.daemon.message)
+
+
+def _populate_pairing_card(Gtk, container, dashboard: NativeDashboardModel) -> None:
+    _add_text_label(Gtk, container, dashboard.pairing.title, css_class="title-4")
+    _add_text_label(Gtk, container, dashboard.pairing.message)
+
+
+def _populate_adapter_card(Gtk, container, dashboard: NativeDashboardModel) -> None:
+    adapters = dashboard.adapter_readiness
+    _add_text_label(Gtk, container, adapters.title, css_class="title-4")
+    _add_text_label(Gtk, container, adapters.summary)
+    _add_text_label(
+        Gtk,
+        container,
+        f"Recommended interface: {adapters.recommended_interface}",
+        css_class="heading",
+    )
+    if adapters.cards:
+        for card in adapters.cards:
+            _add_adapter_card(Gtk, container, card)
     else:
         _add_text_label(
             Gtk,
@@ -353,48 +492,210 @@ def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> N
             css_class="dim-label",
         )
 
-    _add_section_heading(Gtk, container, "Preflight")
+
+def _populate_preflight_card(
+    Gtk,
+    container,
+    dashboard: NativeDashboardModel,
+) -> None:
+    preflight = dashboard.preflight
     _add_text_label(
         Gtk,
         container,
-        f"{model.preflight.readiness_label}: {model.preflight.summary}",
+        f"Readiness: {preflight.readiness_label}",
         css_class="title-4",
     )
-    for fact in model.preflight.facts:
-        _add_text_label(Gtk, container, f"{fact.label}: {fact.value}")
-    for issue in model.preflight.issues:
+    _add_text_label(Gtk, container, f"Severity: {_severity_text(preflight.severity)}")
+    _add_text_label(Gtk, container, preflight.summary)
+
+    _add_text_label(Gtk, container, "Facts", css_class="heading")
+    if preflight.facts:
+        for fact in preflight.facts:
+            _add_text_label(Gtk, container, f"{fact.label}: {fact.value}")
+    else:
         _add_text_label(
             Gtk,
             container,
-            f"Issue ({issue.severity.value}): {issue.message}",
-        )
-    for action in model.preflight.actions:
-        _add_text_label(
-            Gtk,
-            container,
-            f"Guidance (display only): {action.message}",
-        )
-    if not (
-        model.preflight.facts
-        or model.preflight.issues
-        or model.preflight.actions
-    ):
-        _add_text_label(
-            Gtk,
-            container,
-            "No preflight details are available.",
+            "No preflight facts are available.",
             css_class="dim-label",
         )
 
-    _add_section_heading(Gtk, container, model.support_bundle.title)
-    _add_text_label(Gtk, container, model.support_bundle.summary)
-    export_button = Gtk.Button(label=model.support_bundle.action_label)
-    export_button.set_sensitive(model.support_bundle.action_enabled)
+    _add_text_label(Gtk, container, "Issues", css_class="heading")
+    if preflight.issues:
+        for issue in preflight.issues:
+            _add_text_label(
+                Gtk,
+                container,
+                f"{_severity_text(issue.severity)} · {issue.message}",
+            )
+    else:
+        _add_text_label(
+            Gtk,
+            container,
+            "No preflight issues were reported.",
+            css_class="dim-label",
+        )
+
+    _add_text_label(
+        Gtk,
+        container,
+        "Noninteractive actions",
+        css_class="heading",
+    )
+    if preflight.actions:
+        for action in preflight.actions:
+            _add_text_label(
+                Gtk,
+                container,
+                f"Display-only guidance · {action.message}",
+            )
+    else:
+        _add_text_label(
+            Gtk,
+            container,
+            "No noninteractive actions were reported.",
+            css_class="dim-label",
+        )
+
+
+
+def _populate_support_bundle_card(
+    Gtk,
+    container,
+    dashboard: NativeDashboardModel,
+) -> None:
+    support_bundle = dashboard.support_bundle
+    _add_text_label(Gtk, container, support_bundle.summary)
+    export_button = Gtk.Button(label=support_bundle.action_label)
+    export_button.set_sensitive(False)
     container.append(export_button)
+    _add_text_label(
+        Gtk,
+        container,
+        "Export remains disabled in this foundation.",
+        css_class="dim-label",
+    )
+
+
+def _populate_controls_card(
+    Gtk,
+    container,
+    dashboard: NativeDashboardModel,
+) -> None:
+    controls = dashboard.controls
+    _add_text_label(
+        Gtk,
+        container,
+        controls.readiness_label,
+        css_class="title-4",
+    )
+    _add_text_label(Gtk, container, controls.summary)
+    _add_text_label(
+        Gtk,
+        container,
+        "Mutation actions: none",
+        css_class="dim-label",
+    )
+
+
+def _render_dashboard_model(
+    Gtk,
+    container,
+    dashboard: NativeDashboardModel,
+) -> None:
+    """Render the bounded native dashboard with no interactive host actions."""
+
+    _clear_box(container)
+    _add_text_label(Gtk, container, "Read-only dashboard", css_class="title-2")
+    _add_text_label(
+        Gtk,
+        container,
+        "Daemon-owned readiness and diagnostics, presented without host mutation.",
+        css_class="dim-label",
+    )
+
+    grid = Gtk.Grid(column_spacing=16, row_spacing=16)
+    grid.set_column_homogeneous(True)
+
+    daemon_frame, daemon_body = _new_card(
+        Gtk,
+        title="Daemon status",
+        severity=dashboard.daemon.severity,
+    )
+    _populate_daemon_card(Gtk, daemon_body, dashboard)
+    grid.attach(daemon_frame, 0, 0, 1, 1)
+
+    pairing_frame, pairing_body = _new_card(
+        Gtk,
+        title="Pairing status",
+        severity=dashboard.pairing.severity,
+    )
+    _populate_pairing_card(Gtk, pairing_body, dashboard)
+    grid.attach(pairing_frame, 1, 0, 1, 1)
+
+    adapters_frame, adapters_body = _new_card(
+        Gtk,
+        title="Adapter readiness",
+        severity=dashboard.adapter_readiness.severity,
+    )
+    _populate_adapter_card(Gtk, adapters_body, dashboard)
+    grid.attach(adapters_frame, 0, 1, 1, 1)
+
+    preflight_frame, preflight_body = _new_card(
+        Gtk,
+        title="Preflight diagnostics",
+        severity=dashboard.preflight.severity,
+    )
+    _populate_preflight_card(Gtk, preflight_body, dashboard)
+    grid.attach(preflight_frame, 1, 1, 1, 1)
+
+    support_frame, support_body = _new_card(
+        Gtk,
+        title=dashboard.support_bundle.title,
+        severity=dashboard.support_bundle.severity,
+    )
+    _populate_support_bundle_card(Gtk, support_body, dashboard)
+    grid.attach(support_frame, 0, 2, 1, 1)
+
+    controls_frame, controls_body = _new_card(
+        Gtk,
+        title=dashboard.controls.title,
+        severity=dashboard.controls.severity,
+    )
+    _populate_controls_card(Gtk, controls_body, dashboard)
+    grid.attach(controls_frame, 1, 2, 1, 1)
+
+    container.append(grid)
+
+
+def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> None:
+    """Render only bounded, token-free fields from the existing UI model."""
+
+    _render_dashboard_model(Gtk, container, build_dashboard_model(model))
+
+
+def _connect_from_token_entry(
+    *,
+    token_entry,
+    connect_button,
+    controller: FirstRunTokenEntryController,
+    render_model,
+) -> None:
+    """Clear caller input before validating and render only the safe result."""
+
+    token = token_entry.get_text()
+    token_entry.set_text("")
+    connect_button.set_sensitive(False)
+    try:
+        updated_model = controller.connect(token=token)
+        render_model(updated_model)
+    finally:
+        token = ""
+        connect_button.set_sensitive(True)
 
 
 def run_gui() -> int:
-    """Run the first-run GTK prototype against the read-only local API client."""
+    """Run the native read-only dashboard against the local API client."""
 
     Gtk = _load_gtk()
     model = build_initial_model()
@@ -404,7 +705,7 @@ def run_gui() -> int:
     def on_activate(app) -> None:
         window = Gtk.ApplicationWindow(application=app)
         window.set_title(APP_NAME)
-        window.set_default_size(680, 760)
+        window.set_default_size(960, 800)
 
         scroller = Gtk.ScrolledWindow()
         scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -419,7 +720,7 @@ def run_gui() -> int:
         _add_text_label(
             Gtk,
             content,
-            "First-run connection prototype",
+            "Native read-only companion",
             css_class="title-3",
         )
         _add_text_label(
@@ -429,42 +730,41 @@ def run_gui() -> int:
             "The token is used in memory for this validation only and is not saved.",
         )
 
+        connection_row = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=8,
+        )
         token_entry = Gtk.PasswordEntry()
         token_entry.set_placeholder_text("API token")
         token_entry.set_show_peek_icon(True)
-        content.append(token_entry)
+        token_entry.set_hexpand(True)
+        connection_row.append(token_entry)
 
         connect_button = Gtk.Button(label="Connect / Validate token")
-        content.append(connect_button)
+        connection_row.append(connect_button)
+        content.append(connection_row)
 
         display_sections = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
-            spacing=8,
+            spacing=16,
         )
         content.append(display_sections)
         _render_display_model(Gtk, display_sections, model)
 
         def on_connect(_widget) -> None:
-            token = token_entry.get_text()
-            token_entry.set_text("")
-            connect_button.set_sensitive(False)
-            try:
-                updated_model = token_entry_controller.connect(token=token)
-                _render_display_model(Gtk, display_sections, updated_model)
-            finally:
-                token = ""
-                connect_button.set_sensitive(True)
+            _connect_from_token_entry(
+                token_entry=token_entry,
+                connect_button=connect_button,
+                controller=token_entry_controller,
+                render_model=lambda updated_model: _render_display_model(
+                    Gtk,
+                    display_sections,
+                    updated_model,
+                ),
+            )
 
         connect_button.connect("clicked", on_connect)
         token_entry.connect("activate", on_connect)
-
-        _add_text_label(
-            Gtk,
-            content,
-            "Support-bundle export remains disabled. No lifecycle or "
-            "configuration controls are available.",
-            css_class="dim-label",
-        )
 
         scroller.set_child(content)
         window.set_child(scroller)
@@ -496,7 +796,7 @@ def _argument_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the deterministic smoke path or launch the GTK placeholder."""
+    """Run a deterministic smoke path or launch the GTK dashboard."""
 
     args = _argument_parser().parse_args(argv)
     if args.smoke_json:
@@ -509,7 +809,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return run_gui()
     except GuiUnavailableError:
         print(
-            "The graphical prototype requires GTK 4 and PyGObject. "
+            "The native dashboard requires GTK 4 and PyGObject. "
             "Use --smoke-json for the offline shell check.",
             file=sys.stderr,
         )

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -49,6 +49,10 @@ def _readiness_response():
                     "bus_type": "usb",
                     "supports_5ghz": True,
                     "readiness_state": "ready",
+                    "reason_codes": [
+                        "supports_ap_mode",
+                        "daemon_recommended",
+                    ],
                     "explanation": "Ready for display-only diagnostics.",
                 }
             ],
@@ -128,6 +132,99 @@ class FakeInputStream:
 
     def isatty(self):
         return self.interactive
+
+
+class FakeGtkWidget:
+    def __init__(self, **_properties):
+        self.children = []
+        self.parent = None
+        self.css_classes = []
+        self.sensitive = True
+
+    def append(self, child):
+        child.parent = self
+        self.children.append(child)
+
+    def set_child(self, child):
+        self.children = []
+        self.append(child)
+
+    def attach(self, child, *_position):
+        self.append(child)
+
+    def get_first_child(self):
+        return self.children[0] if self.children else None
+
+    def get_next_sibling(self):
+        if self.parent is None:
+            return None
+        siblings = self.parent.children
+        index = siblings.index(self)
+        return siblings[index + 1] if index + 1 < len(siblings) else None
+
+    def remove(self, child):
+        self.children.remove(child)
+        child.parent = None
+
+    def add_css_class(self, css_class):
+        self.css_classes.append(css_class)
+
+    def set_sensitive(self, sensitive):
+        self.sensitive = sensitive
+
+    def set_wrap(self, _wrap):
+        pass
+
+    def set_xalign(self, _alignment):
+        pass
+
+    def set_hexpand(self, _expand):
+        pass
+
+    def set_column_homogeneous(self, _homogeneous):
+        pass
+
+    def set_margin_top(self, _margin):
+        pass
+
+    def set_margin_bottom(self, _margin):
+        pass
+
+    def set_margin_start(self, _margin):
+        pass
+
+    def set_margin_end(self, _margin):
+        pass
+
+
+class FakeGtkLabel(FakeGtkWidget):
+    def __init__(self, *, label):
+        super().__init__()
+        self.label = label
+
+
+class FakeGtkButton(FakeGtkWidget):
+    def __init__(self, *, label):
+        super().__init__()
+        self.label = label
+
+
+class FakeGtk:
+    class Orientation:
+        VERTICAL = "vertical"
+        HORIZONTAL = "horizontal"
+
+    Box = FakeGtkWidget
+    Frame = FakeGtkWidget
+    Grid = FakeGtkWidget
+    Label = FakeGtkLabel
+    Button = FakeGtkButton
+
+
+def _walk_fake_widgets(widget):
+    yield widget
+    for child in widget.children:
+        yield from _walk_fake_widgets(child)
 
 
 def _manifest():
@@ -578,6 +675,289 @@ def test_successful_token_validation_updates_all_display_only_sections():
     assert model.preflight.actions[0].interactive is False
     assert model.support_bundle.action_enabled is False
     assert model.support_bundle.request_performed is False
+
+
+def test_successful_pairing_builds_and_renders_all_native_dashboard_sections():
+    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
+    from flatpak_app import app
+
+    display_model = FirstRunTokenEntryController(
+        client_factory=ScriptedReadOnlyClientFactory()
+    ).connect(token="accepted-dashboard-value")
+
+    dashboard = build_dashboard_model(display_model)
+    container = FakeGtkWidget()
+    app._render_dashboard_model(FakeGtk, container, dashboard)
+
+    assert set(asdict(dashboard)) == {
+        "daemon",
+        "pairing",
+        "adapter_readiness",
+        "preflight",
+        "support_bundle",
+        "controls",
+    }
+    assert dashboard.adapter_readiness.recommended_interface == "wlan1"
+    assert dashboard.adapter_readiness.cards[0].readiness_label == "Ready"
+    assert dashboard.adapter_readiness.cards[0].severity.value == "ok"
+    assert dashboard.adapter_readiness.cards[0].summary
+    assert dashboard.adapter_readiness.cards[0].reasons == (
+        "Supports Ap Mode",
+        "Daemon Recommended",
+    )
+    assert dashboard.preflight.readiness_label == "Needs attention"
+    assert dashboard.preflight.severity.value == "warning"
+    assert dashboard.preflight.summary
+    assert dashboard.preflight.issues
+    assert dashboard.preflight.facts
+    assert dashboard.preflight.actions
+    assert all(not action.interactive for action in dashboard.preflight.actions)
+    assert dashboard.support_bundle.visible is True
+    assert dashboard.support_bundle.action_enabled is False
+    assert dashboard.controls.visible is True
+    assert dashboard.controls.mutation_actions == ()
+    assert dashboard.controls.action_enabled is False
+
+    widgets = tuple(_walk_fake_widgets(container))
+    rendered_text = {
+        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
+    }
+    buttons = [
+        widget for widget in widgets if isinstance(widget, FakeGtkButton)
+    ]
+    for section_title in (
+        "Daemon status",
+        "Pairing status",
+        "Adapter readiness",
+        "Preflight diagnostics",
+        "Support bundle",
+        "Controls boundary",
+    ):
+        assert section_title in rendered_text
+    assert "Recommended interface: wlan1" in rendered_text
+    assert "Readiness: Ready" in rendered_text
+    assert "Severity: OK" in rendered_text
+    assert "Reasons" in rendered_text
+    assert "Facts" in rendered_text
+    assert "Issues" in rendered_text
+    assert "Noninteractive actions" in rendered_text
+    assert "Mutation actions: none" in rendered_text
+    assert [(button.label, button.sensitive) for button in buttons] == [
+        ("Export support bundle", False)
+    ]
+
+
+def test_token_entry_is_cleared_before_dashboard_validation():
+    from flatpak_app import app
+
+    events = []
+
+    class Entry:
+        def __init__(self):
+            self.text = "clear-before-validation-value"
+
+        def get_text(self):
+            events.append("entry-read")
+            return self.text
+
+        def set_text(self, text):
+            self.text = text
+            events.append("entry-cleared")
+
+    class Button:
+        def __init__(self):
+            self.sensitive = True
+
+        def set_sensitive(self, sensitive):
+            self.sensitive = sensitive
+            events.append(f"button-{sensitive}")
+
+    class Controller:
+        def connect(self, *, token):
+            assert token == "clear-before-validation-value"
+            assert entry.text == ""
+            assert button.sensitive is False
+            events.append("validated")
+            return "safe-dashboard-model"
+
+    entry = Entry()
+    button = Button()
+    rendered = []
+
+    app._connect_from_token_entry(
+        token_entry=entry,
+        connect_button=button,
+        controller=Controller(),
+        render_model=rendered.append,
+    )
+
+    assert events == [
+        "entry-read",
+        "entry-cleared",
+        "button-False",
+        "validated",
+        "button-True",
+    ]
+    assert entry.text == ""
+    assert button.sensitive is True
+    assert rendered == ["safe-dashboard-model"]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_daemon", "expected_pairing"),
+    [
+        (
+            ScriptedReadOnlyClientFactory(
+                readiness_result=AuthenticationError(401)
+            ),
+            "Daemon reachable",
+            "Token rejected",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                health_result=ConnectionFailure("offline")
+            ),
+            "Daemon unavailable",
+            "Pairing unavailable",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                readiness_result={"unexpected": "response"}
+            ),
+            "Daemon status unknown",
+            "Pairing status unknown",
+        ),
+        (
+            ScriptedReadOnlyClientFactory(
+                preflight_result=_api_response(
+                    {
+                        "schema_version": 99,
+                        "overall_readiness": "future",
+                    }
+                )
+            ),
+            "Daemon connected",
+            "Paired",
+        ),
+    ],
+    ids=(
+        "rejected",
+        "unreachable",
+        "invalid-pairing",
+        "malformed-diagnostics",
+    ),
+)
+def test_native_dashboard_uses_safe_states_for_pairing_and_response_failures(
+    factory,
+    expected_daemon,
+    expected_pairing,
+):
+    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
+
+    display_model = FirstRunTokenEntryController(
+        client_factory=factory
+    ).connect(token="safe-failure-state-value")
+    dashboard = build_dashboard_model(display_model)
+
+    assert dashboard.daemon.title == expected_daemon
+    assert dashboard.pairing.title == expected_pairing
+    assert dashboard.support_bundle.action_enabled is False
+    assert dashboard.controls.mutation_actions == ()
+    if expected_pairing != "Paired":
+        assert dashboard.adapter_readiness.cards == ()
+        assert dashboard.preflight.issues == ()
+    else:
+        assert dashboard.preflight.severity.value == "unknown"
+        assert dashboard.preflight.issues == ()
+
+
+def test_native_dashboard_exposes_no_secret_or_host_path_values():
+    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
+    from flatpak_app import app
+
+    entered_value = "entered-dashboard-value-must-not-escape"
+    token_value = "daemon-token-value-must-not-escape"
+    passphrase_value = "passphrase-value-must-not-escape"
+    password_value = "password-value-must-not-escape"
+    psk_value = "psk-value-must-not-escape"
+    bearer_value = "bearer-value-must-not-escape"
+    secret_value = "secret-value-must-not-escape"
+    host_path = "/var/lib/vr-hotspot/private-dashboard-state.json"
+    factory = ScriptedReadOnlyClientFactory(
+        readiness_result=_api_response(
+            {
+                "recommended": "wlan1",
+                "basic_mode_recommended": "wlan1",
+                "summary": {"readiness_state": "ready"},
+                "adapters": [
+                    {
+                        "interface": "wlan1",
+                        "readiness_state": "ready",
+                        "explanation": (
+                            f"token={token_value}; "
+                            f"passphrase={passphrase_value}; "
+                            f"password={password_value}; psk={psk_value}; "
+                            f"secret={secret_value}"
+                        ),
+                    }
+                ],
+            }
+        ),
+        preflight_result=_api_response(
+            {
+                "schema_version": 1,
+                "overall_readiness": "warning",
+                "platform": {},
+                "firewall": {},
+                "services": {},
+                "network": {},
+                "wifi": {},
+                "issues": [
+                    {
+                        "severity": "warning",
+                        "code": "redaction_check",
+                        "message": (
+                            f"Authorization: Bearer {bearer_value}; "
+                            f"inspect {host_path}"
+                        ),
+                    }
+                ],
+                "recommended_actions": [],
+            }
+        ),
+    )
+
+    dashboard = build_dashboard_model(
+        FirstRunTokenEntryController(client_factory=factory).connect(
+            token=entered_value
+        )
+    )
+    container = FakeGtkWidget()
+    app._render_dashboard_model(FakeGtk, container, dashboard)
+    rendered_labels = tuple(
+        widget.label
+        for widget in _walk_fake_widgets(container)
+        if isinstance(widget, (FakeGtkLabel, FakeGtkButton))
+    )
+    exposed = (
+        repr(asdict(dashboard))
+        + repr(dashboard)
+        + repr(rendered_labels)
+    )
+
+    for forbidden_value in (
+        entered_value,
+        token_value,
+        passphrase_value,
+        password_value,
+        psk_value,
+        bearer_value,
+        secret_value,
+        host_path,
+    ):
+        assert forbidden_value not in exposed
+    assert "[redacted]" in exposed
+    assert "[host path]" in exposed
 
 
 def test_rejected_token_is_safe_and_never_enters_output_or_logs(caplog):


### PR DESCRIPTION
# Summary
- Add the first native GTK 4 dashboard foundation for the Flatpak companion app.
- Render read-only daemon, pairing, adapter readiness, preflight, support-bundle, and controls-boundary sections after pairing.
- Keep the existing token-entry flow and CLI smoke commands compatible.

# Dashboard scope
- Native scrollable two-column dashboard.
- Adapter cards include recommendation, readiness, severity, summary, and reasons.
- Preflight section includes readiness, severity, summary, facts, issues, and noninteractive guidance.
- Support-bundle export remains disabled.
- Controls/mutation actions remain empty.

# Boundaries
- No token persistence or keyring storage.
- No token discovery from env/disk/portal/daemon config.
- No lifecycle/config/start/stop/restart controls.
- No read-write daemon operations.
- No Flatpak permission expansion.
- No daemon/runtime/installer/WebUI/vendor/CI behavior changes.
- No Steam Frame, VR Direct Link, adapter registry, or HostFactsSnapshot work.

# Validation
- Focused Flatpak tests: 94 passed.
- Full suite: 751 passed, 4 subtests passed.
- Vendor manifest/SBOM/SHA validation passed.
- Installer syntax and install matrix passed.
- Real Flatpak build/install/smoke passed.
- Installed noninteractive live smoke safely refused input with token-free JSON.
- Real live daemon pairing not run for this PR.

# Review
- Final review verdict: approve; no blockers.
- Review file: `/tmp/vrhotspot-flatpak-native-dashboard-foundation-final-review.md`
- Review SHA-256: `efdc55ea5283436055692784a51984e892bb1e14779ad8ba120b85475ec2178c`
