### PR TITLE
Fix Flatpak password entry placeholder compatibility

### DIFF
--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -674,6 +674,36 @@ def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> N
     _render_dashboard_model(Gtk, container, build_dashboard_model(model))
 
 
+def _set_placeholder_text_compat(widget: Any, value: str) -> None:
+    """Set placeholder text when the active GTK binding supports either API."""
+
+    direct_setter = getattr(widget, "set_placeholder_text", None)
+    if callable(direct_setter):
+        try:
+            direct_setter(value)
+        except (AttributeError, TypeError):
+            pass
+        else:
+            return
+
+    property_setter = getattr(widget, "set_property", None)
+    if not callable(property_setter):
+        return
+
+    property_finder = getattr(widget, "find_property", None)
+    if callable(property_finder):
+        try:
+            if property_finder("placeholder-text") is None:
+                return
+        except (AttributeError, TypeError):
+            return
+
+    try:
+        property_setter("placeholder-text", value)
+    except (AttributeError, TypeError):
+        pass
+
+
 def _connect_from_token_entry(
     *,
     token_entry,
@@ -735,7 +765,7 @@ def run_gui() -> int:
             spacing=8,
         )
         token_entry = Gtk.PasswordEntry()
-        token_entry.set_placeholder_text("API token")
+        _set_placeholder_text_compat(token_entry, "API token")
         token_entry.set_show_peek_icon(True)
         token_entry.set_hexpand(True)
         connection_row.append(token_entry)

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -139,6 +139,7 @@ class FakeGtkWidget:
         self.children = []
         self.parent = None
         self.css_classes = []
+        self.signal_handlers = {}
         self.sensitive = True
 
     def append(self, child):
@@ -172,6 +173,9 @@ class FakeGtkWidget:
     def set_sensitive(self, sensitive):
         self.sensitive = sensitive
 
+    def connect(self, signal, handler):
+        self.signal_handlers[signal] = handler
+
     def set_wrap(self, _wrap):
         pass
 
@@ -196,6 +200,39 @@ class FakeGtkWidget:
     def set_margin_end(self, _margin):
         pass
 
+    def set_show_peek_icon(self, _show):
+        pass
+
+
+class FakeGtkApplication:
+    def __init__(self, *, application_id):
+        self.application_id = application_id
+        self.signal_handlers = {}
+
+    def connect(self, signal, handler):
+        self.signal_handlers[signal] = handler
+
+    def run(self, arguments):
+        assert arguments == []
+        self.signal_handlers["activate"](self)
+        return 0
+
+
+class FakeGtkApplicationWindow(FakeGtkWidget):
+    def set_title(self, _title):
+        pass
+
+    def set_default_size(self, _width, _height):
+        pass
+
+    def present(self):
+        pass
+
+
+class FakeGtkScrolledWindow(FakeGtkWidget):
+    def set_policy(self, _horizontal, _vertical):
+        pass
+
 
 class FakeGtkLabel(FakeGtkWidget):
     def __init__(self, *, label):
@@ -214,11 +251,19 @@ class FakeGtk:
         VERTICAL = "vertical"
         HORIZONTAL = "horizontal"
 
+    class PolicyType:
+        NEVER = "never"
+        AUTOMATIC = "automatic"
+
+    Application = FakeGtkApplication
+    ApplicationWindow = FakeGtkApplicationWindow
+    ScrolledWindow = FakeGtkScrolledWindow
     Box = FakeGtkWidget
     Frame = FakeGtkWidget
     Grid = FakeGtkWidget
     Label = FakeGtkLabel
     Button = FakeGtkButton
+    PasswordEntry = FakeGtkWidget
 
 
 def _walk_fake_widgets(widget):
@@ -251,6 +296,77 @@ def test_app_shell_imports_without_importing_gtk(monkeypatch):
 
     assert module.APP_ID == APP_ID
     assert sys.modules.get("gi") is None
+
+
+def test_gui_activation_does_not_require_password_entry_placeholder_setter(
+    monkeypatch,
+):
+    from flatpak_app import app
+
+    assert not hasattr(FakeGtk.PasswordEntry(), "set_placeholder_text")
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+
+    assert app.run_gui() == 0
+
+
+def test_placeholder_helper_prefers_direct_setter():
+    from flatpak_app import app
+
+    calls = []
+
+    class Entry:
+        def set_placeholder_text(self, value):
+            calls.append(("direct", value))
+
+        def set_property(self, name, value):
+            calls.append((name, value))
+
+    app._set_placeholder_text_compat(Entry(), "API token")
+
+    assert calls == [("direct", "API token")]
+
+
+def test_placeholder_helper_falls_back_to_supported_property_setter():
+    from flatpak_app import app
+
+    calls = []
+
+    class Entry:
+        def find_property(self, name):
+            calls.append(("find", name))
+            return object()
+
+        def set_property(self, name, value):
+            calls.append((name, value))
+
+    app._set_placeholder_text_compat(Entry(), "API token")
+
+    assert calls == [
+        ("find", "placeholder-text"),
+        ("placeholder-text", "API token"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "entry",
+    (
+        object(),
+        type(
+            "UnsupportedPropertyEntry",
+            (),
+            {
+                "find_property": lambda self, _name: None,
+                "set_property": lambda self, _name, _value: pytest.fail(
+                    "unsupported property must not be set"
+                ),
+            },
+        )(),
+    ),
+)
+def test_placeholder_helper_noops_when_placeholder_is_unsupported(entry):
+    from flatpak_app import app
+
+    app._set_placeholder_text_compat(entry, "API token")
 
 
 def test_smoke_json_exits_successfully_is_bounded_and_has_expected_sections():


### PR DESCRIPTION
# Summary
- Fix installed Flatpak GUI crash when GTK PasswordEntry lacks `set_placeholder_text()`.
- Add a compatibility helper that prefers the direct setter, falls back to the `placeholder-text` property, and no-ops safely when unsupported.
- Preserve the native dashboard foundation from #85.

# Runtime bug fixed
- Installed GUI crashed on activation at `token_entry.set_placeholder_text("API token")`.
- Installed-runtime validation confirmed the direct setter is unavailable, property fallback works, and GUI launch stays open.

# Boundaries
- Password entry remains hidden/masked.
- Token clearing before validation remains intact.
- No token logging, persistence, keyring storage, serialization, or discovery.
- No lifecycle/config/start/stop/restart controls.
- No support-bundle export behavior.
- No Flatpak permission expansion.
- No daemon/runtime/installer/WebUI/vendor behavior changes.

# Validation
- Focused shell tests: 42 passed.
- Grouped Flatpak tests: 99 passed.
- Full suite: 756 passed, 4 subtests passed.
- Vendor manifest/SBOM/SHA validation passed.
- Installer syntax and install matrix passed.
- Real Flatpak build/install and both smoke paths passed.
- GUI launch validation: `timeout 10` exited 124 with no traceback, meaning the app stayed open.

# Review
- Final review verdict: approve; no blockers.
- Review file: `/tmp/vrhotspot-flatpak-password-entry-placeholder-hotfix-final-review.md`
- Review SHA-256: `2bf7d10c204c9b29c8861b3b1992f59c4f938579dcbd55e1003110bf3524d383`
