### PR TITLE
Add locked Flatpak Web Portal shell spike

### DIFF
--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,23 +1,23 @@
 # Flatpak control app architecture plan
 
-Status: PR #87 Web Portal parity pass for the native dashboard; PRs #77-#86 retained
+Status: PR #88 locked Web Portal shell spike; PRs #77-#87 retained
 
 Date: 2026-07-23
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #87 refines PR #85's native read-only dashboard using the
-existing Web Portal as a design and product reference while retaining PR #86's
-installed GTK `PasswordEntry` compatibility fix, PR #82's in-memory first-run
-token entry, PR #83's explicit terminal-only live daemon pairing smoke path,
-and PR #84's optional installer prompt. The dashboard uses PR #78's read-only
-local API client, PR #79's pairing state, and PR #80's toolkit-agnostic UI
-model/controller foundation.
+application. PR #88 adds an explicit locked WebKitGTK shell spike that renders
+the daemon-served Web Portal. The Web Portal is now intended to become the
+visual source of truth for the Flatpak instead of being cloned in native GTK.
+PR #85/#87's native dashboard remains available as the default and as the
+fallback during this spike; switching the default is separately reviewed future
+work.
 
-The Web Portal is a terminology, hierarchy, and visual-product reference only.
-The companion remains a native GTK application: it does not embed the Portal,
-use a WebView, or package frontend runtime dependencies. PR #87 adds no daemon
-API/runtime behavior, privileged Flatpak action, permission expansion, token
-persistence, credential-storage behavior, or Web UI behavior change.
+The spike reuses PR #86's installed GTK `PasswordEntry` compatibility fix,
+PR #82's native in-memory first-run token entry, PR #83's explicit terminal-only
+live daemon pairing smoke path, and PR #84's optional installer prompt. It adds
+no daemon API/runtime behavior, privileged Flatpak action, permission expansion,
+token injection or discovery, persistent credential storage, installer change,
+or Web UI behavior change.
 
 ## Architectural decision
 
@@ -572,6 +572,56 @@ start, stop, restart, or repair action. Token persistence/keyring integration,
 lifecycle/configuration controls, support-bundle desktop export, and production
 packaging polish remain separately reviewed future work.
 
+## PR #88 locked Web Portal shell spike
+
+PR #88 adds the explicit `--web-portal-shell` runtime flag. It does not accept a
+URL argument. The flag loads the daemon-served Portal directly from
+`http://127.0.0.1:8732/ui`; the daemon's public `/` route redirects to that same
+page and `/assets/*` serves its existing CSS, JavaScript, images, and bundled
+frontend libraries. No Portal asset is copied into the Flatpak.
+
+GNOME Platform 50 supplies the GTK 4 WebKitGTK binding as the `WebKit` GI
+namespace version `6.0`. The shell imports it lazily and creates a
+`WebKit.NetworkSession.new_ephemeral()` session. Persistent HTTP credential
+storage, cookies, page cache, offline application cache, DNS prefetching,
+back/forward gestures, automatic JavaScript windows, and file-URL access are
+disabled. The portal's own manual token-entry behavior remains inside the
+daemon-served frontend and any Web Storage it uses is confined to the ephemeral
+WebKit session rather than persisted by the Flatpak shell.
+
+The WebView is locked to the exact literal HTTP origin
+`http://127.0.0.1:8732`. Navigation and response policy decisions fail closed
+unless their URI has that exact scheme, host, and port. New-window navigation is
+always denied, and context menus and WebKit permission requests are denied.
+An additive default Content Security Policy permits documents, subresources,
+forms, and API connections only on the pinned daemon origin; external sites and
+remote subresources are not permitted. There is no address bar, arbitrary URL
+option, popup window, or general-browser mode.
+
+The shell does not place an API token in a URL, header, request override,
+JavaScript, WebKit user script, Local Storage, Session Storage, cookie, model,
+exception, representation, or smoke JSON. It does not read a daemon token from
+the environment, daemon configuration, files, keyrings, portals, `/etc`,
+`/var/lib`, or another filesystem location. Token entry, validation, and use
+remain the existing Web Portal's behavior. The native dashboard's separate
+manual-entry path remains unchanged.
+
+If the `WebKit` 6.0 namespace or required ephemeral-session API is unavailable,
+the explicit spike mode launches the retained native GTK dashboard. If WebKit
+construction fails during activation, that window is also populated with the
+native dashboard instead of crashing. If the fixed local Portal load fails, the
+shell displays a bounded token-free local-daemon error with a retry button that
+reloads only the same fixed URL.
+
+The manifest continues to use only its existing network, IPC, Wayland, and
+fallback X11 finish arguments. WebKitGTK is supplied by the selected GNOME 50
+runtime, so PR #88 adds neither a separately downloaded dependency nor a
+permission, filesystem grant, bus grant, device grant, or copied browser/UI
+payload. The Flatpak remains a companion shell; `vr-hotspotd` remains the
+privileged authority and still serves the Portal and owns all API,
+authentication, lifecycle, configuration, networking, and host mutation
+behavior. PR #88 does not switch the default launch mode.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -664,7 +714,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #84 | Optional installer companion prompt. Add a default-No guided choice and an explicit `--install-flatpak-companion` unattended opt-in for a best-effort user-scoped local build/install. Add no remote configuration, token transfer/storage, smoke execution, daemon/runtime behavior, uninstaller mutation, or permission change. | Deterministic installer tests cover guided No/Yes, unattended default/opt-in, missing tools, bounded build failure, cleanup, credential-environment scrubbing, unchanged manifest permissions, and non-destructive uninstall boundaries. Existing Flatpak tests and real packaging validation remain required. |
 | PR #85 | Native dashboard foundation. Replace the linear GTK placeholder presentation with a two-column read-only dashboard that renders the existing safe daemon, pairing, adapter-readiness, preflight, disabled support-bundle, and empty controls models after pairing. Add no refresh, token retention/storage, mutation control, portal behavior, direct networking, or permission. | Deterministic tests prove all six cards render, token input clears before validation, adapter and preflight detail remains bounded and sanitized, rejected/unreachable/malformed states remain safe, support export stays disabled, mutation actions stay empty, GTK remains optional, both smoke commands remain compatible, and the manifest permissions remain unchanged. |
 | PR #86 | Installed GTK PasswordEntry compatibility hotfix. Preserve the hidden password-style field while supporting both the direct placeholder setter and the GTK property API, and safely omit the optional placeholder when neither is available. Add no token, client, model, permission, or control behavior. | Deterministic activation and helper tests cover the installed binding shape, direct setter, supported fallback property, and unsupported-property no-op without weakening token clearing or lazy GTK loading. |
-| PR #87 | Native dashboard Web Portal parity pass (current phase). Use the Portal as a design/product reference to improve the native GTK header, connection/pairing hierarchy, readiness summary, recommended-adapter emphasis, preflight facts/issues/actions, severity badges, and honest unavailable sections. Do not embed the Portal, add a WebView or frontend runtime, retain tokens, add actions/export, change Web UI or daemon behavior, or expand permissions. | Deterministic model/view tests prove parity labels, all five severity badges, paired and recommended emphasis, disabled support export, empty controls, absent lifecycle/configuration buttons, hidden/cleared token entry, placeholder compatibility, lazy GTK, token-free smoke contracts, redaction, and unchanged manifest permissions. |
+| PR #87 | Native dashboard Web Portal parity pass. Use the Portal as a design/product reference to improve the native GTK header, connection/pairing hierarchy, readiness summary, recommended-adapter emphasis, preflight facts/issues/actions, severity badges, and honest unavailable sections. Do not embed the Portal, add a WebView or frontend runtime, retain tokens, add actions/export, change Web UI or daemon behavior, or expand permissions. | Deterministic model/view tests prove parity labels, all five severity badges, paired and recommended emphasis, disabled support export, empty controls, absent lifecycle/configuration buttons, hidden/cleared token entry, placeholder compatibility, lazy GTK, token-free smoke contracts, redaction, and unchanged manifest permissions. |
+| PR #88 | Locked Web Portal shell spike (current phase). Add an explicit WebKitGTK 6.0 mode that loads only the daemon-served `http://127.0.0.1:8732/ui` Portal in an ephemeral, origin-locked WebView. Keep the native dashboard as default and fallback. Add no copied frontend, arbitrary URL, token injection/discovery/persistence, Web UI or daemon behavior, installer behavior, or permission. | Deterministic tests pin the route and exact origin, deny external and new-window navigation, prove ephemeral/no-injection construction and bounded load failure, exercise WebKit-unavailable and construction fallback, preserve both smoke contracts and native token-entry compatibility, and verify unchanged manifest permissions. Real packaging and manual shell validation remain required. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -688,7 +739,7 @@ a production Flatpak release:
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #87's dashboard choices are not blanket approval for production packaging
+PR #88's shell choices are not blanket approval for production packaging
 or additional permissions.
 
 ## Future test and validation expectations
@@ -745,24 +796,26 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #87
+## Explicit non-goals for PR #88
 
-- No finished production UI or existing Web UI change. The Web Portal is a
-  design/product reference only; the GTK window remains a native read-only
-  dashboard, not a WebView or embedded Portal.
-- No copied frontend runtime dependency, browser engine, or Web Portal
-  JavaScript/style asset.
+- No default UI switch or native-dashboard removal. The Web Portal is intended
+  to become the visual source of truth, but the locked WebView remains an
+  explicit spike mode and native GTK remains the default and fallback.
+- No existing Web UI behavior or asset change, copied Web Portal
+  JavaScript/style/image asset, or second frontend implementation.
+- No arbitrary URL argument, address bar, external navigation, popup/new-window
+  navigation, remote-site load, or general browser.
 - No Flathub submission, release artifact, production metadata polish,
   screenshots, signing, or distribution automation.
-- No start, stop, restart, repair, configuration, passphrase, adapter-selection,
-  or other mutation control.
-- No support-bundle download, temporary file handling, file chooser, portal
-  integration, or export implementation. The disabled model affordance is
-  non-interactive and performs no request.
-- No token discovery, persistent storage, keyring/portal integration, token
-  issuance, rotation, or daemon-side pairing endpoint. The only token source is
-  intentional entry in the hidden GTK field or strict hidden terminal prompt
-  for the current in-memory call.
+- No shell-added start, stop, restart, repair, lifecycle, configuration,
+  passphrase, adapter-selection, support-bundle, or other control. Controls
+  already present in the daemon-served Portal are unchanged.
+- No shell token injection into URLs, headers, JavaScript, WebKit user scripts,
+  Web Storage, or cookies; no token discovery, persistent storage,
+  keyring/portal integration, issuance, rotation, or daemon-side pairing
+  endpoint. The Portal retains its existing manual entry behavior inside the
+  ephemeral WebKit session, and the native/terminal manual entry paths remain
+  unchanged.
 - No daemon endpoint, API response, authentication, pairing, lifecycle,
   diagnostics, support-bundle, or runtime behavior change.
 - No top-level or backend installer, uninstaller, systemd-unit, platform matrix,
@@ -782,11 +835,12 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No known-adapter registry or adapter-policy implementation.
 - No HostFactsSnapshot work or consumer change.
 
-PR #87 authorizes only the native read-only dashboard parity layout, its
-deterministic GTK-independent behavior tests, and documentation updates.
+PR #88 authorizes only the explicit locked daemon-served Web Portal shell, its
+ephemeral WebKit setup, origin/navigation policy, safe native/error fallback,
+deterministic tests, and documentation updates.
 PR #83's recorded manual live-pairing validation remains historical evidence;
-PR #87 does not claim a new real-daemon pairing result unless the installed
-command is run against an available daemon. PR #87 does not claim token
+PR #88 does not claim a new real-daemon pairing result unless the installed
+command is run against an available daemon. PR #88 does not claim token
 persistence, keyring integration, lifecycle/configuration controls,
 support-bundle portal export, a Flathub-polished release, Steam Frame support,
 VR Direct Link support, or a known-adapter registry. Lifecycle/configuration

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -1,4 +1,4 @@
-"""Minimal unprivileged native dashboard for the VRhotspot Flatpak."""
+"""Unprivileged native and locked Web Portal shells for the VRhotspot Flatpak."""
 
 from .app import (
     APP_ID,
@@ -9,12 +9,18 @@ from .app import (
     MAX_LIVE_SMOKE_JSON_BYTES,
     MAX_SMOKE_JSON_BYTES,
     NativeDashboardModel,
+    WEBKIT_GI_NAMESPACE,
+    WEBKIT_GI_VERSION,
+    WEB_PORTAL_ORIGIN,
+    WEB_PORTAL_URL,
     build_dashboard_model,
     build_initial_model,
     build_smoke_payload,
+    is_approved_web_portal_uri,
     main,
     render_smoke_json,
     run_live_pairing_smoke_json,
+    run_web_portal_shell,
 )
 
 __all__ = [
@@ -26,10 +32,16 @@ __all__ = [
     "MAX_LIVE_SMOKE_JSON_BYTES",
     "MAX_SMOKE_JSON_BYTES",
     "NativeDashboardModel",
+    "WEBKIT_GI_NAMESPACE",
+    "WEBKIT_GI_VERSION",
+    "WEB_PORTAL_ORIGIN",
+    "WEB_PORTAL_URL",
     "build_dashboard_model",
     "build_initial_model",
     "build_smoke_payload",
+    "is_approved_web_portal_uri",
     "main",
     "render_smoke_json",
     "run_live_pairing_smoke_json",
+    "run_web_portal_shell",
 ]

--- a/flatpak_app/__main__.py
+++ b/flatpak_app/__main__.py
@@ -1,4 +1,4 @@
-"""Module entry point for the VRhotspot Flatpak native dashboard."""
+"""Module entry point for the VRhotspot Flatpak desktop shell."""
 
 from .app import main
 

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -1,4 +1,4 @@
-"""Launchable, read-only Flatpak native dashboard foundation."""
+"""Launchable Flatpak shell with native and locked Web Portal modes."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import getpass
 import json
 import sys
 from typing import Any, Sequence
+from urllib.parse import urlsplit
 import warnings
 
 from flatpak_client import (
@@ -29,8 +30,22 @@ from flatpak_client import (
 
 APP_ID = "io.github.josethevrtech.VRhotspot"
 APP_NAME = "VR Hotspot"
+WEB_PORTAL_ORIGIN = "http://127.0.0.1:8732"
+WEB_PORTAL_URL = f"{WEB_PORTAL_ORIGIN}/ui"
+WEBKIT_GI_NAMESPACE = "WebKit"
+WEBKIT_GI_VERSION = "6.0"
 MAX_SMOKE_JSON_BYTES = 8_192
 MAX_LIVE_SMOKE_JSON_BYTES = 65_536
+_WEB_PORTAL_CSP = (
+    f"default-src {WEB_PORTAL_ORIGIN}; "
+    f"connect-src {WEB_PORTAL_ORIGIN}; "
+    f"img-src {WEB_PORTAL_ORIGIN} data:; "
+    f"style-src {WEB_PORTAL_ORIGIN} 'unsafe-inline'; "
+    f"script-src {WEB_PORTAL_ORIGIN} 'unsafe-inline'; "
+    f"font-src {WEB_PORTAL_ORIGIN}; "
+    "object-src 'none'; frame-src 'none'; base-uri 'none'; "
+    f"form-action {WEB_PORTAL_ORIGIN}"
+)
 _DASHBOARD_CSS = """
 .dashboard-card {
   border-radius: 10px;
@@ -58,6 +73,10 @@ _LIVE_SMOKE_INPUT_EXIT = 2
 
 class GuiUnavailableError(RuntimeError):
     """GTK 4 or PyGObject is unavailable for the graphical shell."""
+
+
+class WebKitUnavailableError(RuntimeError):
+    """The pinned WebKitGTK GI API is unavailable for the portal shell."""
 
 
 @dataclass(frozen=True)
@@ -388,6 +407,129 @@ def _load_gtk():
             "GTK 4 and PyGObject are required for the graphical shell."
         ) from None
     return Gtk
+
+
+def _load_webkit():
+    """Import the GNOME 50 WebKitGTK namespace only for the opt-in shell."""
+
+    try:
+        import gi
+
+        gi.require_version(WEBKIT_GI_NAMESPACE, WEBKIT_GI_VERSION)
+        from gi.repository import WebKit
+
+        if not callable(getattr(WebKit.NetworkSession, "new_ephemeral", None)):
+            raise AttributeError
+        if not hasattr(WebKit, "WebView") or not hasattr(WebKit, "Settings"):
+            raise AttributeError
+    except (ImportError, ValueError, AttributeError):
+        raise WebKitUnavailableError(
+            "WebKitGTK 6.0 is unavailable for the locked Web Portal shell."
+        ) from None
+    return WebKit
+
+
+def is_approved_web_portal_uri(uri: object) -> bool:
+    """Accept only HTTP URLs on the one pinned daemon loopback origin."""
+
+    if not isinstance(uri, str) or not uri:
+        return False
+    try:
+        parsed = urlsplit(uri)
+        port = parsed.port
+    except (TypeError, ValueError):
+        return False
+    return (
+        parsed.scheme == "http"
+        and parsed.netloc == "127.0.0.1:8732"
+        and parsed.hostname == "127.0.0.1"
+        and port == 8732
+        and parsed.username is None
+        and parsed.password is None
+    )
+
+
+def _policy_decision_uri(decision, decision_type, WebKit) -> str:
+    try:
+        if decision_type in (
+            WebKit.PolicyDecisionType.NAVIGATION_ACTION,
+            WebKit.PolicyDecisionType.NEW_WINDOW_ACTION,
+        ):
+            return decision.get_navigation_action().get_request().get_uri()
+        if decision_type == WebKit.PolicyDecisionType.RESPONSE:
+            return decision.get_response().get_uri()
+    except (AttributeError, TypeError, ValueError):
+        return ""
+    return ""
+
+
+def _handle_web_portal_policy(_web_view, decision, decision_type, WebKit) -> bool:
+    """Resolve every WebKit policy request explicitly and fail closed."""
+
+    uri = _policy_decision_uri(decision, decision_type, WebKit)
+    allowed = (
+        decision_type != WebKit.PolicyDecisionType.NEW_WINDOW_ACTION
+        and is_approved_web_portal_uri(uri)
+    )
+    try:
+        if allowed:
+            decision.use()
+        else:
+            decision.ignore()
+    except (AttributeError, TypeError):
+        return True
+    return True
+
+
+def _build_locked_web_portal_view(WebKit):
+    """Create an ephemeral WebView without credential or script injection."""
+
+    network_session = WebKit.NetworkSession.new_ephemeral()
+    if network_session.is_ephemeral() is not True:
+        raise WebKitUnavailableError(
+            "WebKitGTK did not provide an ephemeral network session."
+        )
+    network_session.set_persistent_credential_storage_enabled(False)
+    network_session.get_cookie_manager().set_accept_policy(
+        WebKit.CookieAcceptPolicy.NEVER
+    )
+
+    settings = WebKit.Settings()
+    settings.set_enable_developer_extras(False)
+    settings.set_enable_dns_prefetching(False)
+    settings.set_enable_offline_web_application_cache(False)
+    settings.set_enable_page_cache(False)
+    settings.set_enable_back_forward_navigation_gestures(False)
+    settings.set_javascript_can_open_windows_automatically(False)
+    settings.set_allow_file_access_from_file_urls(False)
+    settings.set_allow_universal_access_from_file_urls(False)
+
+    web_view = WebKit.WebView(
+        network_session=network_session,
+        settings=settings,
+        default_content_security_policy=_WEB_PORTAL_CSP,
+    )
+    web_view.connect(
+        "decide-policy",
+        lambda view, decision, decision_type: _handle_web_portal_policy(
+            view,
+            decision,
+            decision_type,
+            WebKit,
+        ),
+    )
+    web_view.connect("create", lambda _view, _navigation_action: None)
+    web_view.connect("context-menu", lambda *_args: True)
+
+    def deny_permission(_view, request) -> bool:
+        try:
+            request.deny()
+        except (AttributeError, TypeError):
+            pass
+        return True
+
+    web_view.connect("permission-request", deny_permission)
+    return web_view
 
 
 def _add_text_label(Gtk, container, text: str, *, css_class: str | None = None):
@@ -1074,128 +1216,211 @@ def _connect_from_token_entry(
         connect_button.set_sensitive(True)
 
 
-def run_gui() -> int:
-    """Run the native read-only dashboard against the local API client."""
+def _populate_native_dashboard_window(Gtk, window) -> None:
+    """Populate one application window with the retained native dashboard."""
 
-    Gtk = _load_gtk()
     model = build_initial_model()
     token_entry_controller = FirstRunTokenEntryController()
+    window.set_title(APP_NAME)
+    window.set_default_size(1040, 900)
+    _install_dashboard_styles(Gtk, window)
+
+    scroller = Gtk.ScrolledWindow()
+    scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+    content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
+    content.set_margin_top(28)
+    content.set_margin_bottom(28)
+    content.set_margin_start(28)
+    content.set_margin_end(28)
+
+    app_header = Gtk.Box(
+        orientation=Gtk.Orientation.HORIZONTAL,
+        spacing=16,
+    )
+    header_copy = Gtk.Box(
+        orientation=Gtk.Orientation.VERTICAL,
+        spacing=4,
+    )
+    header_copy.set_hexpand(True)
+    _add_text_label(Gtk, header_copy, APP_NAME, css_class="title-1")
+    _add_text_label(
+        Gtk,
+        header_copy,
+        "Native Dashboard",
+        css_class="title-3",
+    )
+    _add_text_label(
+        Gtk,
+        header_copy,
+        "Local VR readiness and diagnostics at a glance.",
+        css_class="dim-label",
+    )
+    app_header.append(header_copy)
+    header_badges = Gtk.Box(
+        orientation=Gtk.Orientation.VERTICAL,
+        spacing=6,
+    )
+    _add_status_badge(
+        Gtk,
+        header_badges,
+        StatusSeverity.UNKNOWN,
+        text="NATIVE GTK",
+    )
+    _add_status_badge(
+        Gtk,
+        header_badges,
+        StatusSeverity.OK,
+        text="READ-ONLY",
+    )
+    app_header.append(header_badges)
+    content.append(app_header)
+
+    connection_frame, connection_body = _new_card(
+        Gtk,
+        title="Connect to Local Daemon",
+        severity=None,
+    )
+    _add_text_label(
+        Gtk,
+        connection_body,
+        "Enter the API token configured for the local VRhotspot daemon. "
+        "The token is used in memory for this validation only and is not saved.",
+    )
+
+    connection_row = Gtk.Box(
+        orientation=Gtk.Orientation.HORIZONTAL,
+        spacing=8,
+    )
+    token_entry = Gtk.PasswordEntry()
+    _set_placeholder_text_compat(token_entry, "API token")
+    token_entry.set_show_peek_icon(True)
+    token_entry.set_hexpand(True)
+    connection_row.append(token_entry)
+
+    connect_button = Gtk.Button(label="Connect / Validate token")
+    connection_row.append(connect_button)
+    connection_body.append(connection_row)
+    _add_text_label(
+        Gtk,
+        connection_body,
+        "The entry is cleared before validation. Pairing does not persist a session.",
+        css_class="dim-label",
+    )
+    content.append(connection_frame)
+
+    display_sections = Gtk.Box(
+        orientation=Gtk.Orientation.VERTICAL,
+        spacing=16,
+    )
+    content.append(display_sections)
+    _render_display_model(Gtk, display_sections, model)
+
+    def on_connect(_widget) -> None:
+        _connect_from_token_entry(
+            token_entry=token_entry,
+            connect_button=connect_button,
+            controller=token_entry_controller,
+            render_model=lambda updated_model: _render_display_model(
+                Gtk,
+                display_sections,
+                updated_model,
+            ),
+        )
+
+    connect_button.connect("clicked", on_connect)
+    token_entry.connect("activate", on_connect)
+
+    scroller.set_child(content)
+    window.set_child(scroller)
+
+
+def run_gui() -> int:
+    """Run the retained native read-only dashboard."""
+
+    Gtk = _load_gtk()
     application = Gtk.Application(application_id=APP_ID)
 
     def on_activate(app) -> None:
         window = Gtk.ApplicationWindow(application=app)
-        window.set_title(APP_NAME)
-        window.set_default_size(1040, 900)
-        _install_dashboard_styles(Gtk, window)
+        _populate_native_dashboard_window(Gtk, window)
+        window.present()
 
-        scroller = Gtk.ScrolledWindow()
-        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+    application.connect("activate", on_activate)
+    return int(application.run([]))
 
-        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
-        content.set_margin_top(28)
-        content.set_margin_bottom(28)
-        content.set_margin_start(28)
-        content.set_margin_end(28)
 
-        app_header = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL,
-            spacing=16,
-        )
-        header_copy = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
-            spacing=4,
-        )
-        header_copy.set_hexpand(True)
-        _add_text_label(Gtk, header_copy, APP_NAME, css_class="title-1")
+def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
+    """Populate a locked portal shell, or report that native fallback is needed."""
+
+    window.set_title(APP_NAME)
+    window.set_default_size(1200, 900)
+    root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+    try:
+        web_view = _build_locked_web_portal_view(WebKit)
+    except Exception:
+        return False
+
+    web_view.set_hexpand(True)
+    web_view.set_vexpand(True)
+
+    def show_portal() -> None:
+        _clear_box(root)
+        root.append(web_view)
+
+    def show_unreachable() -> None:
+        _clear_box(root)
+        error_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        error_box.set_margin_top(36)
+        error_box.set_margin_bottom(36)
+        error_box.set_margin_start(36)
+        error_box.set_margin_end(36)
         _add_text_label(
             Gtk,
-            header_copy,
-            "Native Dashboard",
-            css_class="title-3",
-        )
-        _add_text_label(
-            Gtk,
-            header_copy,
-            "Local VR readiness and diagnostics at a glance.",
-            css_class="dim-label",
-        )
-        app_header.append(header_copy)
-        header_badges = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
-            spacing=6,
-        )
-        _add_status_badge(
-            Gtk,
-            header_badges,
-            StatusSeverity.UNKNOWN,
-            text="NATIVE GTK",
-        )
-        _add_status_badge(
-            Gtk,
-            header_badges,
-            StatusSeverity.OK,
-            text="READ-ONLY",
-        )
-        app_header.append(header_badges)
-        content.append(app_header)
-
-        connection_frame, connection_body = _new_card(
-            Gtk,
-            title="Connect to Local Daemon",
-            severity=None,
+            error_box,
+            "Local Web Portal unavailable",
+            css_class="title-2",
         )
         _add_text_label(
             Gtk,
-            connection_body,
-            "Enter the API token configured for the local VRhotspot daemon. "
-            "The token is used in memory for this validation only and is not saved.",
+            error_box,
+            "The Flatpak could not load the local daemon Web Portal at "
+            "127.0.0.1:8732. Confirm that vr-hotspotd is installed and running, "
+            "then retry. No external site was opened.",
         )
+        retry_button = Gtk.Button(label="Retry local portal")
 
-        connection_row = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL,
-            spacing=8,
-        )
-        token_entry = Gtk.PasswordEntry()
-        _set_placeholder_text_compat(token_entry, "API token")
-        token_entry.set_show_peek_icon(True)
-        token_entry.set_hexpand(True)
-        connection_row.append(token_entry)
+        def on_retry(_button) -> None:
+            show_portal()
+            web_view.load_uri(WEB_PORTAL_URL)
 
-        connect_button = Gtk.Button(label="Connect / Validate token")
-        connection_row.append(connect_button)
-        connection_body.append(connection_row)
-        _add_text_label(
-            Gtk,
-            connection_body,
-            "The entry is cleared before validation. Pairing does not persist a session.",
-            css_class="dim-label",
-        )
-        content.append(connection_frame)
+        retry_button.connect("clicked", on_retry)
+        error_box.append(retry_button)
+        root.append(error_box)
 
-        display_sections = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
-            spacing=16,
-        )
-        content.append(display_sections)
-        _render_display_model(Gtk, display_sections, model)
+    def on_load_failed(_view, _load_event, failing_uri, _error) -> bool:
+        if is_approved_web_portal_uri(failing_uri):
+            show_unreachable()
+        return True
 
-        def on_connect(_widget) -> None:
-            _connect_from_token_entry(
-                token_entry=token_entry,
-                connect_button=connect_button,
-                controller=token_entry_controller,
-                render_model=lambda updated_model: _render_display_model(
-                    Gtk,
-                    display_sections,
-                    updated_model,
-                ),
-            )
+    web_view.connect("load-failed", on_load_failed)
+    show_portal()
+    window.set_child(root)
+    web_view.load_uri(WEB_PORTAL_URL)
+    return True
 
-        connect_button.connect("clicked", on_connect)
-        token_entry.connect("activate", on_connect)
 
-        scroller.set_child(content)
-        window.set_child(scroller)
+def run_web_portal_shell() -> int:
+    """Run the opt-in daemon-served Web Portal inside a locked WebKit view."""
+
+    Gtk = _load_gtk()
+    WebKit = _load_webkit()
+    application = Gtk.Application(application_id=APP_ID)
+
+    def on_activate(app) -> None:
+        window = Gtk.ApplicationWindow(application=app)
+        if not _populate_web_portal_window(Gtk, WebKit, window):
+            _populate_native_dashboard_window(Gtk, window)
         window.present()
 
     application.connect("activate", on_activate)
@@ -1220,6 +1445,11 @@ def _argument_parser() -> argparse.ArgumentParser:
             "authenticated read-only state as JSON, and exit"
         ),
     )
+    parser.add_argument(
+        "--web-portal-shell",
+        action="store_true",
+        help="launch the locked local daemon Web Portal shell spike",
+    )
     return parser
 
 
@@ -1232,6 +1462,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.live_pairing_smoke_json:
         return run_live_pairing_smoke_json()
+    if args.web_portal_shell:
+        try:
+            return run_web_portal_shell()
+        except WebKitUnavailableError:
+            pass
 
     try:
         return run_gui()

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -186,6 +186,9 @@ class FakeGtkWidget:
     def set_hexpand(self, _expand):
         pass
 
+    def set_vexpand(self, _expand):
+        pass
+
     def set_column_homogeneous(self, _homogeneous):
         pass
 
@@ -273,6 +276,77 @@ class FakeGtk:
     PasswordEntry = FakeGtkPasswordEntry
 
 
+class FakeCookieManager:
+    def __init__(self):
+        self.accept_policy = None
+
+    def set_accept_policy(self, policy):
+        self.accept_policy = policy
+
+
+class FakeWebKitNetworkSession:
+    last_created = None
+
+    def __init__(self):
+        self.ephemeral = True
+        self.persistent_credentials = None
+        self.cookie_manager = FakeCookieManager()
+        type(self).last_created = self
+
+    @classmethod
+    def new_ephemeral(cls):
+        return cls()
+
+    def is_ephemeral(self):
+        return self.ephemeral
+
+    def set_persistent_credential_storage_enabled(self, enabled):
+        self.persistent_credentials = enabled
+
+    def get_cookie_manager(self):
+        return self.cookie_manager
+
+
+class FakeWebKitSettings:
+    last_created = None
+
+    def __init__(self):
+        self.values = {}
+        type(self).last_created = self
+
+    def __getattr__(self, name):
+        if name.startswith("set_"):
+            return lambda value: self.values.__setitem__(name, value)
+        raise AttributeError(name)
+
+
+class FakeWebKitWebView(FakeGtkWidget):
+    last_created = None
+
+    def __init__(self, **properties):
+        super().__init__()
+        self.properties = properties
+        self.loaded_uris = []
+        type(self).last_created = self
+
+    def load_uri(self, uri):
+        self.loaded_uris.append(uri)
+
+
+class FakeWebKit:
+    class PolicyDecisionType:
+        NAVIGATION_ACTION = "navigation"
+        NEW_WINDOW_ACTION = "new-window"
+        RESPONSE = "response"
+
+    class CookieAcceptPolicy:
+        NEVER = "never"
+
+    NetworkSession = FakeWebKitNetworkSession
+    Settings = FakeWebKitSettings
+    WebView = FakeWebKitWebView
+
+
 def _walk_fake_widgets(widget):
     yield widget
     for child in widget.children:
@@ -311,6 +385,324 @@ def test_app_shell_imports_without_importing_gtk(monkeypatch):
 
     assert module.APP_ID == APP_ID
     assert sys.modules.get("gi") is None
+
+
+@pytest.mark.parametrize(
+    "uri",
+    (
+        "http://127.0.0.1:8732/",
+        "http://127.0.0.1:8732/ui",
+        "http://127.0.0.1:8732/assets/ui.js?v=1",
+        "http://127.0.0.1:8732/v1/status#safe-fragment",
+    ),
+)
+def test_web_portal_shell_accepts_only_paths_on_the_pinned_origin(uri):
+    from flatpak_app import (
+        WEB_PORTAL_ORIGIN,
+        WEB_PORTAL_URL,
+        is_approved_web_portal_uri,
+    )
+
+    assert WEB_PORTAL_ORIGIN == "http://127.0.0.1:8732"
+    assert WEB_PORTAL_URL == "http://127.0.0.1:8732/ui"
+    assert is_approved_web_portal_uri(uri) is True
+
+
+@pytest.mark.parametrize(
+    "uri",
+    (
+        "",
+        None,
+        "https://127.0.0.1:8732/ui",
+        "http://localhost:8732/ui",
+        "http://127.0.0.1/ui",
+        "http://127.0.0.1:80/ui",
+        "http://127.0.0.2:8732/ui",
+        "http://[::1]:8732/ui",
+        "http://127.0.0.1:8732.evil.example/ui",
+        "http://127.0.0.1:8732@evil.example/ui",
+        "https://example.com/",
+        "file:///etc/vr-hotspot/env",
+        "data:text/html,external",
+        "javascript:alert(1)",
+        "blob:http://127.0.0.1:8732/value",
+    ),
+)
+def test_web_portal_shell_rejects_arbitrary_or_non_pinned_urls(uri):
+    from flatpak_app import is_approved_web_portal_uri
+
+    assert is_approved_web_portal_uri(uri) is False
+
+
+@pytest.mark.parametrize(
+    ("decision_type", "uri", "expected_action"),
+    (
+        ("navigation", "http://127.0.0.1:8732/ui", "use"),
+        ("navigation", "https://example.com/", "ignore"),
+        ("new-window", "http://127.0.0.1:8732/ui", "ignore"),
+        ("new-window", "https://example.com/", "ignore"),
+        ("response", "http://127.0.0.1:8732/assets/ui.js", "use"),
+        ("response", "https://example.com/remote.js", "ignore"),
+        ("unknown", "http://127.0.0.1:8732/ui", "ignore"),
+    ),
+)
+def test_web_portal_policy_explicitly_blocks_external_and_new_window_navigation(
+    decision_type,
+    uri,
+    expected_action,
+):
+    from flatpak_app import app
+
+    class Request:
+        def get_uri(self):
+            return uri
+
+    class NavigationAction:
+        def get_request(self):
+            return Request()
+
+    class Response:
+        def get_uri(self):
+            return uri
+
+    class Decision:
+        def __init__(self):
+            self.actions = []
+
+        def get_navigation_action(self):
+            return NavigationAction()
+
+        def get_response(self):
+            return Response()
+
+        def use(self):
+            self.actions.append("use")
+
+        def ignore(self):
+            self.actions.append("ignore")
+
+    decision = Decision()
+
+    assert (
+        app._handle_web_portal_policy(
+            None,
+            decision,
+            decision_type,
+            FakeWebKit,
+        )
+        is True
+    )
+    assert decision.actions == [expected_action]
+
+
+def test_locked_web_portal_view_is_ephemeral_and_has_no_injection_surface():
+    from flatpak_app import app
+
+    web_view = app._build_locked_web_portal_view(FakeWebKit)
+    session = FakeWebKitNetworkSession.last_created
+    settings = FakeWebKitSettings.last_created
+    source = inspect.getsource(app._build_locked_web_portal_view)
+
+    assert session is not None
+    assert session.is_ephemeral() is True
+    assert session.persistent_credentials is False
+    assert session.cookie_manager.accept_policy == "never"
+    assert web_view.properties["network_session"] is session
+    assert web_view.properties["settings"] is settings
+    assert (
+        web_view.properties["default_content_security_policy"]
+        == app._WEB_PORTAL_CSP
+    )
+    assert app.WEB_PORTAL_ORIGIN in app._WEB_PORTAL_CSP
+    assert "object-src 'none'" in app._WEB_PORTAL_CSP
+    assert "frame-src 'none'" in app._WEB_PORTAL_CSP
+    assert settings.values["set_enable_dns_prefetching"] is False
+    assert settings.values["set_enable_page_cache"] is False
+    assert (
+        settings.values["set_javascript_can_open_windows_automatically"] is False
+    )
+    assert {
+        "decide-policy",
+        "create",
+        "context-menu",
+        "permission-request",
+    } <= set(web_view.signal_handlers)
+    for forbidden in (
+        "X-Api-Token",
+        "Authorization",
+        "Bearer ",
+        "localStorage",
+        "sessionStorage",
+        "UserScript",
+        "add_script",
+        "add_style_sheet",
+        "set_uri(",
+    ):
+        assert forbidden not in source
+
+
+def test_web_portal_shell_loads_only_the_fixed_daemon_served_route(monkeypatch):
+    from flatpak_app import app
+
+    FakeGtkApplicationWindow.last_presented = None
+    FakeWebKitWebView.last_created = None
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+
+    assert app.run_web_portal_shell() == 0
+
+    window = FakeGtkApplicationWindow.last_presented
+    web_view = FakeWebKitWebView.last_created
+    assert window is not None
+    assert web_view is not None
+    assert web_view.loaded_uris == [app.WEB_PORTAL_URL]
+    assert "load-failed" in web_view.signal_handlers
+    assert not any(
+        isinstance(widget, FakeGtkPasswordEntry)
+        for widget in _walk_fake_widgets(window)
+    )
+
+
+def test_web_portal_load_failure_shows_bounded_safe_retry_ui(monkeypatch):
+    from flatpak_app import app
+
+    FakeGtkApplicationWindow.last_presented = None
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+    assert app.run_web_portal_shell() == 0
+
+    window = FakeGtkApplicationWindow.last_presented
+    web_view = FakeWebKitWebView.last_created
+    secret = "failure-detail-must-not-render"
+    handled = web_view.signal_handlers["load-failed"](
+        web_view,
+        "started",
+        app.WEB_PORTAL_URL,
+        RuntimeError(secret),
+    )
+    widgets = tuple(_walk_fake_widgets(window))
+    labels = {
+        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
+    }
+    buttons = [
+        widget for widget in widgets if isinstance(widget, FakeGtkButton)
+    ]
+
+    assert handled is True
+    assert "Local Web Portal unavailable" in labels
+    assert secret not in repr(labels)
+    assert [button.label for button in buttons] == ["Retry local portal"]
+    buttons[0].signal_handlers["clicked"](buttons[0])
+    assert web_view.loaded_uris == [app.WEB_PORTAL_URL, app.WEB_PORTAL_URL]
+
+
+def test_webkit_unavailable_falls_back_to_native_dashboard(monkeypatch):
+    from flatpak_app import app
+
+    calls = []
+
+    def unavailable():
+        raise app.WebKitUnavailableError("bounded")
+
+    monkeypatch.setattr(app, "run_web_portal_shell", unavailable)
+    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 19)
+
+    assert app.main(["--web-portal-shell"]) == 19
+    assert calls == ["native"]
+
+
+def test_webkit_construction_failure_falls_back_in_the_same_window(monkeypatch):
+    from flatpak_app import app
+
+    FakeGtkApplicationWindow.last_presented = None
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+
+    def fail_to_construct(_webkit):
+        raise RuntimeError("bounded")
+
+    monkeypatch.setattr(app, "_build_locked_web_portal_view", fail_to_construct)
+
+    assert app.run_web_portal_shell() == 0
+
+    window = FakeGtkApplicationWindow.last_presented
+    widgets = tuple(_walk_fake_widgets(window))
+    labels = {
+        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
+    }
+    assert isinstance(window.children[0], FakeGtkScrolledWindow)
+    assert {"VR Hotspot", "Native Dashboard", "NATIVE GTK"} <= labels
+
+
+def test_web_portal_shell_has_no_token_injection_or_persistence_path():
+    from flatpak_app import app
+
+    portal_source = "\n".join(
+        inspect.getsource(value)
+        for value in (
+            app._build_locked_web_portal_view,
+            app._populate_web_portal_window,
+            app.run_web_portal_shell,
+        )
+    )
+    exposed = (
+        repr(app.WEB_PORTAL_ORIGIN)
+        + repr(app.WEB_PORTAL_URL)
+        + repr(app._WEB_PORTAL_CSP)
+        + app.render_smoke_json()
+    )
+
+    assert inspect.signature(app.run_web_portal_shell).parameters == {}
+    assert "?" not in app.WEB_PORTAL_URL
+    assert "#" not in app.WEB_PORTAL_URL
+    assert "token" not in exposed.casefold()
+    for forbidden in (
+        "X-Api-Token",
+        "Authorization",
+        "Bearer ",
+        "localStorage",
+        "sessionStorage",
+        "UserScript",
+        "add_script",
+        "set_cookie",
+        "set_http_headers",
+        "getenv",
+        "/etc/",
+        "/var/lib/",
+    ):
+        assert forbidden not in portal_source
+
+
+def test_native_dashboard_remains_the_default_fallback(monkeypatch):
+    from flatpak_app import app
+
+    calls = []
+    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 23)
+    monkeypatch.setattr(
+        app,
+        "run_web_portal_shell",
+        lambda: pytest.fail("the spike must remain opt-in"),
+    )
+
+    assert app.main([]) == 23
+    assert calls == ["native"]
+
+
+def test_web_portal_flag_accepts_no_url_or_other_value():
+    from flatpak_app import app
+
+    parser = app._argument_parser()
+    parsed = parser.parse_args(["--web-portal-shell"])
+    portal_action = next(
+        action
+        for action in parser._actions
+        if "--web-portal-shell" in action.option_strings
+    )
+
+    assert parsed.web_portal_shell is True
+    assert portal_action.nargs == 0
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--web-portal-shell", "https://example.com/"])
 
 
 def test_gui_activation_does_not_require_password_entry_placeholder_setter(
@@ -1050,20 +1442,19 @@ def test_native_dashboard_styles_are_bounded_and_have_no_external_assets():
     } <= set(line.strip().split(" {", 1)[0] for line in stylesheet.splitlines())
 
 
-def test_native_dashboard_does_not_embed_a_web_runtime_or_frontend_assets():
+def test_web_portal_shell_does_not_copy_or_package_frontend_assets():
     source = Path("flatpak_app/app.py").read_text(encoding="utf-8").casefold()
     manifest_text = MANIFEST_PATH.read_text(encoding="utf-8").casefold()
 
-    for forbidden in (
-        "webkit",
-        "webview",
+    assert "webkit" in source
+    assert "webview" in source
+    for copied_asset in (
         "index.html",
         "ui.js",
         "ui.css",
         "../../assets/",
     ):
-        assert forbidden not in source
-        assert forbidden not in manifest_text
+        assert copied_asset not in manifest_text
 
 
 def test_token_entry_is_cleared_before_dashboard_validation():
@@ -1431,7 +1822,6 @@ def test_app_shell_has_no_direct_host_secret_or_network_access():
         "getenv(",
         "keyring",
         "SecretService",
-        "portal",
         "/etc/",
         "/var/lib/",
         "VR_HOTSPOTD_API_TOKEN",
@@ -1458,6 +1848,7 @@ def test_shell_has_no_token_cli_argument_or_discovery_source():
     assert "--token" not in option_strings
     assert "--api-token" not in option_strings
     assert "--live-pairing-smoke-json" in option_strings
+    assert "--web-portal-shell" in option_strings
     assert "getpass.getpass" in source
     assert "isatty()" in source
     assert "FirstRunTokenEntryController" in source


### PR DESCRIPTION
# Summary
- Add an opt-in locked Web Portal shell mode for the Flatpak companion app.
- Render the daemon-served local Web Portal at `http://127.0.0.1:8732/ui` through WebKitGTK.
- Keep the native GTK dashboard as the default and fallback for this spike.

# Web Portal shell
- Adds `--web-portal-shell`.
- Uses the existing daemon-served `/ui` route.
- Confirms GNOME 50 provides WebKitGTK through GI 6.0.
- Uses an ephemeral WebKit session where supported.
- Adds bounded unreachable-daemon/error UI.

# Security boundaries
- No arbitrary URL input.
- Navigation is pinned to the local daemon origin.
- External, deceptive, popup, new-window, non-loopback, and non-HTTP navigation are denied.
- No WebView address bar.
- No token injection into URLs, headers, scripts, storage, cookies, or logs.
- No token persistence, keyring storage, or daemon token discovery.
- The existing Portal manual token flow remains unchanged inside the ephemeral WebKit session.

# Boundaries unchanged
- Native GTK dashboard remains available.
- Flatpak permissions are unchanged.
- No daemon API/runtime behavior changes.
- No installer behavior changes.
- No WebUI asset changes.
- No backend/vendor changes.
- No lifecycle/config/start/stop/restart controls added by the shell.

# Validation
- Focused tests: 143 passed.
- Full suite: 800 passed, 4 subtests passed.
- Vendor manifest/SBOM/SHA validation passed.
- Installer syntax and install matrix passed.
- Real Flatpak build/install passed.
- Installed offline smoke passed.
- Noninteractive live smoke safely exited 2 with `interactive_input_required`.
- Manual Web Portal shell GUI validation: `timeout 10` exited 124 with no traceback; only non-blocking Mesa warnings.
- Daemon journal confirmed installed WebView requested `/ui`.

# Review
- Final review verdict: approve; no blockers.
- Review file: `/tmp/vrhotspot-flatpak-web-portal-shell-spike-final-review.md`
- Review SHA-256: `c40c0d7a47a2a3687fd610d44653200a68043fa312f52a7243ab5ba6823951d6`

# Follow-up
- Do not switch the default Flatpak UI yet.
- Next PR should harden real-WebKit navigation tests, ephemeral storage verification, download policy, authorization surface, recovery testing, and visual regression coverage.
