### PR TITLE
Add Flatpak tray control surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/install
 sudo bash /tmp/vrhotspot-install.sh --non-interactive
 ```
 
-### Optional prototype Flatpak companion
+### Optional Flatpak desktop companion
 
 The guided installer asks `Install the Flatpak companion app?` and defaults to
 No while the companion and its local packaging mature. Choosing No leaves the
@@ -56,12 +56,25 @@ runtime/SDK to already be available. It does not add Flathub or another Flatpak
 remote. Missing prerequisites or a failed build are reported clearly, temporary
 build files are removed, and the daemon install continues.
 
-After installation, launch the companion and enter the existing daemon API
-token manually in its hidden token field. The installer does not read, pass,
-copy, or store the daemon token for the Flatpak. Token persistence/keyring
-storage, lifecycle/configuration controls, support-bundle portal export,
-Flathub polish, Steam Frame, VR Direct Link, and adapter-registry work remain
-future work.
+The desktop launcher starts the companion in tray mode. It opens a native
+dashboard initially, stays available through a cyan-and-black system-tray icon,
+and hides the window to the tray when the window is closed. The tray provides
+live status, lifecycle controls, Share Internet Connection, Privacy Mode, and
+the existing Start Hotspot Automatically setting. Explicit Quit exits only the
+desktop companion and does not stop an already-running hotspot.
+
+Use **Authentication…** to enter the existing daemon API token. Saving it is an
+explicit choice and uses the desktop Secret Service provider (including a
+compatible KDE Wallet setup); otherwise it remains in memory only. The
+installer and Flatpak never discover the token from daemon host files. The Web
+Portal shell remains a separate opt-in launch mode:
+
+```bash
+flatpak run io.github.josethevrtech.VRhotspot --web-portal-shell
+```
+
+Launching the tray companion at desktop login is not implemented and remains
+distinct from starting the hotspot automatically with the computer.
 
 **Other Linux distributions**
 
@@ -169,9 +182,13 @@ Enter the **API token** shown during installation to access the interface.
 **Lifecycle Controls:**
 - Start / Stop / Repair / Restart
 - `POST /v1/start`, `POST /v1/stop`, `POST /v1/repair`, `POST /v1/restart`
+- `POST /v1/autostart` - Coordinate the existing hotspot boot-autostart unit
+  and canonical `autostart` setting
 
 **Status & Monitoring:**
 - `GET /v1/status` - Current hotspot status
+- `GET /v1/config` - Current canonical configuration, including
+  `enable_internet` and `autostart`
 - `GET /v1/status?include_logs=1` - Status with logs
 - `GET /v1/adapters` - List available Wi-Fi adapters
 - `GET /v1/adapters/readiness` - Adapter Intelligence v2 readiness model
@@ -299,16 +316,24 @@ sudo ufw allow 8732/tcp
 
 ### Autostart on Boot
 
-Enable autostart (if not done during installation):
+This means **Start Hotspot Automatically** with the computer. It is separate
+from launching the desktop tray companion at login. The setting coordinates
+the canonical `autostart` config value with the existing
+`vr-hotspot-autostart.service`.
+
+After installing the Flatpak companion, use the tray toggle. During daemon
+installation or repair, use the existing installer options:
 
 ```bash
-sudo systemctl enable --now vr-hotspot-autostart.service
+cd /var/lib/vr-hotspot/app/backend/scripts
+sudo ./install.sh --enable-autostart
 ```
 
 Disable autostart:
 
 ```bash
-sudo systemctl disable --now vr-hotspot-autostart.service
+cd /var/lib/vr-hotspot/app/backend/scripts
+sudo ./install.sh --disable-autostart
 ```
 
 ---

--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -14,6 +14,11 @@ from urllib.parse import parse_qs, quote, urlsplit
 
 from vr_hotspotd.adapters.inventory import get_adapters
 from vr_hotspotd.adapters.readiness import build_readiness_model
+from vr_hotspotd.autostart import (
+    AUTOSTART_ROLLBACK_FAILED,
+    AutostartControlError,
+    set_hotspot_autostart,
+)
 from vr_hotspotd.config import (
     ConfigValidationError,
     INVALID_NETWORK_CONFIG,
@@ -1533,6 +1538,50 @@ class APIHandler(BaseHTTPRequestHandler):
                     result_code="restarted:" + res.code,
                     data=self._status_view(include_logs=False),
                     warnings=warnings,
+                ),
+            )
+            return
+
+        if path == "/v1/autostart":
+            if (
+                not isinstance(body, dict)
+                or set(body) != {"enabled"}
+                or type(body.get("enabled")) is not bool
+            ):
+                self._respond(
+                    400,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code="invalid_request",
+                        warnings=body_warnings + ["boolean_enabled_required"],
+                    ),
+                )
+                return
+            try:
+                enabled = set_hotspot_autostart(body["enabled"])
+            except AutostartControlError as exc:
+                self._respond(
+                    500,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code=(
+                            "autostart_state_inconsistent"
+                            if exc.code == AUTOSTART_ROLLBACK_FAILED
+                            else "autostart_update_failed"
+                        ),
+                        warnings=body_warnings + [exc.code],
+                    ),
+                )
+                return
+            self._respond(
+                200,
+                self._envelope(
+                    correlation_id=cid,
+                    result_code=(
+                        "autostart_enabled" if enabled else "autostart_disabled"
+                    ),
+                    data={"autostart": enabled},
+                    warnings=body_warnings,
                 ),
             )
             return

--- a/backend/vr_hotspotd/autostart.py
+++ b/backend/vr_hotspotd/autostart.py
@@ -1,0 +1,81 @@
+"""Canonical hotspot-at-boot configuration and systemd synchronization."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Callable, Sequence
+
+from vr_hotspotd.config import load_config_snapshot, write_config_file
+
+
+AUTOSTART_UNIT = "vr-hotspot-autostart.service"
+AUTOSTART_ROLLBACK_FAILED = "autostart_rollback_failed_state_inconsistent"
+_SYSTEMCTL_TIMEOUT_SECONDS = 15.0
+
+
+class AutostartControlError(RuntimeError):
+    """A fixed, non-command-output failure from autostart synchronization."""
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+    def __repr__(self) -> str:
+        return f"AutostartControlError(code={self.code!r})"
+
+
+def _run_systemctl(argv: Sequence[str]):
+    child_environment = os.environ.copy()
+    child_environment.pop("VR_HOTSPOTD_API_TOKEN", None)
+    return subprocess.run(
+        list(argv),
+        capture_output=True,
+        check=False,
+        env=child_environment,
+        text=True,
+        timeout=_SYSTEMCTL_TIMEOUT_SECONDS,
+    )
+
+
+def _systemctl_command(enabled: bool) -> tuple[str, ...]:
+    if enabled:
+        return ("systemctl", "enable", AUTOSTART_UNIT)
+    return ("systemctl", "disable", "--now", AUTOSTART_UNIT)
+
+
+def set_hotspot_autostart(
+    enabled: bool,
+    *,
+    runner: Callable[[Sequence[str]], object] = _run_systemctl,
+    config_loader: Callable[[], dict] = load_config_snapshot,
+    config_writer: Callable[[dict], dict] = write_config_file,
+) -> bool:
+    """Synchronize the existing config key and installer-owned systemd unit."""
+
+    if type(enabled) is not bool:
+        raise AutostartControlError("invalid_autostart_value")
+
+    try:
+        previous = bool(config_loader().get("autostart", False))
+    except Exception:
+        raise AutostartControlError("autostart_config_read_failed") from None
+    try:
+        result = runner(_systemctl_command(enabled))
+    except Exception:
+        raise AutostartControlError("autostart_service_update_failed") from None
+
+    if getattr(result, "returncode", None) != 0:
+        raise AutostartControlError("autostart_service_update_failed")
+
+    try:
+        config_writer({"autostart": enabled})
+    except Exception:
+        try:
+            rollback_result = runner(_systemctl_command(previous))
+        except Exception:
+            raise AutostartControlError(AUTOSTART_ROLLBACK_FAILED) from None
+        if getattr(rollback_result, "returncode", None) != 0:
+            raise AutostartControlError(AUTOSTART_ROLLBACK_FAILED) from None
+        raise AutostartControlError("autostart_config_update_failed") from None
+    return enabled

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,25 +1,25 @@
 # Flatpak control app architecture plan
 
-Status: PR #90 Flatpak Web Portal shell display scaling/density polish; PRs #77-#89 retained
+Status: PR #91 Flatpak system-tray control surface and desktop identity; PRs #77-#90 retained
 
-Date: 2026-07-23
+Date: 2026-07-24
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #90 applies a fixed, bounded WebKit display zoom only to PR
-#88's explicit locked Web Portal shell, building on PR #89's shared
-daemon-served Portal layout and dark form-control theme. The browser `/ui` route
-continues to use those shared assets at normal browser scale. The Web Portal
-remains the visual source of truth for the Flatpak instead of being cloned in
-native GTK. PR #85/#87's native dashboard remains available as the default and
-fallback; switching the default is separately reviewed future work.
+application. PR #91 adds a functional Plasma-compatible system-tray control
+surface, close-to-tray lifecycle, current hotspot status, narrowly scoped
+daemon controls, explicit authentication UI, optional Secret Service storage,
+and cyan/black desktop identity. PR #90's fixed, bounded WebKit display zoom
+and PR #88's origin-locked Web Portal shell remain unchanged. The browser
+`/ui` route continues to use the shared assets at normal browser scale. The
+native GTK dashboard remains the default window and fallback; switching the
+default to the Web Portal shell is separately reviewed future work.
 
 The shell retains PR #86's installed GTK `PasswordEntry` compatibility fix,
 PR #82's native in-memory first-run token entry, PR #83's explicit terminal-only
-live daemon pairing smoke path, and PR #84's optional installer prompt. PR #90
-adds no daemon API/runtime behavior, privileged Flatpak action, permission
-expansion, token injection or discovery, persistent credential storage,
-installer change, shared CSS change, or Web UI JavaScript/control behavior
-change.
+live daemon pairing smoke path, and PR #84's optional installer prompt. PR #91
+does not inject a token into WebKit, change the shared Web Portal assets, add
+direct host command execution, add host filesystem access, or move privileged
+network ownership out of the daemon.
 
 ## Architectural decision
 
@@ -676,6 +676,90 @@ native GTK default/fallback remain unchanged. Switching the default UI and the
 additional WebKit hardening and prerequisite review for such a switch remain
 separately approved future work.
 
+## PR #91 system-tray control surface and desktop identity
+
+PR #91 makes the optional Flatpak companion a persistent desktop utility while
+keeping `vr-hotspotd` as the sole privileged host-mutation boundary. An explicit
+`--tray` launch mode owns a StatusNotifierItem and DBusMenu, shows the native GTK
+dashboard initially, restores it on primary tray activation, and hides it when
+the user closes the window. `Quit VR Hotspot` exits only the companion; it does
+not issue a hotspot stop request. If the tray backend cannot register, the
+normal native application still opens and closes normally instead of crashing
+or becoming hidden without a reachable tray icon.
+
+The GNOME 50 runtime provides Gio/GDBus and libsecret but does not provide an
+AppIndicator/Ayatana binding. The tray therefore implements the standard
+StatusNotifierItem and `com.canonical.dbusmenu` interfaces with lazy Gio
+imports. KDE Plasma consumes those interfaces directly. Menu construction and
+state sensitivity live in a toolkit-independent model, separate from the
+authenticated API controller and desktop backend. Mutation requests are
+serialized, repeat activation is rejected while work is pending, and a
+successful operation refreshes status and configuration before the controls
+are re-enabled.
+
+The tray uses only these fixed daemon operations:
+
+- `GET /v1/status` for live phase and running state
+- `GET /v1/config` for `enable_internet` and `autostart`
+- existing authenticated `POST /v1/start`, `/v1/stop`, `/v1/restart`, and
+  `/v1/repair` lifecycle operations
+- existing authenticated `POST /v1/config` with the strict
+  `enable_internet` field for the tray label `Share Internet Connection`
+- new authenticated `POST /v1/autostart` with exactly one Boolean `enabled`
+  field for `Start Hotspot Automatically`
+
+Hotspot boot autostart remains the existing coordinated
+`config["autostart"]` plus `vr-hotspot-autostart.service` behavior. The narrow
+autostart endpoint invokes a fixed enable or disable operation for that
+existing unit and updates the same canonical config value; it is not a second
+startup system or a generic service/config mutation endpoint.
+
+`Launch VR Hotspot at login` is a distinct desktop-session concern. PR #91
+does not implement that toggle: the Background portal can request background
+or autostart behavior but does not provide a dependable current-state query
+that could keep a tray checkbox honest across Plasma and other desktops.
+Creating a competing home-file mechanism would also broaden the current
+Flatpak lifecycle. A future implementation must control only this app's entry
+and must not be labeled as hotspot boot autostart.
+
+Privacy Mode remains a companion-local display choice matching the Portal's
+existing local preference. It controls whether a tray status refresh requests
+bounded daemon logs; it is not presented as daemon configuration. The tray
+currently defaults to privacy enabled and does not persist that preference.
+
+The Authentication dialog accepts only explicit user entry. It can test the
+credential, explicitly reveal or copy it, replace it, clear it, or save it
+through a stable libsecret schema:
+`io.github.josethevrtech.VRhotspot.ApiToken`, with app-specific
+`application` and `credential` attributes. Normal retrieval is silent only
+after the user opted to save. Secret Service can be backed by KDE Wallet or
+another desktop provider. When no provider is available, the token remains
+memory-only and the UI reports that secure persistence is unavailable. The
+Flatpak never searches `/etc/vr-hotspot/env`, `/var/lib/vr-hotspot`, command
+arguments, URLs, query strings, or plaintext files for a token, and clearing
+removes only the matching VR Hotspot wallet item.
+
+The installed scalable application icon now uses a cyan VR mark on a near-black
+rounded tile, with running, working, and error variants that retain the same
+base identity at panel sizes. Packaging installs all variants through the
+existing application-ID icon path.
+
+The only new session-bus grants are:
+
+- `--talk-name=org.kde.StatusNotifierWatcher` to register the standard tray item
+- `--talk-name=org.freedesktop.secrets` for explicit Secret Service storage
+
+PR #91 adds no system-bus, device, host/home filesystem, broad D-Bus, or host
+command permission. The app retains ordinary `--share=network` only for its
+fixed authenticated loopback API origin. Notifications contain fixed bounded
+operation summaries and never include credentials or raw daemon errors.
+
+`--smoke-json`, `--live-pairing-smoke-json`, and the opt-in
+`--web-portal-shell` remain compatible. The Web Portal shell retains its 1.75x
+zoom, ephemeral session, exact loopback origin, CSP, and navigation lock.
+Native GTK remains the default/fallback outside explicit tray mode. A future
+default Web Portal switch remains a separate review.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -771,7 +855,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #87 | Native dashboard Web Portal parity pass. Use the Portal as a design/product reference to improve the native GTK header, connection/pairing hierarchy, readiness summary, recommended-adapter emphasis, preflight facts/issues/actions, severity badges, and honest unavailable sections. Do not embed the Portal, add a WebView or frontend runtime, retain tokens, add actions/export, change Web UI or daemon behavior, or expand permissions. | Deterministic model/view tests prove parity labels, all five severity badges, paired and recommended emphasis, disabled support export, empty controls, absent lifecycle/configuration buttons, hidden/cleared token entry, placeholder compatibility, lazy GTK, token-free smoke contracts, redaction, and unchanged manifest permissions. |
 | PR #88 | Locked Web Portal shell spike. Add an explicit WebKitGTK 6.0 mode that loads only the daemon-served `http://127.0.0.1:8732/ui` Portal in an ephemeral, origin-locked WebView. Keep the native dashboard as default and fallback. Add no copied frontend, arbitrary URL, token injection/discovery/persistence, Web UI or daemon behavior, installer behavior, or permission. | Deterministic tests pin the route and exact origin, deny external and new-window navigation, prove ephemeral/no-injection construction and bounded load failure, exercise WebKit-unavailable and construction fallback, preserve both smoke contracts and native token-entry compatibility, and verify unchanged manifest permissions. Real packaging and manual shell validation remain required. |
 | PR #89 | Web Portal shell layout and theme polish. Improve the shared Portal CSS so Basic mode uses wide, medium, and narrow windows effectively and WebKitGTK renders select/input controls with readable dark, focused, and disabled states. Preserve Pro behavior, WebView security, opt-in launch, native fallback, tokens, APIs, runtime, installer, vendor files, and permissions. | Deterministic asset tests prove flexible Basic card/container rules, wide and narrow breakpoints, dark native-form overrides, focus/disabled contrast, retained Basic/Pro selectors and USB adapter control; the #88 shell/security/token/manifest tests remain green; browser `/ui` and the Flatpak shell consume the same daemon-served assets. |
-| PR #90 | Flatpak Web Portal shell display scaling/density polish (current phase). Apply a fixed, bounded 1.75x WebKit zoom only to the opt-in locked shell. Preserve the normal-scale browser Portal, shared assets, exact origin and navigation lock, ephemeral session, token boundaries, native default/fallback, daemon/runtime/installer behavior, vendor files, and permissions. | Deterministic shell tests prove the fixed zoom and clamp, absence of user-controlled zoom inputs, unchanged shared-CSS scaling, retained opt-in/default/fallback behavior, and the existing navigation, token, smoke, and manifest boundaries. Real packaging and manual shell/browser validation remain required. |
+| PR #90 | Flatpak Web Portal shell display scaling/density polish. Apply a fixed, bounded 1.75x WebKit zoom only to the opt-in locked shell. Preserve the normal-scale browser Portal, shared assets, exact origin and navigation lock, ephemeral session, token boundaries, native default/fallback, daemon/runtime/installer behavior, vendor files, and permissions. | Deterministic shell tests prove the fixed zoom and clamp, absence of user-controlled zoom inputs, unchanged shared-CSS scaling, retained opt-in/default/fallback behavior, and the existing navigation, token, smoke, and manifest boundaries. Real packaging and manual shell/browser validation remain required. |
+| PR #91 | Flatpak system-tray control surface and desktop identity (current phase). Add a Plasma-compatible StatusNotifierItem/DBusMenu backend, close-to-tray lifecycle, typed live-state model, fixed lifecycle/config controls, existing hotspot boot-autostart control, explicit Secret Service authentication UI, and cyan/black icon variants. | Deterministic tests prove complete menu/state mapping, serialized authenticated mutations, refresh-after-success, canonical `enable_internet` and hotspot-autostart behavior, companion-only quit, safe wallet fallback and token handling, optional desktop imports, retained shell/native/smoke contracts, narrow D-Bus grants, and installed icon identity. Real packaging and manual tray validation remain required. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -785,17 +870,17 @@ a production Flatpak release:
 | Question | Required decision |
 |---|---|
 | Application ID | PR #81 uses `io.github.josethevrtech.VRhotspot`; confirm naming and publication ownership before a store submission. |
-| Permissions | PR #81 documents its prototype finish-args; reassess network breadth, display compatibility, and any future portal before production. |
+| Permissions | PR #91 adds only exact session-bus talk grants for `org.kde.StatusNotifierWatcher` and `org.freedesktop.secrets`; reassess network breadth, display compatibility, and any future portal before production. |
 | Runtime and SDK | PR #81 selects GNOME 50 for the prototype; define update cadence, end-of-life policy, architecture targets, and reproducible/offline release expectations. |
-| Desktop file | PR #81 provides a minimal launcher entry with no desktop actions or URL scheme; review production naming and startup behavior. |
-| Icons and metainfo | PR #81 provides simple prototype SVG and AppStream metadata; production artwork, screenshots, releases, privacy copy, and store polish remain unresolved. Existing Web UI assets are not automatically release-ready desktop metadata. |
+| Desktop file | PR #91 launches explicit tray mode with no URL scheme; desktop-login autostart is not implemented. Review production startup policy separately. |
+| Icons and metainfo | PR #91 installs cyan/black scalable base and state icons plus updated AppStream tray copy; screenshots, release process, privacy copy, and store polish remain unresolved. |
 | Local daemon discovery | Decide how to detect an installed/compatible daemon without broad filesystem access, service-manager control, or token leakage. |
 | Offline/local-first behavior | Confirm that installed control functions need no cloud service; define behavior when the internet is unavailable and distinguish that from daemon unavailability. |
 | Versioning and compatibility | Define client, API, and daemon compatibility ranges, upgrade ordering, unsupported-version messaging, and rollback expectations. |
 | Release process | Define source provenance, dependency review, reproducible build inputs, signing, store submission, release notes, and coordination with host-daemon releases. |
 | Installation/update ownership | Keep daemon installation and privileged updates separate from Flatpak updates; document how users avoid incompatible independent versions. |
 
-PR #88-#90's shell and presentation choices are not blanket approval for
+PR #88-#91's shell, tray, and presentation choices are not blanket approval for
 production packaging or additional permissions.
 
 ## Future test and validation expectations
@@ -852,54 +937,33 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #90
+## Explicit non-goals for PR #91
 
-- No default UI switch or native-dashboard removal. The Web Portal is intended
-  to become the visual source of truth, but the locked WebView remains an
-  explicit opt-in mode and native GTK remains the default and fallback.
-- No Web UI JavaScript/behavior change, copied Web Portal JavaScript/style/image
-  asset, Flatpak-only frontend, or second frontend implementation. PR #90
-  changes only the locked WebView's fixed display zoom.
-- No arbitrary URL argument, address bar, external navigation, popup/new-window
-  navigation, remote-site load, or general browser.
-- No Flathub submission, release artifact, production metadata polish,
-  screenshots, signing, or distribution automation.
-- No shell-added start, stop, restart, repair, lifecycle, configuration,
-  passphrase, adapter-selection, support-bundle, or other control. Controls
-  already present in the daemon-served Portal are unchanged.
-- No shell token injection into URLs, headers, JavaScript, WebKit user scripts,
-  Web Storage, or cookies; no token discovery, persistent storage,
-  keyring/portal integration, issuance, rotation, or daemon-side pairing
-  endpoint. The Portal retains its existing manual entry behavior inside the
-  ephemeral WebKit session, and the native/terminal manual entry paths remain
-  unchanged.
-- No daemon endpoint, API response, authentication, pairing, lifecycle,
-  diagnostics, support-bundle, or runtime behavior change.
-- No top-level or backend installer, uninstaller, systemd-unit, platform matrix,
-  or CI-script behavior change. PR #84's optional companion prompt remains
-  unchanged.
-- No privileged networking in the Flatpak.
-- No direct Flatpak control of firewall rules, NetworkManager, iwd, hostapd,
-  dnsmasq, systemd units, kernel or network namespaces, interfaces, routes,
-  NAT, or other privileged host mutation.
-- No broad host filesystem access and no direct reading of daemon secrets,
-  configuration, logs, or state.
-- No vendor file or vendor manifest change.
-- No bundled or automatically downloaded proprietary Steam/Valve drivers,
-  firmware, utilities, or depot content.
-- No Steam Frame implementation or support claim.
-- No VR Direct Link implementation or support claim.
-- No known-adapter registry or adapter-policy implementation.
-- No HostFactsSnapshot work or consumer change.
+- No default Web Portal UI switch or native-dashboard removal. The locked
+  WebView remains explicit and opt-in; native GTK remains the default/fallback.
+- No Web UI JavaScript, CSS, route, CSP, origin, navigation, token, or session
+  behavior change.
+- No arbitrary URL argument, address bar, external/new-window navigation,
+  remote-site load, or general browser.
+- No token CLI argument, discovery endpoint, direct `/etc` or `/var/lib`
+  secret read, plaintext credential file, automatic copy/reveal, or WebKit
+  token injection.
+- No desktop-login companion autostart. It remains distinct from existing
+  hotspot boot autostart and requires a separately reviewed reliable mechanism.
+- No generic daemon configuration or systemd-control API. The new endpoint is
+  limited to the existing hotspot-autostart unit and Boolean config setting.
+- No Flatpak command execution for daemon controls and no direct access to
+  systemctl, NetworkManager, iwd, hostapd, dnsmasq, firewall, routing,
+  interfaces, devices, namespaces, or other privileged host mutation.
+- No broad host/home filesystem, system-bus, device, or wildcard D-Bus access.
+- No installer redesign, uninstaller behavior change, vendor file/manifest
+  change, support-bundle export, Flathub release automation, screenshots, or
+  signing.
+- No Steam Frame, VR Direct Link, known-adapter registry, or
+  HostFactsSnapshot work.
 
-PR #90 authorizes only fixed, bounded Flatpak Web Portal shell display scaling,
-its deterministic shell and retained-boundary tests, and documentation updates.
-PR #83's recorded manual live-pairing validation remains historical evidence;
-PR #90 does not claim a new real-daemon pairing result unless the installed
-command is run against an available daemon. PR #90 does not claim token
-persistence, keyring integration, lifecycle/configuration controls,
-support-bundle portal export, a Flathub-polished release, Steam Frame support,
-VR Direct Link support, or a known-adapter registry. Lifecycle/configuration
-controls, support-bundle portal export, token persistence/keyring integration,
-production packaging polish, Steam Frame, VR Direct Link, adapter registry
-work, and all later phases remain separately approved work.
+PR #91 authorizes only the tray lifecycle/control/authentication surface, its
+fixed autostart API, narrowly scoped session-bus grants, cyan/black desktop
+identity, deterministic tests, and documentation above. A real daemon pairing
+or live lifecycle result is claimed only when exercised with an explicitly
+entered credential; no credential is printed or exported in validation.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -20,7 +20,17 @@ from .app import (
     main,
     render_smoke_json,
     run_live_pairing_smoke_json,
+    run_tray,
     run_web_portal_shell,
+)
+from .tray import (
+    ICON_NAMES,
+    StatusNotifierBackend,
+    TrayMenuItem,
+    TrayMenuModel,
+    TrayRuntime,
+    WindowLifecycleController,
+    build_tray_menu_model,
 )
 
 __all__ = [
@@ -43,5 +53,13 @@ __all__ = [
     "main",
     "render_smoke_json",
     "run_live_pairing_smoke_json",
+    "run_tray",
     "run_web_portal_shell",
+    "ICON_NAMES",
+    "StatusNotifierBackend",
+    "TrayMenuItem",
+    "TrayMenuModel",
+    "TrayRuntime",
+    "WindowLifecycleController",
+    "build_tray_menu_model",
 ]

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -25,6 +25,8 @@ from flatpak_client import (
     StatusSeverity,
     SupportBundleAffordance,
     TokenPairingController,
+    AuthenticationController,
+    TrayControlController,
 )
 
 
@@ -430,6 +432,21 @@ def _load_webkit():
             "WebKitGTK 6.0 is unavailable for the locked Web Portal shell."
         ) from None
     return WebKit
+
+
+def _load_tray_desktop_modules():
+    """Load only the session desktop modules needed by explicit tray mode."""
+
+    try:
+        import gi
+
+        gi.require_version("Gdk", "4.0")
+        from gi.repository import Gdk, Gio, GLib
+    except (ImportError, ValueError):
+        raise GuiUnavailableError(
+            "GDK, GIO, and GLib are required for tray mode."
+        ) from None
+    return Gdk, Gio, GLib
 
 
 def is_approved_web_portal_uri(uri: object) -> bool:
@@ -1440,6 +1457,102 @@ def run_web_portal_shell() -> int:
     return int(application.run([]))
 
 
+def run_tray() -> int:
+    """Run the native app with an optional persistent StatusNotifierItem."""
+
+    Gtk = _load_gtk()
+    Gdk, Gio, GLib = _load_tray_desktop_modules()
+    from .tray import (
+        StatusNotifierBackend,
+        TrayRuntime,
+        WindowLifecycleController,
+        build_tray_menu_model,
+    )
+
+    application = Gtk.Application(application_id=APP_ID)
+    runtime_holder: dict[str, Any] = {}
+    portal_window_holder: dict[str, Any] = {}
+
+    def on_activate(app) -> None:
+        existing = runtime_holder.get("runtime")
+        if existing is not None:
+            existing.show()
+            return
+
+        window = Gtk.ApplicationWindow(application=app)
+        _populate_native_dashboard_window(Gtk, window)
+        authentication = AuthenticationController()
+        controls = TrayControlController(authentication)
+        lifecycle = WindowLifecycleController(
+            application=app,
+            window=window,
+        )
+
+        def open_diagnostics() -> None:
+            lifecycle.show()
+
+        def open_web_portal() -> None:
+            existing_portal = portal_window_holder.get("window")
+            if existing_portal is not None:
+                existing_portal.present()
+                return
+            try:
+                WebKit = _load_webkit()
+                portal_window = Gtk.ApplicationWindow(application=app)
+                if not _populate_web_portal_window(
+                    Gtk,
+                    WebKit,
+                    portal_window,
+                ):
+                    lifecycle.show()
+                    return
+            except Exception:
+                lifecycle.show()
+                return
+
+            def clear_portal(*_args):
+                portal_window_holder.pop("window", None)
+                return False
+
+            portal_window.connect("close-request", clear_portal)
+            portal_window_holder["window"] = portal_window
+            portal_window.present()
+
+        initial_menu = build_tray_menu_model(
+            controls.state,
+            window_visible=True,
+        )
+        backend = StatusNotifierBackend(
+            Gio=Gio,
+            GLib=GLib,
+            model=initial_menu,
+            on_action=lambda action: runtime_holder["runtime"].dispatch_action(
+                action
+            ),
+            on_activate=lambda: runtime_holder["runtime"].show(),
+        )
+        runtime = TrayRuntime(
+            application=app,
+            lifecycle=lifecycle,
+            controls=controls,
+            authentication=authentication,
+            backend=backend,
+            Gtk=Gtk,
+            Gdk=Gdk,
+            Gio=Gio,
+            GLib=GLib,
+            open_diagnostics=open_diagnostics,
+            open_web_portal=open_web_portal,
+        )
+        runtime_holder["runtime"] = runtime
+        window.connect("close-request", runtime.close_request)
+        lifecycle.show()
+        runtime.start()
+
+    application.connect("activate", on_activate)
+    return int(application.run([]))
+
+
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="vrhotspot-flatpak",
@@ -1463,6 +1576,11 @@ def _argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="launch the locked local daemon Web Portal shell spike",
     )
+    parser.add_argument(
+        "--tray",
+        action="store_true",
+        help="launch the persistent system-tray control companion",
+    )
     return parser
 
 
@@ -1479,6 +1597,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         try:
             return run_web_portal_shell()
         except WebKitUnavailableError:
+            pass
+    if args.tray:
+        try:
+            return run_tray()
+        except GuiUnavailableError:
             pass
 
     try:

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -1,0 +1,1014 @@
+"""Tray/menu presentation and optional StatusNotifierItem desktop backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+from typing import Callable
+
+from flatpak_client import (
+    ActionOutcome,
+    AuthenticationController,
+    FirstRunState,
+    TrayControlController,
+    TrayState,
+    TrayStatus,
+)
+
+
+APP_ID = "io.github.josethevrtech.VRhotspot"
+APP_NAME = "VR Hotspot"
+ICON_NAMES = {
+    TrayStatus.STOPPED: APP_ID,
+    TrayStatus.RUNNING: f"{APP_ID}-running",
+    TrayStatus.TRANSITIONING: f"{APP_ID}-working",
+    TrayStatus.ERROR: f"{APP_ID}-error",
+}
+
+
+@dataclass(frozen=True)
+class TrayMenuItem:
+    item_id: int
+    action: str
+    label: str
+    enabled: bool = True
+    checked: bool | None = None
+    separator: bool = False
+
+
+@dataclass(frozen=True)
+class TrayMenuModel:
+    items: tuple[TrayMenuItem, ...]
+    icon_name: str
+    notifier_status: str
+    tooltip: str
+
+    def action_labels(self) -> tuple[str, ...]:
+        return tuple(item.label for item in self.items if not item.separator)
+
+
+def build_tray_menu_model(
+    state: TrayState,
+    *,
+    window_visible: bool,
+) -> TrayMenuModel:
+    """Build a deterministic menu independent of GTK and the tray backend."""
+
+    ready = (
+        state.daemon_available
+        and state.authenticated
+        and state.busy_action is None
+        and state.status is not TrayStatus.TRANSITIONING
+    )
+    items = (
+        TrayMenuItem(1, "show", "Show VR Hotspot", not window_visible),
+        TrayMenuItem(2, "hide", "Hide VR Hotspot", window_visible),
+        TrayMenuItem(3, "separator-1", "", separator=True),
+        TrayMenuItem(
+            4,
+            "status",
+            f"Current status: {state.status_label}",
+            enabled=False,
+        ),
+        TrayMenuItem(5, "separator-2", "", separator=True),
+        TrayMenuItem(
+            6,
+            "start",
+            "Start Hotspot",
+            enabled=ready and state.status is TrayStatus.STOPPED,
+        ),
+        TrayMenuItem(
+            7,
+            "stop",
+            "Stop Hotspot",
+            enabled=ready and state.status is TrayStatus.RUNNING,
+        ),
+        TrayMenuItem(
+            8,
+            "restart",
+            "Restart Service",
+            enabled=ready and state.status is TrayStatus.RUNNING,
+        ),
+        TrayMenuItem(9, "repair", "Repair Network", enabled=ready),
+        TrayMenuItem(
+            10,
+            "refresh",
+            "Refresh Status",
+            enabled=state.busy_action is None,
+        ),
+        TrayMenuItem(11, "separator-3", "", separator=True),
+        TrayMenuItem(
+            12,
+            "share_internet",
+            "Share Internet Connection",
+            enabled=ready and state.share_internet is not None,
+            checked=state.share_internet is True,
+        ),
+        TrayMenuItem(
+            13,
+            "privacy",
+            "Privacy Mode",
+            checked=state.privacy_mode,
+        ),
+        TrayMenuItem(
+            14,
+            "hotspot_autostart",
+            "Start Hotspot Automatically",
+            enabled=ready and state.hotspot_autostart is not None,
+            checked=state.hotspot_autostart is True,
+        ),
+        TrayMenuItem(15, "separator-4", "", separator=True),
+        TrayMenuItem(16, "authentication", "Authentication…"),
+        TrayMenuItem(17, "diagnostics", "Open Diagnostics"),
+        TrayMenuItem(18, "web_portal", "Open Web Portal Shell"),
+        TrayMenuItem(19, "separator-5", "", separator=True),
+        TrayMenuItem(20, "quit", "Quit VR Hotspot"),
+    )
+    return TrayMenuModel(
+        items=items,
+        icon_name=ICON_NAMES[state.status],
+        notifier_status=(
+            "NeedsAttention" if state.status is TrayStatus.ERROR else "Active"
+        ),
+        tooltip=f"{APP_NAME} — {state.status_label}",
+    )
+
+
+class WindowLifecycleController:
+    """Show, hide, close-to-tray, and companion-only quit behavior."""
+
+    def __init__(self, *, application, window, tray_active: bool = False):
+        self._application = application
+        self._window = window
+        self._tray_active = tray_active
+        self._visible = False
+
+    def __repr__(self) -> str:
+        return (
+            "WindowLifecycleController("
+            f"tray_active={self._tray_active!r}, visible={self._visible!r})"
+        )
+
+    @property
+    def visible(self) -> bool:
+        return self._visible
+
+    @property
+    def tray_active(self) -> bool:
+        return self._tray_active
+
+    @property
+    def window(self):
+        return self._window
+
+    def set_tray_active(self, active: bool) -> None:
+        self._tray_active = active is True
+
+    def show(self) -> None:
+        self._window.present()
+        self._visible = True
+
+    def hide(self) -> None:
+        self._window.hide()
+        self._visible = False
+
+    def toggle(self) -> None:
+        if self._visible:
+            self.hide()
+        else:
+            self.show()
+
+    def close_request(self, *_args) -> bool:
+        if not self._tray_active:
+            return False
+        self.hide()
+        return True
+
+    def quit_companion(self) -> None:
+        self._application.quit()
+
+
+_STATUS_NOTIFIER_XML = """
+<node>
+  <interface name="org.kde.StatusNotifierItem">
+    <method name="ContextMenu"><arg type="i" direction="in"/><arg type="i" direction="in"/></method>
+    <method name="Activate"><arg type="i" direction="in"/><arg type="i" direction="in"/></method>
+    <method name="SecondaryActivate"><arg type="i" direction="in"/><arg type="i" direction="in"/></method>
+    <method name="Scroll"><arg type="i" direction="in"/><arg type="s" direction="in"/></method>
+    <property name="Category" type="s" access="read"/>
+    <property name="Id" type="s" access="read"/>
+    <property name="Title" type="s" access="read"/>
+    <property name="Status" type="s" access="read"/>
+    <property name="WindowId" type="u" access="read"/>
+    <property name="IconName" type="s" access="read"/>
+    <property name="IconPixmap" type="a(iiay)" access="read"/>
+    <property name="OverlayIconName" type="s" access="read"/>
+    <property name="OverlayIconPixmap" type="a(iiay)" access="read"/>
+    <property name="AttentionIconName" type="s" access="read"/>
+    <property name="AttentionIconPixmap" type="a(iiay)" access="read"/>
+    <property name="AttentionMovieName" type="s" access="read"/>
+    <property name="ToolTip" type="(sa(iiay)ss)" access="read"/>
+    <property name="ItemIsMenu" type="b" access="read"/>
+    <property name="Menu" type="o" access="read"/>
+    <signal name="NewTitle"/>
+    <signal name="NewIcon"/>
+    <signal name="NewAttentionIcon"/>
+    <signal name="NewOverlayIcon"/>
+    <signal name="NewToolTip"/>
+    <signal name="NewStatus"><arg type="s"/></signal>
+  </interface>
+</node>
+"""
+
+_DBUS_MENU_XML = """
+<node>
+  <interface name="com.canonical.dbusmenu">
+    <method name="GetLayout">
+      <arg name="parentId" type="i" direction="in"/>
+      <arg name="recursionDepth" type="i" direction="in"/>
+      <arg name="propertyNames" type="as" direction="in"/>
+      <arg name="revision" type="u" direction="out"/>
+      <arg name="layout" type="(ia{sv}av)" direction="out"/>
+    </method>
+    <method name="GetGroupProperties">
+      <arg name="ids" type="ai" direction="in"/>
+      <arg name="propertyNames" type="as" direction="in"/>
+      <arg name="properties" type="a(ia{sv})" direction="out"/>
+    </method>
+    <method name="GetProperty">
+      <arg name="id" type="i" direction="in"/>
+      <arg name="name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="Event">
+      <arg name="id" type="i" direction="in"/>
+      <arg name="eventId" type="s" direction="in"/>
+      <arg name="data" type="v" direction="in"/>
+      <arg name="timestamp" type="u" direction="in"/>
+    </method>
+    <method name="EventGroup">
+      <arg name="events" type="a(isvu)" direction="in"/>
+      <arg name="idErrors" type="ai" direction="out"/>
+    </method>
+    <method name="AboutToShow">
+      <arg name="id" type="i" direction="in"/>
+      <arg name="needUpdate" type="b" direction="out"/>
+    </method>
+    <method name="AboutToShowGroup">
+      <arg name="ids" type="ai" direction="in"/>
+      <arg name="updatesNeeded" type="ai" direction="out"/>
+      <arg name="idErrors" type="ai" direction="out"/>
+    </method>
+    <property name="Version" type="u" access="read"/>
+    <property name="TextDirection" type="s" access="read"/>
+    <property name="Status" type="s" access="read"/>
+    <property name="IconThemePath" type="as" access="read"/>
+    <signal name="ItemsPropertiesUpdated">
+      <arg type="a(ia{sv})"/><arg type="a(ias)"/>
+    </signal>
+    <signal name="LayoutUpdated"><arg type="u"/><arg type="i"/></signal>
+  </interface>
+</node>
+"""
+
+
+class StatusNotifierBackend:
+    """Minimal standards-compatible StatusNotifierItem and D-Bus menu backend."""
+
+    ITEM_PATH = "/StatusNotifierItem"
+    MENU_PATH = "/MenuBar"
+    ITEM_INTERFACE = "org.kde.StatusNotifierItem"
+    MENU_INTERFACE = "com.canonical.dbusmenu"
+
+    def __init__(
+        self,
+        *,
+        Gio,
+        GLib,
+        model: TrayMenuModel,
+        on_action: Callable[[str], None],
+        on_activate: Callable[[], None],
+    ):
+        self._Gio = Gio
+        self._GLib = GLib
+        self._model = model
+        self._on_action = on_action
+        self._on_activate = on_activate
+        self._connection = None
+        self._registrations: list[int] = []
+        self._revision = 1
+
+    def __repr__(self) -> str:
+        return (
+            "StatusNotifierBackend("
+            f"registered={bool(self._registrations)!r}, revision={self._revision!r})"
+        )
+
+    def start(self) -> bool:
+        connection = None
+        registrations: list[int] = []
+        try:
+            connection = self._Gio.bus_get_sync(
+                self._Gio.BusType.SESSION,
+                None,
+            )
+            item_info = self._Gio.DBusNodeInfo.new_for_xml(
+                _STATUS_NOTIFIER_XML
+            ).interfaces[0]
+            menu_info = self._Gio.DBusNodeInfo.new_for_xml(
+                _DBUS_MENU_XML
+            ).interfaces[0]
+            item_id = connection.register_object(
+                self.ITEM_PATH,
+                item_info,
+                self._handle_item_method,
+                self._get_item_property,
+                None,
+            )
+            if not item_id:
+                raise RuntimeError
+            registrations.append(item_id)
+            menu_id = connection.register_object(
+                self.MENU_PATH,
+                menu_info,
+                self._handle_menu_method,
+                self._get_menu_property,
+                None,
+            )
+            if not menu_id:
+                raise RuntimeError
+            registrations.append(menu_id)
+            self._connection = connection
+            self._registrations = registrations
+            connection.call_sync(
+                "org.kde.StatusNotifierWatcher",
+                "/StatusNotifierWatcher",
+                "org.kde.StatusNotifierWatcher",
+                "RegisterStatusNotifierItem",
+                self._GLib.Variant("(s)", (APP_ID,)),
+                None,
+                self._Gio.DBusCallFlags.NONE,
+                5_000,
+                None,
+            )
+            return True
+        except Exception:
+            if connection is not None:
+                for registration in registrations:
+                    try:
+                        connection.unregister_object(registration)
+                    except Exception:
+                        pass
+            self._registrations = []
+            self._connection = None
+            self.stop()
+            return False
+
+    def stop(self) -> None:
+        if self._connection is not None:
+            for registration in self._registrations:
+                try:
+                    self._connection.unregister_object(registration)
+                except Exception:
+                    pass
+        self._registrations = []
+        self._connection = None
+
+    def update(self, model: TrayMenuModel) -> None:
+        icon_changed = model.icon_name != self._model.icon_name
+        status_changed = model.notifier_status != self._model.notifier_status
+        tooltip_changed = model.tooltip != self._model.tooltip
+        self._model = model
+        self._revision += 1
+        connection = self._connection
+        if connection is None:
+            return
+        try:
+            connection.emit_signal(
+                None,
+                self.MENU_PATH,
+                self.MENU_INTERFACE,
+                "LayoutUpdated",
+                self._GLib.Variant("(ui)", (self._revision, 0)),
+            )
+            if icon_changed:
+                connection.emit_signal(
+                    None,
+                    self.ITEM_PATH,
+                    self.ITEM_INTERFACE,
+                    "NewIcon",
+                    None,
+                )
+            if status_changed:
+                connection.emit_signal(
+                    None,
+                    self.ITEM_PATH,
+                    self.ITEM_INTERFACE,
+                    "NewStatus",
+                    self._GLib.Variant("(s)", (model.notifier_status,)),
+                )
+            if tooltip_changed:
+                connection.emit_signal(
+                    None,
+                    self.ITEM_PATH,
+                    self.ITEM_INTERFACE,
+                    "NewToolTip",
+                    None,
+                )
+        except Exception:
+            pass
+
+    def _get_item_property(
+        self,
+        _connection,
+        _sender,
+        _object_path,
+        _interface_name,
+        property_name,
+    ):
+        Variant = self._GLib.Variant
+        properties = {
+            "Category": Variant("s", "ApplicationStatus"),
+            "Id": Variant("s", APP_ID),
+            "Title": Variant("s", APP_NAME),
+            "Status": Variant("s", self._model.notifier_status),
+            "WindowId": Variant("u", 0),
+            "IconName": Variant("s", self._model.icon_name),
+            "IconPixmap": Variant("a(iiay)", []),
+            "OverlayIconName": Variant("s", ""),
+            "OverlayIconPixmap": Variant("a(iiay)", []),
+            "AttentionIconName": Variant("s", f"{APP_ID}-error"),
+            "AttentionIconPixmap": Variant("a(iiay)", []),
+            "AttentionMovieName": Variant("s", ""),
+            "ToolTip": Variant(
+                "(sa(iiay)ss)",
+                (
+                    self._model.icon_name,
+                    [],
+                    APP_NAME,
+                    self._model.tooltip,
+                ),
+            ),
+            "ItemIsMenu": Variant("b", False),
+            "Menu": Variant("o", self.MENU_PATH),
+        }
+        return properties.get(property_name)
+
+    def _handle_item_method(
+        self,
+        _connection,
+        _sender,
+        _object_path,
+        _interface_name,
+        method_name,
+        _parameters,
+        invocation,
+    ) -> None:
+        if method_name in {"Activate", "SecondaryActivate"}:
+            try:
+                self._on_activate()
+            except Exception:
+                pass
+        invocation.return_value(None)
+
+    def _item_by_id(self, item_id: int) -> TrayMenuItem | None:
+        return next(
+            (item for item in self._model.items if item.item_id == item_id),
+            None,
+        )
+
+    def _menu_properties(
+        self,
+        item: TrayMenuItem,
+        property_names: tuple[str, ...] = (),
+    ) -> dict:
+        Variant = self._GLib.Variant
+        if item.separator:
+            values = {"type": Variant("s", "separator")}
+        else:
+            values = {
+                "label": Variant("s", item.label),
+                "enabled": Variant("b", item.enabled),
+                "visible": Variant("b", True),
+            }
+            if item.checked is not None:
+                values["toggle-type"] = Variant("s", "checkmark")
+                values["toggle-state"] = Variant("i", 1 if item.checked else 0)
+        if property_names:
+            allowed = set(property_names)
+            values = {key: value for key, value in values.items() if key in allowed}
+        return values
+
+    def _layout(self):
+        Variant = self._GLib.Variant
+        children = [
+            Variant(
+                "(ia{sv}av)",
+                (item.item_id, self._menu_properties(item), []),
+            )
+            for item in self._model.items
+        ]
+        return (
+            0,
+            {"children-display": Variant("s", "submenu")},
+            children,
+        )
+
+    def _get_menu_property(
+        self,
+        _connection,
+        _sender,
+        _object_path,
+        _interface_name,
+        property_name,
+    ):
+        Variant = self._GLib.Variant
+        return {
+            "Version": Variant("u", 3),
+            "TextDirection": Variant("s", "ltr"),
+            "Status": Variant("s", "normal"),
+            "IconThemePath": Variant("as", ["/app/share/icons/hicolor"]),
+        }.get(property_name)
+
+    def _dispatch_event(self, item_id: int, event_id: str) -> bool:
+        item = self._item_by_id(item_id)
+        if (
+            item is None
+            or item.separator
+            or not item.enabled
+            or event_id not in {"clicked", "activated"}
+        ):
+            return False
+        try:
+            self._on_action(item.action)
+        except Exception:
+            return False
+        return True
+
+    def _handle_menu_method(
+        self,
+        _connection,
+        _sender,
+        _object_path,
+        _interface_name,
+        method_name,
+        parameters,
+        invocation,
+    ) -> None:
+        Variant = self._GLib.Variant
+        values = parameters.unpack()
+        if method_name == "GetLayout":
+            invocation.return_value(
+                Variant("(u(ia{sv}av))", (self._revision, self._layout()))
+            )
+            return
+        if method_name == "GetGroupProperties":
+            ids, property_names = values
+            rows = []
+            for item_id in ids:
+                item = self._item_by_id(item_id)
+                if item is not None:
+                    rows.append(
+                        (
+                            item.item_id,
+                            self._menu_properties(item, tuple(property_names)),
+                        )
+                    )
+            invocation.return_value(Variant("(a(ia{sv}))", (rows,)))
+            return
+        if method_name == "GetProperty":
+            item_id, property_name = values
+            item = self._item_by_id(item_id)
+            value = None
+            if item is not None:
+                value = self._menu_properties(item).get(property_name)
+            invocation.return_value(
+                Variant(
+                    "(v)",
+                    (
+                        value
+                        if value is not None
+                        else Variant("s", ""),
+                    ),
+                )
+            )
+            return
+        if method_name == "Event":
+            item_id, event_id, _data, _timestamp = values
+            self._dispatch_event(item_id, event_id)
+            invocation.return_value(None)
+            return
+        if method_name == "EventGroup":
+            events = values[0]
+            errors = [
+                item_id
+                for item_id, event_id, _data, _timestamp in events
+                if not self._dispatch_event(item_id, event_id)
+            ]
+            invocation.return_value(Variant("(ai)", (errors,)))
+            return
+        if method_name == "AboutToShow":
+            invocation.return_value(Variant("(b)", (False,)))
+            return
+        if method_name == "AboutToShowGroup":
+            invocation.return_value(Variant("(aiai)", ([], [])))
+            return
+        invocation.return_dbus_error(
+            "com.canonical.dbusmenu.Error.UnknownMethod",
+            "Unsupported menu method.",
+        )
+
+
+class TrayRuntime:
+    """Connect the testable model/controller to GTK and StatusNotifierItem."""
+
+    def __init__(
+        self,
+        *,
+        application,
+        lifecycle: WindowLifecycleController,
+        controls: TrayControlController,
+        authentication: AuthenticationController,
+        backend: StatusNotifierBackend,
+        Gtk,
+        Gdk,
+        Gio,
+        GLib,
+        open_diagnostics: Callable[[], None],
+        open_web_portal: Callable[[], None],
+    ):
+        self._application = application
+        self._lifecycle = lifecycle
+        self._controls = controls
+        self._authentication = authentication
+        self._backend = backend
+        self._Gtk = Gtk
+        self._Gdk = Gdk
+        self._Gio = Gio
+        self._GLib = GLib
+        self._open_diagnostics = open_diagnostics
+        self._open_web_portal = open_web_portal
+        self._worker_lock = threading.Lock()
+        self._notification_counter = 0
+        self._last_detail_code = ""
+        self._auth_window = None
+
+    def __repr__(self) -> str:
+        return (
+            "TrayRuntime("
+            f"tray_active={self._lifecycle.tray_active!r}, "
+            f"worker_active={self._worker_lock.locked()!r})"
+        )
+
+    def start(self) -> bool:
+        active = self._backend.start()
+        self._lifecycle.set_tray_active(active)
+        if active:
+            self._application.hold()
+            self._GLib.timeout_add_seconds(5, self._periodic_refresh)
+        self._update_menu()
+        self.refresh_async()
+        return active
+
+    def _periodic_refresh(self) -> bool:
+        self.refresh_async()
+        return self._lifecycle.tray_active
+
+    def _update_menu(self) -> None:
+        self._backend.update(
+            build_tray_menu_model(
+                self._controls.state,
+                window_visible=self._lifecycle.visible,
+            )
+        )
+
+    def show(self) -> None:
+        self._lifecycle.show()
+        self._update_menu()
+
+    def hide(self) -> None:
+        self._lifecycle.hide()
+        self._update_menu()
+
+    def close_request(self, *_args) -> bool:
+        """Hide to the active tray and immediately refresh exported menu state."""
+
+        handled = self._lifecycle.close_request(*_args)
+        if handled:
+            self._update_menu()
+        return handled
+
+    def _notify(self, outcome: ActionOutcome) -> None:
+        title = ""
+        body = ""
+        if outcome.succeeded and outcome.code == "hotspot_started":
+            title, body = "VR Hotspot", "Hotspot started."
+        elif outcome.succeeded and outcome.code == "hotspot_stopped":
+            title, body = "VR Hotspot", "Hotspot stopped."
+        elif not outcome.succeeded and outcome.code == "daemon_unavailable":
+            title, body = "VR Hotspot unavailable", "The local daemon is unavailable."
+        elif not outcome.succeeded:
+            title, body = "VR Hotspot operation failed", "The requested operation failed."
+        if not title:
+            return
+        try:
+            notification = self._Gio.Notification.new(title)
+            notification.set_body(body)
+            notification.set_icon(self._Gio.ThemedIcon.new(APP_ID))
+            self._notification_counter += 1
+            self._application.send_notification(
+                f"tray-result-{self._notification_counter}",
+                notification,
+            )
+        except Exception:
+            pass
+
+    def _finish_worker(self, outcome: ActionOutcome | None = None) -> bool:
+        try:
+            detail_code = self._controls.state.detail_code
+            if (
+                detail_code == "daemon_unavailable"
+                and detail_code != self._last_detail_code
+                and (
+                    outcome is None
+                    or outcome.code != "daemon_unavailable"
+                )
+            ):
+                self._notify(
+                    ActionOutcome(
+                        accepted=True,
+                        succeeded=False,
+                        code="daemon_unavailable",
+                        message="The local daemon is unavailable.",
+                        state=self._controls.state,
+                    )
+                )
+            if outcome is not None:
+                self._notify(outcome)
+            self._last_detail_code = detail_code
+            self._update_menu()
+        finally:
+            if self._worker_lock.locked():
+                self._worker_lock.release()
+        return False
+
+    def _run_worker(
+        self,
+        call: Callable[[], object],
+        *,
+        pending_action: str | None = None,
+    ) -> None:
+        if not self._worker_lock.acquire(blocking=False):
+            return
+        if pending_action is not None:
+            self._controls.mark_operation_pending(pending_action)
+        self._update_menu()
+
+        def worker() -> None:
+            outcome = None
+            try:
+                value = call()
+                if isinstance(value, ActionOutcome):
+                    outcome = value
+            except Exception:
+                outcome = ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="operation_failed",
+                    message="The requested operation failed.",
+                    state=self._controls.state,
+                )
+            self._GLib.idle_add(self._finish_worker, outcome)
+
+        threading.Thread(
+            target=worker,
+            name="vrhotspot-tray-operation",
+            daemon=True,
+        ).start()
+
+    def refresh_async(self) -> None:
+        self._run_worker(self._controls.refresh)
+
+    def _open_authentication(self) -> None:
+        if self._auth_window is not None:
+            self._auth_window.present()
+            return
+
+        Gtk = self._Gtk
+        window = Gtk.Window(application=self._application)
+        window.set_title("VR Hotspot Authentication")
+        window.set_default_size(560, 330)
+        window.set_transient_for(self._lifecycle.window)
+        window.set_modal(True)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        content.set_margin_top(20)
+        content.set_margin_bottom(20)
+        content.set_margin_start(20)
+        content.set_margin_end(20)
+
+        heading = Gtk.Label(label="Authentication")
+        heading.set_xalign(0.0)
+        heading.add_css_class("title-2")
+        content.append(heading)
+        description = Gtk.Label(
+            label=(
+                "Enter the existing daemon API token. It remains in memory "
+                "unless secure wallet storage is explicitly selected."
+            )
+        )
+        description.set_wrap(True)
+        description.set_xalign(0.0)
+        content.append(description)
+
+        entry = Gtk.PasswordEntry()
+        entry.set_show_peek_icon(True)
+        entry.set_hexpand(True)
+        content.append(entry)
+
+        save_securely = Gtk.CheckButton(
+            label="Save API token securely in system wallet"
+        )
+        save_securely.set_active(self._authentication.securely_saved)
+        content.append(save_securely)
+
+        status = Gtk.Label(label="")
+        status.set_wrap(True)
+        status.set_xalign(0.0)
+        content.append(status)
+
+        buttons = Gtk.FlowBox()
+        buttons.set_selection_mode(Gtk.SelectionMode.NONE)
+        for label, handler in (
+            (
+                "Save or replace token",
+                lambda *_args: self._auth_save(
+                    entry,
+                    save_securely,
+                    status,
+                ),
+            ),
+            (
+                "Test authentication",
+                lambda *_args: self._auth_test(entry, status),
+            ),
+            (
+                "Copy saved token",
+                lambda *_args: self._auth_copy(status),
+            ),
+            (
+                "Reveal saved token",
+                lambda *_args: self._auth_reveal(entry, status),
+            ),
+            (
+                "Clear saved token",
+                lambda *_args: self._auth_clear(entry, status),
+            ),
+            ("Close", lambda *_args: window.close()),
+        ):
+            button = Gtk.Button(label=label)
+            button.connect("clicked", handler)
+            buttons.insert(button, -1)
+        content.append(buttons)
+        window.set_child(content)
+
+        def closed(*_args):
+            entry.set_text("")
+            self._auth_window = None
+            return False
+
+        window.connect("close-request", closed)
+        self._auth_window = window
+        window.present()
+
+    def _auth_save(self, entry, save_securely, status) -> None:
+        token = entry.get_text()
+        entry.set_text("")
+        try:
+            result = self._authentication.save_or_replace(
+                token,
+                save_securely=save_securely.get_active() is True,
+            )
+        except Exception:
+            status.set_text("The API token could not be saved.")
+            return
+        finally:
+            token = ""
+        status.set_text(result.message)
+        save_securely.set_active(result.securely_saved)
+        self.refresh_async()
+
+    def _auth_test(self, entry, status) -> None:
+        token = entry.get_text()
+        entry.set_text("")
+        try:
+            result = self._authentication.test_authentication(
+                explicit_token=token or None
+            )
+        except Exception:
+            status.set_text("Authentication could not be tested safely.")
+            return
+        finally:
+            token = ""
+        messages = {
+            FirstRunState.TOKEN_ACCEPTED: "Authentication succeeded.",
+            FirstRunState.TOKEN_REJECTED: "Authentication was rejected.",
+            FirstRunState.DAEMON_UNREACHABLE: "The local daemon is unavailable.",
+            FirstRunState.DAEMON_TOKEN_MISSING: (
+                "The daemon has no configured API token."
+            ),
+            FirstRunState.DAEMON_REACHABLE_UNPAIRED: "Enter an API token first.",
+            FirstRunState.INVALID_RESPONSE: (
+                "The daemon returned an unsupported response."
+            ),
+        }
+        status.set_text(messages[result.state])
+        self.refresh_async()
+
+    def _auth_copy(self, status) -> None:
+        token = self._authentication.copy_token()
+        if not token:
+            status.set_text("No saved API token is available.")
+            return
+        try:
+            display = self._Gdk.Display.get_default()
+            if display is None:
+                raise RuntimeError
+            display.get_clipboard().set(token)
+            status.set_text("API token copied to the clipboard.")
+        except Exception:
+            status.set_text("The API token could not be copied.")
+        finally:
+            token = ""
+
+    def _auth_reveal(self, entry, status) -> None:
+        token = self._authentication.reveal_token()
+        if not token:
+            status.set_text("No saved API token is available.")
+            return
+        entry.set_text(token)
+        status.set_text("API token revealed by explicit request.")
+        token = ""
+
+    def _auth_clear(self, entry, status) -> None:
+        entry.set_text("")
+        result = self._authentication.clear()
+        status.set_text(result.message)
+        self.refresh_async()
+
+    def dispatch_action(self, action: str) -> None:
+        state = self._controls.state
+        if action == "show":
+            self.show()
+        elif action == "hide":
+            self.hide()
+        elif action == "start":
+            self._run_worker(
+                lambda: self._controls.perform("start"),
+                pending_action="start",
+            )
+        elif action == "stop":
+            self._run_worker(
+                lambda: self._controls.perform("stop"),
+                pending_action="stop",
+            )
+        elif action == "restart":
+            self._run_worker(
+                lambda: self._controls.perform("restart"),
+                pending_action="restart",
+            )
+        elif action == "repair":
+            self._run_worker(
+                lambda: self._controls.perform("repair"),
+                pending_action="repair",
+            )
+        elif action == "refresh":
+            self.refresh_async()
+        elif action == "share_internet":
+            self._run_worker(
+                lambda: self._controls.perform(
+                    "share_internet",
+                    enabled=not bool(state.share_internet),
+                ),
+                pending_action="share_internet",
+            )
+        elif action == "privacy":
+            self._controls.set_privacy_mode(not state.privacy_mode)
+            self._update_menu()
+        elif action == "hotspot_autostart":
+            self._run_worker(
+                lambda: self._controls.perform(
+                    "hotspot_autostart",
+                    enabled=not bool(state.hotspot_autostart),
+                ),
+                pending_action="hotspot_autostart",
+            )
+        elif action == "authentication":
+            self._open_authentication()
+        elif action == "diagnostics":
+            self._open_diagnostics()
+        elif action == "web_portal":
+            self._open_web_portal()
+        elif action == "quit":
+            self._backend.stop()
+            self._lifecycle.quit_companion()

--- a/flatpak_client/__init__.py
+++ b/flatpak_client/__init__.py
@@ -42,6 +42,23 @@ from .ui import (
     SummaryFact,
     SupportBundleAffordance,
 )
+from .wallet import (
+    SECRET_ATTRIBUTES,
+    SECRET_LABEL,
+    SECRET_SCHEMA_NAME,
+    AuthenticationController,
+    AuthenticationResult,
+    SecretServiceWalletBackend,
+    WalletBackend,
+    WalletUnavailableError,
+)
+from .control import (
+    ActionOutcome,
+    TokenProvider,
+    TrayControlController,
+    TrayState,
+    TrayStatus,
+)
 
 __all__ = [
     "DEFAULT_BASE_URL",
@@ -80,4 +97,17 @@ __all__ = [
     "StatusSeverity",
     "SummaryFact",
     "SupportBundleAffordance",
+    "SECRET_ATTRIBUTES",
+    "SECRET_LABEL",
+    "SECRET_SCHEMA_NAME",
+    "AuthenticationController",
+    "AuthenticationResult",
+    "SecretServiceWalletBackend",
+    "WalletBackend",
+    "WalletUnavailableError",
+    "ActionOutcome",
+    "TokenProvider",
+    "TrayControlController",
+    "TrayState",
+    "TrayStatus",
 ]

--- a/flatpak_client/client.py
+++ b/flatpak_client/client.py
@@ -1,4 +1,4 @@
-"""Small, read-only HTTP client for the local VRhotspot daemon API."""
+"""Small, explicit HTTP client for the local VRhotspot daemon API."""
 
 from __future__ import annotations
 
@@ -22,8 +22,16 @@ import uuid
 DEFAULT_BASE_URL = "http://127.0.0.1:8732"
 
 _HEALTH_PATH = "/healthz"
+_STATUS_PATH = "/v1/status"
+_STATUS_WITH_LOGS_PATH = "/v1/status?include_logs=1"
+_CONFIG_PATH = "/v1/config"
 _PREFLIGHT_PATH = "/v1/diagnostics/preflight"
 _ADAPTER_READINESS_PATH = "/v1/adapters/readiness"
+_START_PATH = "/v1/start"
+_STOP_PATH = "/v1/stop"
+_RESTART_PATH = "/v1/restart"
+_REPAIR_PATH = "/v1/repair"
+_AUTOSTART_PATH = "/v1/autostart"
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 _MAX_RESPONSE_BYTES = 1_000_000
 _MAX_ERROR_BODY_BYTES = 4_096
@@ -105,12 +113,13 @@ class ResponseTooLargeError(LocalApiClientError):
 
 @dataclass(frozen=True, repr=False)
 class HttpRequest:
-    """A GET request passed to the injectable transport."""
+    """A bounded request passed to the injectable transport."""
 
     url: str
     method: str
     headers: Mapping[str, str]
     timeout: float
+    body: bytes = b""
 
     def __repr__(self) -> str:
         safe_headers = {
@@ -120,7 +129,8 @@ class HttpRequest:
         return (
             "HttpRequest("
             f"url={self.url!r}, method={self.method!r}, "
-            f"headers={safe_headers!r}, timeout={self.timeout!r})"
+            f"headers={safe_headers!r}, timeout={self.timeout!r}, "
+            f"body_bytes={len(self.body)!r})"
         )
 
 
@@ -144,7 +154,7 @@ class HttpResponse:
 
 @dataclass(frozen=True, repr=False)
 class ApiResponse:
-    """The validated daemon envelope returned by a read-only JSON method."""
+    """The validated daemon envelope returned by a reviewed JSON method."""
 
     correlation_id: str
     result_code: str
@@ -208,6 +218,7 @@ class UrlLibTransport:
     def send(self, request: HttpRequest) -> HttpResponse:
         urllib_request = Request(
             request.url,
+            data=request.body or None,
             headers=dict(request.headers),
             method=request.method,
         )
@@ -321,7 +332,7 @@ def _contains_secret(value: Any, secret: str) -> bool:
 
 
 class LocalApiClient:
-    """GET-only client for the future unprivileged Flatpak control app."""
+    """Loopback-only client with explicit methods for reviewed daemon routes."""
 
     def __init__(
         self,
@@ -378,25 +389,154 @@ class LocalApiClient:
 
         return self._get_api_response(_ADAPTER_READINESS_PATH)
 
+    def status(self, *, include_logs: bool = False) -> ApiResponse:
+        """Fetch current daemon-owned hotspot state with an explicit log choice."""
+
+        if type(include_logs) is not bool:
+            raise LocalApiClientError("Status log selection requires a boolean.")
+        return self._get_api_response(
+            _STATUS_WITH_LOGS_PATH if include_logs else _STATUS_PATH
+        )
+
+    def config(self) -> ApiResponse:
+        """Fetch the redacted daemon configuration view."""
+
+        return self._get_api_response(_CONFIG_PATH)
+
+    def start_hotspot(self) -> ApiResponse:
+        """Request hotspot start through the authenticated daemon."""
+
+        return self._request_api_response(
+            _START_PATH,
+            method="POST",
+            body={},
+            accepted_result_codes={
+                "already_running",
+                "started",
+                "started_with_fallback",
+            },
+        )
+
+    def stop_hotspot(self) -> ApiResponse:
+        """Request hotspot stop through the authenticated daemon."""
+
+        return self._request_api_response(
+            _STOP_PATH,
+            method="POST",
+            body={},
+            accepted_result_codes={"already_stopped", "stopped"},
+        )
+
+    def restart_service(self) -> ApiResponse:
+        """Request the existing stop/repair/start restart workflow."""
+
+        return self._request_api_response(
+            _RESTART_PATH,
+            method="POST",
+            body={},
+            accepted_result_prefixes=("restarted:",),
+        )
+
+    def repair_network(self) -> ApiResponse:
+        """Request the existing daemon-owned network repair workflow."""
+
+        return self._request_api_response(
+            _REPAIR_PATH,
+            method="POST",
+            body={},
+            accepted_result_codes={"repaired"},
+        )
+
+    def set_share_internet(self, enabled: bool) -> ApiResponse:
+        """Update only the canonical enable_internet setting."""
+
+        if type(enabled) is not bool:
+            raise LocalApiClientError(
+                "Share Internet Connection requires a boolean value."
+            )
+        return self._request_api_response(
+            _CONFIG_PATH,
+            method="POST",
+            body={"config": {"enable_internet": enabled}},
+            accepted_result_codes={"config_saved"},
+        )
+
+    def set_hotspot_autostart(self, enabled: bool) -> ApiResponse:
+        """Synchronize the canonical hotspot-at-boot setting through the daemon."""
+
+        if type(enabled) is not bool:
+            raise LocalApiClientError(
+                "Start Hotspot Automatically requires a boolean value."
+            )
+        return self._request_api_response(
+            _AUTOSTART_PATH,
+            method="POST",
+            body={"enabled": enabled},
+            accepted_result_codes={
+                "autostart_disabled",
+                "autostart_enabled",
+            },
+        )
+
     def _get_api_response(self, path: str) -> ApiResponse:
-        response = self._get(path, authenticated=True)
+        return self._request_api_response(path, method="GET")
+
+    def _request_api_response(
+        self,
+        path: str,
+        *,
+        method: str,
+        body: Mapping[str, Any] | None = None,
+        accepted_result_codes: set[str] | None = None,
+        accepted_result_prefixes: tuple[str, ...] = (),
+    ) -> ApiResponse:
+        response = self._request(
+            path,
+            method=method,
+            authenticated=True,
+            body=body,
+        )
         self._raise_for_status(response)
         self._ensure_success_body_is_bounded(response)
-        return self._parse_envelope(response.body)
+        return self._parse_envelope(
+            response.body,
+            accepted_result_codes=accepted_result_codes or {"ok"},
+            accepted_result_prefixes=accepted_result_prefixes,
+        )
 
     def _get(self, path: str, *, authenticated: bool) -> HttpResponse:
+        return self._request(path, method="GET", authenticated=authenticated)
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str,
+        authenticated: bool,
+        body: Mapping[str, Any] | None = None,
+    ) -> HttpResponse:
         headers = {
             "Accept": "application/json",
-            "User-Agent": "vrhotspot-flatpak-client-prototype",
+            "User-Agent": "vrhotspot-flatpak-client",
             "X-Correlation-Id": f"flatpak-client-{uuid.uuid4()}",
         }
         if authenticated and self._token:
             headers["X-Api-Token"] = self._token
+        request_body = b""
+        if body is not None:
+            request_body = json.dumps(
+                dict(body),
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            headers["Content-Type"] = "application/json"
         request = HttpRequest(
             url=self._base_url + path,
-            method="GET",
+            method=method,
             headers=headers,
             timeout=self._timeout,
+            body=request_body,
         )
 
         connection_error: Optional[ConnectionFailure] = None
@@ -455,7 +595,13 @@ class LocalApiClient:
                 "The local daemon API response exceeded the client size limit."
             )
 
-    def _parse_envelope(self, body: bytes) -> ApiResponse:
+    def _parse_envelope(
+        self,
+        body: bytes,
+        *,
+        accepted_result_codes: set[str],
+        accepted_result_prefixes: tuple[str, ...],
+    ) -> ApiResponse:
         try:
             payload = json.loads(body.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
@@ -486,7 +632,10 @@ class LocalApiClient:
             raise InvalidResponseError(
                 "The local daemon API returned an invalid response envelope."
             )
-        if result_code != "ok":
+        accepted = result_code in accepted_result_codes or any(
+            result_code.startswith(prefix) for prefix in accepted_result_prefixes
+        )
+        if not accepted:
             safe_result_code = self._safe_text(result_code)
             raise DaemonApiError(
                 f"The local daemon API returned result_code={safe_result_code}.",

--- a/flatpak_client/control.py
+++ b/flatpak_client/control.py
@@ -1,0 +1,417 @@
+"""Testable tray state and daemon control logic without desktop imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+import threading
+from typing import Protocol
+
+from .client import (
+    ApiResponse,
+    AuthenticationError,
+    ConnectionFailure,
+    DaemonTokenMissingError,
+    LocalApiClient,
+    LocalApiClientError,
+)
+
+
+class TrayStatus(str, Enum):
+    RUNNING = "running"
+    STOPPED = "stopped"
+    TRANSITIONING = "transitioning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class TrayState:
+    """Bounded, token-free state consumed by any tray backend."""
+
+    status: TrayStatus = TrayStatus.ERROR
+    status_label: str = "Error"
+    phase: str = "unknown"
+    running: bool = False
+    daemon_available: bool = False
+    authenticated: bool = False
+    busy_action: str | None = None
+    share_internet: bool | None = None
+    privacy_mode: bool = True
+    hotspot_autostart: bool | None = None
+    message: str = "Authentication is required."
+    detail_code: str = "token_missing"
+
+
+@dataclass(frozen=True)
+class ActionOutcome:
+    """Fixed, secret-free result for one tray action."""
+
+    accepted: bool
+    succeeded: bool
+    code: str
+    message: str
+    state: TrayState
+
+
+class TokenProvider(Protocol):
+    def token_for_operation(self) -> str | None:
+        """Return an explicitly entered or previously saved token."""
+
+
+class TrayControlController:
+    """Serialize tray actions and project daemon responses into safe state."""
+
+    def __init__(
+        self,
+        token_provider: TokenProvider,
+        *,
+        client_factory=LocalApiClient,
+    ):
+        self._token_provider = token_provider
+        self._client_factory = client_factory
+        self._state = TrayState()
+        self._state_lock = threading.Lock()
+        self._operation_lock = threading.Lock()
+
+    def __repr__(self) -> str:
+        return (
+            "TrayControlController("
+            f"status={self.state.status.value!r}, "
+            f"busy={self.state.busy_action is not None!r})"
+        )
+
+    @property
+    def state(self) -> TrayState:
+        with self._state_lock:
+            return self._state
+
+    def _set_state(self, state: TrayState) -> TrayState:
+        with self._state_lock:
+            self._state = state
+            return state
+
+    def _error_state(
+        self,
+        *,
+        message: str,
+        detail_code: str,
+        daemon_available: bool,
+        authenticated: bool = False,
+    ) -> TrayState:
+        current = self.state
+        return TrayState(
+            status=TrayStatus.ERROR,
+            status_label="Error",
+            phase="error",
+            daemon_available=daemon_available,
+            authenticated=authenticated,
+            privacy_mode=current.privacy_mode,
+            message=message,
+            detail_code=detail_code,
+        )
+
+    def _client(self):
+        token = self._token_provider.token_for_operation()
+        if not token:
+            return None
+        try:
+            return self._client_factory(token=token)
+        except Exception:
+            return None
+
+    def _state_from_responses(
+        self,
+        status_response: ApiResponse,
+        config_response: ApiResponse,
+    ) -> TrayState:
+        status_data = status_response.data
+        config_data = config_response.data
+        phase_value = status_data.get("phase")
+        phase = phase_value if isinstance(phase_value, str) else "unknown"
+        running = status_data.get("running") is True
+
+        if phase in {"starting", "stopping"}:
+            status = TrayStatus.TRANSITIONING
+            label = "Transitioning"
+        elif phase == "error":
+            status = TrayStatus.ERROR
+            label = "Error"
+        elif running or phase == "running":
+            status = TrayStatus.RUNNING
+            label = "Running"
+            running = True
+        elif phase == "stopped" or status_data.get("running") is False:
+            status = TrayStatus.STOPPED
+            label = "Stopped"
+            running = False
+        else:
+            status = TrayStatus.ERROR
+            label = "Error"
+
+        share_internet = config_data.get("enable_internet")
+        if type(share_internet) is not bool:
+            share_internet = None
+        hotspot_autostart = config_data.get("autostart")
+        if type(hotspot_autostart) is not bool:
+            hotspot_autostart = None
+
+        return TrayState(
+            status=status,
+            status_label=label,
+            phase=phase,
+            running=running,
+            daemon_available=True,
+            authenticated=True,
+            busy_action=None,
+            share_internet=share_internet,
+            privacy_mode=self.state.privacy_mode,
+            hotspot_autostart=hotspot_autostart,
+            message=f"Current status: {label}",
+            detail_code=status.value,
+        )
+
+    def _fetch_state(self, client) -> TrayState:
+        try:
+            status_response = client.status(
+                include_logs=not self.state.privacy_mode
+            )
+            config_response = client.config()
+            if not isinstance(status_response, ApiResponse) or not isinstance(
+                config_response, ApiResponse
+            ):
+                raise TypeError
+            return self._state_from_responses(status_response, config_response)
+        except AuthenticationError:
+            return self._error_state(
+                message="Authentication was rejected.",
+                detail_code="authentication_rejected",
+                daemon_available=True,
+            )
+        except DaemonTokenMissingError:
+            return self._error_state(
+                message="The daemon has no configured API token.",
+                detail_code="daemon_token_missing",
+                daemon_available=True,
+            )
+        except ConnectionFailure:
+            return self._error_state(
+                message="The local daemon is unavailable.",
+                detail_code="daemon_unavailable",
+                daemon_available=False,
+            )
+        except (LocalApiClientError, TypeError):
+            return self._error_state(
+                message="The daemon returned an unsupported response.",
+                detail_code="invalid_response",
+                daemon_available=True,
+            )
+        except Exception:
+            return self._error_state(
+                message="The tray operation failed safely.",
+                detail_code="operation_failed",
+                daemon_available=False,
+            )
+
+    def refresh(self) -> TrayState:
+        if not self._operation_lock.acquire(blocking=False):
+            return self.state
+        try:
+            client = self._client()
+            if client is None:
+                return self._set_state(
+                    self._error_state(
+                        message="Enter the daemon API token in Authentication.",
+                        detail_code="token_missing",
+                        daemon_available=False,
+                    )
+                )
+            return self._set_state(self._fetch_state(client))
+        finally:
+            self._operation_lock.release()
+
+    def _working_state(self, action: str) -> TrayState:
+        current = self.state
+        return replace(
+            current,
+            status=TrayStatus.TRANSITIONING,
+            status_label="Transitioning",
+            phase="working",
+            busy_action=action,
+            message="Operation in progress.",
+            detail_code="operation_in_progress",
+        )
+
+    def mark_operation_pending(self, action: str) -> TrayState:
+        """Expose transitioning state as soon as the desktop queues an action."""
+
+        if not isinstance(action, str) or not action:
+            return self.state
+        return self._set_state(self._working_state(action))
+
+    def perform(self, action: str, *, enabled: bool | None = None) -> ActionOutcome:
+        if not self._operation_lock.acquire(blocking=False):
+            state = self.state
+            return ActionOutcome(
+                accepted=False,
+                succeeded=False,
+                code="operation_in_progress",
+                message="Another operation is already in progress.",
+                state=state,
+            )
+
+        self._set_state(self._working_state(action))
+        try:
+            client = self._client()
+            if client is None:
+                state = self._set_state(
+                    self._error_state(
+                        message="Enter the daemon API token in Authentication.",
+                        detail_code="token_missing",
+                        daemon_available=False,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="token_missing",
+                    message=state.message,
+                    state=state,
+                )
+
+            calls = {
+                "start": client.start_hotspot,
+                "stop": client.stop_hotspot,
+                "restart": client.restart_service,
+                "repair": client.repair_network,
+            }
+            response = None
+            try:
+                if action == "share_internet":
+                    if type(enabled) is not bool:
+                        raise LocalApiClientError(
+                            "Share Internet Connection requires a boolean value."
+                        )
+                    response = client.set_share_internet(enabled)
+                elif action == "hotspot_autostart":
+                    if type(enabled) is not bool:
+                        raise LocalApiClientError(
+                            "Start Hotspot Automatically requires a boolean value."
+                        )
+                    response = client.set_hotspot_autostart(enabled)
+                else:
+                    call = calls.get(action)
+                    if call is None:
+                        raise LocalApiClientError("Unsupported tray action.")
+                    response = call()
+            except AuthenticationError:
+                state = self._set_state(
+                    self._error_state(
+                        message="Authentication was rejected.",
+                        detail_code="authentication_rejected",
+                        daemon_available=True,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="authentication_rejected",
+                    message=state.message,
+                    state=state,
+                )
+            except DaemonTokenMissingError:
+                state = self._set_state(
+                    self._error_state(
+                        message="The daemon has no configured API token.",
+                        detail_code="daemon_token_missing",
+                        daemon_available=True,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="daemon_token_missing",
+                    message=state.message,
+                    state=state,
+                )
+            except ConnectionFailure:
+                state = self._set_state(
+                    self._error_state(
+                        message="The local daemon is unavailable.",
+                        detail_code="daemon_unavailable",
+                        daemon_available=False,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="daemon_unavailable",
+                    message=state.message,
+                    state=state,
+                )
+            except Exception:
+                state = self._set_state(
+                    self._error_state(
+                        message="The requested operation failed.",
+                        detail_code="operation_failed",
+                        daemon_available=True,
+                        authenticated=True,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="operation_failed",
+                    message=state.message,
+                    state=state,
+                )
+
+            state = self._set_state(self._fetch_state(client))
+            messages = {
+                "start": ("hotspot_started", "Hotspot started."),
+                "stop": ("hotspot_stopped", "Hotspot stopped."),
+                "restart": ("service_restarted", "Hotspot service restarted."),
+                "repair": ("network_repaired", "Network repair completed."),
+                "share_internet": (
+                    "share_internet_updated",
+                    "Share Internet Connection setting updated.",
+                ),
+                "hotspot_autostart": (
+                    "hotspot_autostart_updated",
+                    "Start Hotspot Automatically setting updated.",
+                ),
+            }
+            code, message = messages[action]
+            if (
+                action == "start"
+                and isinstance(response, ApiResponse)
+                and response.result_code == "already_running"
+            ):
+                code, message = (
+                    "hotspot_already_running",
+                    "The hotspot was already running.",
+                )
+            elif (
+                action == "stop"
+                and isinstance(response, ApiResponse)
+                and response.result_code == "already_stopped"
+            ):
+                code, message = (
+                    "hotspot_already_stopped",
+                    "The hotspot was already stopped.",
+                )
+            return ActionOutcome(
+                accepted=True,
+                succeeded=True,
+                code=code,
+                message=message,
+                state=state,
+            )
+        finally:
+            self._operation_lock.release()
+
+    def set_privacy_mode(self, enabled: bool) -> TrayState:
+        if type(enabled) is not bool:
+            return self.state
+        with self._state_lock:
+            self._state = replace(self._state, privacy_mode=enabled)
+            return self._state

--- a/flatpak_client/wallet.py
+++ b/flatpak_client/wallet.py
@@ -1,0 +1,316 @@
+"""Explicit in-memory and Secret Service storage for the daemon API token."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .client import LocalApiClient, LocalApiClientError
+from .pairing import FirstRunResult, FirstRunState, TokenPairingController
+
+
+SECRET_SCHEMA_NAME = "io.github.josethevrtech.VRhotspot.ApiToken"
+SECRET_LABEL = "VR Hotspot daemon API token"
+SECRET_ATTRIBUTES = {
+    "application": "io.github.josethevrtech.VRhotspot",
+    "credential": "daemon-api-token",
+}
+
+
+class WalletUnavailableError(RuntimeError):
+    """The desktop has no usable Secret Service provider."""
+
+    def __init__(self):
+        super().__init__("Secure wallet storage is unavailable.")
+
+
+class WalletBackend(Protocol):
+    """Narrow wallet contract used by the authentication controller."""
+
+    def available(self) -> bool:
+        """Return whether a Secret Service provider can be reached."""
+
+    def load(self) -> str | None:
+        """Load only VR Hotspot's saved daemon token."""
+
+    def store(self, token: str) -> None:
+        """Save or replace only VR Hotspot's daemon token."""
+
+    def clear(self) -> bool:
+        """Remove only VR Hotspot's daemon token."""
+
+
+class SecretServiceWalletBackend:
+    """Lazy libsecret backend using one stable app-specific schema."""
+
+    def __init__(self):
+        self._secret = None
+        self._schema = None
+
+    def __repr__(self) -> str:
+        return "SecretServiceWalletBackend(schema=app-specific, token_stored=False)"
+
+    def _load(self):
+        if self._secret is not None and self._schema is not None:
+            return self._secret, self._schema
+        try:
+            import gi
+
+            gi.require_version("Secret", "1")
+            from gi.repository import Secret
+
+            schema = Secret.Schema.new(
+                SECRET_SCHEMA_NAME,
+                Secret.SchemaFlags.NONE,
+                {
+                    "application": Secret.SchemaAttributeType.STRING,
+                    "credential": Secret.SchemaAttributeType.STRING,
+                },
+            )
+        except Exception:
+            raise WalletUnavailableError() from None
+        self._secret = Secret
+        self._schema = schema
+        return Secret, schema
+
+    def available(self) -> bool:
+        try:
+            Secret, _schema = self._load()
+            service = Secret.Service.get_sync(
+                Secret.ServiceFlags.OPEN_SESSION,
+                None,
+            )
+            return service is not None
+        except Exception:
+            return False
+
+    def load(self) -> str | None:
+        try:
+            Secret, schema = self._load()
+            value = Secret.password_lookup_sync(
+                schema,
+                dict(SECRET_ATTRIBUTES),
+                None,
+            )
+        except Exception:
+            raise WalletUnavailableError() from None
+        return value if isinstance(value, str) and value else None
+
+    def store(self, token: str) -> None:
+        try:
+            Secret, schema = self._load()
+            stored = Secret.password_store_sync(
+                schema,
+                dict(SECRET_ATTRIBUTES),
+                Secret.COLLECTION_DEFAULT,
+                SECRET_LABEL,
+                token,
+                None,
+            )
+        except Exception:
+            raise WalletUnavailableError() from None
+        if stored is not True:
+            raise WalletUnavailableError()
+
+    def clear(self) -> bool:
+        try:
+            Secret, schema = self._load()
+            return bool(
+                Secret.password_clear_sync(
+                    schema,
+                    dict(SECRET_ATTRIBUTES),
+                    None,
+                )
+            )
+        except Exception:
+            raise WalletUnavailableError() from None
+
+
+@dataclass(frozen=True)
+class AuthenticationResult:
+    """Token-free result for authentication dialog actions."""
+
+    code: str
+    message: str
+    token_available: bool
+    securely_saved: bool
+
+
+class AuthenticationController:
+    """Own one session token and optional explicit Secret Service persistence."""
+
+    def __init__(
+        self,
+        *,
+        wallet: WalletBackend | None = None,
+        client_factory=LocalApiClient,
+    ):
+        self._wallet = wallet if wallet is not None else SecretServiceWalletBackend()
+        self._client_factory = client_factory
+        self._memory_token = ""
+        self._securely_saved = False
+
+    def __repr__(self) -> str:
+        return (
+            "AuthenticationController("
+            f"token_available={bool(self._memory_token)!r}, "
+            f"securely_saved={self._securely_saved!r})"
+        )
+
+    @property
+    def securely_saved(self) -> bool:
+        return self._securely_saved
+
+    def wallet_available(self) -> bool:
+        try:
+            return self._wallet.available() is True
+        except Exception:
+            return False
+
+    def save_or_replace(
+        self,
+        token: str,
+        *,
+        save_securely: bool,
+    ) -> AuthenticationResult:
+        try:
+            self._client_factory(token=token)
+        except LocalApiClientError:
+            return AuthenticationResult(
+                code="invalid_token",
+                message="Enter a non-empty API token using supported characters.",
+                token_available=bool(self._memory_token),
+                securely_saved=self._securely_saved,
+            )
+        except Exception:
+            return AuthenticationResult(
+                code="invalid_token",
+                message="The API token could not be accepted.",
+                token_available=bool(self._memory_token),
+                securely_saved=self._securely_saved,
+            )
+        if not token:
+            return AuthenticationResult(
+                code="invalid_token",
+                message="Enter the daemon API token.",
+                token_available=bool(self._memory_token),
+                securely_saved=self._securely_saved,
+            )
+
+        self._memory_token = token
+        if not save_securely:
+            try:
+                self._wallet.clear()
+            except Exception:
+                self._securely_saved = False
+                return AuthenticationResult(
+                    code="saved_in_memory_wallet_unavailable",
+                    message=(
+                        "The API token is retained in memory for this session. "
+                        "Secure wallet storage was unavailable, so an older "
+                        "VR Hotspot wallet entry could not be checked or removed."
+                    ),
+                    token_available=True,
+                    securely_saved=False,
+                )
+            self._securely_saved = False
+            return AuthenticationResult(
+                code="saved_in_memory",
+                message="API token retained in memory for this session only.",
+                token_available=True,
+                securely_saved=False,
+            )
+
+        try:
+            self._wallet.store(token)
+        except Exception:
+            self._securely_saved = False
+            return AuthenticationResult(
+                code="wallet_unavailable",
+                message=(
+                    "Secure wallet persistence is unavailable; the API token "
+                    "is retained in memory for this session only."
+                ),
+                token_available=True,
+                securely_saved=False,
+            )
+
+        self._securely_saved = True
+        return AuthenticationResult(
+            code="saved_securely",
+            message="API token saved securely in the system wallet.",
+            token_available=True,
+            securely_saved=True,
+        )
+
+    def token_for_operation(self) -> str | None:
+        if self._memory_token:
+            return self._memory_token
+        try:
+            token = self._wallet.load()
+        except Exception:
+            self._securely_saved = False
+            return None
+        if not token:
+            self._securely_saved = False
+            return None
+        try:
+            self._client_factory(token=token)
+        except Exception:
+            return None
+        self._memory_token = token
+        self._securely_saved = True
+        return token
+
+    def test_authentication(
+        self,
+        *,
+        explicit_token: str | None = None,
+    ) -> FirstRunResult:
+        token = (
+            explicit_token
+            if isinstance(explicit_token, str) and explicit_token
+            else self.token_for_operation()
+        )
+        return TokenPairingController(self._client_factory).evaluate(token=token)
+
+    def reveal_token(self) -> str | None:
+        """Return the current token only for an explicit reveal action."""
+
+        return self.token_for_operation()
+
+    def copy_token(self) -> str | None:
+        """Return the current token only for an explicit copy action."""
+
+        return self.token_for_operation()
+
+    def clear(self) -> AuthenticationResult:
+        self._memory_token = ""
+        removed = False
+        try:
+            removed = self._wallet.clear()
+        except Exception:
+            self._securely_saved = False
+            return AuthenticationResult(
+                code="cleared_memory_wallet_unavailable",
+                message=(
+                    "The in-memory token was cleared. Secure wallet storage "
+                    "was unavailable."
+                ),
+                token_available=False,
+                securely_saved=False,
+            )
+        self._securely_saved = False
+        return AuthenticationResult(
+            code="cleared",
+            message=(
+                "VR Hotspot's saved API token was cleared."
+                if removed
+                else "No saved VR Hotspot API token was present."
+            ),
+            token_available=False,
+            securely_saved=False,
+        )
+
+    def authentication_state(self) -> FirstRunState:
+        return self.test_authentication().state

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot-error.svg
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot-error.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="4" y="4" width="120" height="120" rx="27" fill="#05070a" stroke="#00eaff" stroke-width="5"/>
+  <path d="M22 34 42 91 62 34M69 91V35h20c12 0 18 7 18 17s-6 17-18 17H70m18 0 20 22" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+  <circle cx="105" cy="103" r="17" fill="#05070a" stroke="#ff0055" stroke-width="5"/>
+  <path d="M105 93v12" stroke="#ff0055" stroke-linecap="round" stroke-width="5"/>
+  <circle cx="105" cy="111" r="2.8" fill="#ff0055"/>
+</svg>

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot-running.svg
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot-running.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="4" y="4" width="120" height="120" rx="27" fill="#05070a" stroke="#00eaff" stroke-width="5"/>
+  <path d="M22 34 42 91 62 34M69 91V35h20c12 0 18 7 18 17s-6 17-18 17H70m18 0 20 22" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+  <circle cx="105" cy="103" r="17" fill="#05070a" stroke="#00ff9d" stroke-width="5"/>
+  <circle cx="105" cy="103" r="7" fill="#00ff9d"/>
+</svg>

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot-working.svg
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot-working.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="4" y="4" width="120" height="120" rx="27" fill="#05070a" stroke="#00eaff" stroke-width="5"/>
+  <path d="M22 34 42 91 62 34M69 91V35h20c12 0 18 7 18 17s-6 17-18 17H70m18 0 20 22" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+  <circle cx="105" cy="103" r="17" fill="#05070a" stroke="#ffee00" stroke-width="5"/>
+  <path d="M96 103h18M105 94v18" stroke="#ffee00" stroke-linecap="round" stroke-width="5"/>
+</svg>

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.desktop
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
 Name=VR Hotspot
-Comment=Launch the VR Hotspot Flatpak shell prototype
-Exec=vrhotspot-flatpak
+Comment=Control VR Hotspot from the desktop and system tray
+Exec=vrhotspot-flatpak --tray
 Icon=io.github.josethevrtech.VRhotspot
 Terminal=false
 Categories=Network;

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.json
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.json
@@ -8,7 +8,9 @@
     "--share=network",
     "--share=ipc",
     "--socket=wayland",
-    "--socket=fallback-x11"
+    "--socket=fallback-x11",
+    "--talk-name=org.kde.StatusNotifierWatcher",
+    "--talk-name=org.freedesktop.secrets"
   ],
   "modules": [
     {
@@ -16,12 +18,15 @@
       "buildsystem": "simple",
       "build-commands": [
         "install -d /app/lib/vrhotspot/flatpak_app /app/lib/vrhotspot/flatpak_client",
-        "install -m 0644 flatpak_app/__init__.py flatpak_app/__main__.py flatpak_app/app.py /app/lib/vrhotspot/flatpak_app/",
-        "install -m 0644 flatpak_client/__init__.py flatpak_client/client.py flatpak_client/pairing.py flatpak_client/ui.py /app/lib/vrhotspot/flatpak_client/",
+        "install -m 0644 flatpak_app/__init__.py flatpak_app/__main__.py flatpak_app/app.py flatpak_app/tray.py /app/lib/vrhotspot/flatpak_app/",
+        "install -m 0644 flatpak_client/__init__.py flatpak_client/client.py flatpak_client/control.py flatpak_client/pairing.py flatpak_client/ui.py flatpak_client/wallet.py /app/lib/vrhotspot/flatpak_client/",
         "install -Dm755 vrhotspot-flatpak /app/bin/vrhotspot-flatpak",
         "install -Dm644 io.github.josethevrtech.VRhotspot.desktop /app/share/applications/io.github.josethevrtech.VRhotspot.desktop",
         "install -Dm644 io.github.josethevrtech.VRhotspot.metainfo.xml /app/share/metainfo/io.github.josethevrtech.VRhotspot.metainfo.xml",
-        "install -Dm644 io.github.josethevrtech.VRhotspot.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot.svg"
+        "install -Dm644 io.github.josethevrtech.VRhotspot.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot.svg",
+        "install -Dm644 io.github.josethevrtech.VRhotspot-running.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot-running.svg",
+        "install -Dm644 io.github.josethevrtech.VRhotspot-working.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot-working.svg",
+        "install -Dm644 io.github.josethevrtech.VRhotspot-error.svg /app/share/icons/hicolor/scalable/apps/io.github.josethevrtech.VRhotspot-error.svg"
       ],
       "sources": [
         {
@@ -41,6 +46,11 @@
         },
         {
           "type": "file",
+          "path": "../../flatpak_app/tray.py",
+          "dest": "flatpak_app"
+        },
+        {
+          "type": "file",
           "path": "../../flatpak_client/__init__.py",
           "dest": "flatpak_client"
         },
@@ -51,12 +61,22 @@
         },
         {
           "type": "file",
+          "path": "../../flatpak_client/control.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
           "path": "../../flatpak_client/pairing.py",
           "dest": "flatpak_client"
         },
         {
           "type": "file",
           "path": "../../flatpak_client/ui.py",
+          "dest": "flatpak_client"
+        },
+        {
+          "type": "file",
+          "path": "../../flatpak_client/wallet.py",
           "dest": "flatpak_client"
         },
         {
@@ -74,6 +94,18 @@
         {
           "type": "file",
           "path": "io.github.josethevrtech.VRhotspot.svg"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot-running.svg"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot-working.svg"
+        },
+        {
+          "type": "file",
+          "path": "io.github.josethevrtech.VRhotspot-error.svg"
         }
       ]
     }

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.metainfo.xml
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.github.josethevrtech.VRhotspot</id>
   <name>VR Hotspot</name>
-  <summary>Prototype control shell for a host-installed VRhotspot daemon</summary>
+  <summary>Desktop and tray controls for a host-installed VRhotspot daemon</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
   <developer id="io.github.josethevrtech">
@@ -10,9 +10,9 @@
   </developer>
   <description>
     <p>
-      VR Hotspot is an early Flatpak app shell for the separately installed
-      VRhotspot daemon. This prototype launches an offline, unpaired status
-      window and does not provide hotspot lifecycle or configuration controls.
+      VR Hotspot is a desktop companion for the separately installed VRhotspot
+      daemon. It provides a persistent system-tray status icon, basic hotspot
+      controls, and optional secure API-token storage.
     </p>
     <p>
       The privileged daemon and its host installer remain separate from this
@@ -23,9 +23,9 @@
   <launchable type="desktop-id">io.github.josethevrtech.VRhotspot.desktop</launchable>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="0.1.0" date="2026-07-23">
+    <release version="0.2.0" date="2026-07-24">
       <description>
-        <p>First rough installable and testable Flatpak shell prototype.</p>
+        <p>Added the functional system-tray control surface and wallet support.</p>
       </description>
     </release>
   </releases>

--- a/packaging/flatpak/io.github.josethevrtech.VRhotspot.svg
+++ b/packaging/flatpak/io.github.josethevrtech.VRhotspot.svg
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <defs>
-    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#6d4aff"/>
-      <stop offset="1" stop-color="#1466cc"/>
-    </linearGradient>
-  </defs>
-  <rect width="128" height="128" rx="28" fill="url(#background)"/>
-  <path
-    d="M30 50c19-18 49-18 68 0M40 63c13-12 35-12 48 0M52 76c7-6 17-6 24 0"
-    fill="none"
-    stroke="#fff"
-    stroke-linecap="round"
-    stroke-width="9"
-  />
-  <circle cx="64" cy="91" r="7" fill="#fff"/>
+  <rect x="4" y="4" width="120" height="120" rx="27" fill="#05070a" stroke="#00eaff" stroke-width="5"/>
+  <path d="M22 34 42 91 62 34" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-linejoin="round" stroke-width="11"/>
+  <path d="M69 91V35h20c12 0 18 7 18 17s-6 17-18 17H70m18 0 20 22" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-linejoin="round" stroke-width="10"/>
+  <path d="M88 22c8-7 20-7 28 0M94 29c5-4 12-4 17 0" fill="none" stroke="#00eaff" stroke-linecap="round" stroke-width="4"/>
 </svg>

--- a/tests/test_api_autostart.py
+++ b/tests/test_api_autostart.py
@@ -1,0 +1,286 @@
+import io
+import json
+from email.message import Message
+from types import SimpleNamespace
+
+import pytest
+
+from vr_hotspotd import api
+from vr_hotspotd import autostart
+from vr_hotspotd.autostart import (
+    AUTOSTART_ROLLBACK_FAILED,
+    AUTOSTART_UNIT,
+    AutostartControlError,
+    set_hotspot_autostart,
+)
+
+
+def _handler(body):
+    raw = json.dumps(body).encode("utf-8")
+    handler = api.APIHandler.__new__(api.APIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    headers = Message()
+    headers["Content-Length"] = str(len(raw))
+    headers["X-Api-Token"] = "configured-token"
+    handler.headers = headers
+    handler.command = "POST"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = "POST /v1/autostart HTTP/1.1"
+    handler.path = "/v1/autostart"
+    handler._last_code = None
+    handler.send_response = lambda code, _message=None: setattr(
+        handler, "_last_code", code
+    )
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _payload(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("enabled", "expected_command"),
+    (
+        (True, ("systemctl", "enable", AUTOSTART_UNIT)),
+        (False, ("systemctl", "disable", "--now", AUTOSTART_UNIT)),
+    ),
+)
+def test_canonical_autostart_sync_uses_existing_unit_and_config(
+    enabled,
+    expected_command,
+):
+    commands = []
+    writes = []
+
+    result = set_hotspot_autostart(
+        enabled,
+        runner=lambda command: commands.append(tuple(command))
+        or SimpleNamespace(returncode=0),
+        config_loader=lambda: {"autostart": not enabled},
+        config_writer=lambda updates: writes.append(dict(updates)) or updates,
+    )
+
+    assert result is enabled
+    assert commands == [expected_command]
+    assert writes == [{"autostart": enabled}]
+
+
+def test_systemctl_child_never_inherits_daemon_api_token(monkeypatch):
+    captured = {}
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "must-not-reach-child")
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = tuple(argv)
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(autostart.subprocess, "run", fake_run)
+
+    result = autostart._run_systemctl(
+        ("systemctl", "enable", AUTOSTART_UNIT)
+    )
+
+    assert result.returncode == 0
+    assert captured["argv"] == ("systemctl", "enable", AUTOSTART_UNIT)
+    assert "VR_HOTSPOTD_API_TOKEN" not in captured["env"]
+
+
+def test_autostart_config_write_failure_restores_previous_service_state():
+    commands = []
+
+    def fail_writer(_updates):
+        raise OSError("sensitive host detail must not escape")
+
+    with pytest.raises(AutostartControlError) as exc_info:
+        set_hotspot_autostart(
+            True,
+            runner=lambda command: commands.append(tuple(command))
+            or SimpleNamespace(returncode=0),
+            config_loader=lambda: {"autostart": False},
+            config_writer=fail_writer,
+        )
+
+    assert exc_info.value.code == "autostart_config_update_failed"
+    assert "sensitive host detail" not in str(exc_info.value)
+    assert commands == [
+        ("systemctl", "enable", AUTOSTART_UNIT),
+        ("systemctl", "disable", "--now", AUTOSTART_UNIT),
+    ]
+
+
+@pytest.mark.parametrize("rollback_raises", (False, True))
+def test_autostart_config_write_and_rollback_failure_reports_inconsistent_state(
+    rollback_raises,
+):
+    commands = []
+    secret = "rollback-secret-output-must-not-escape"
+
+    def runner(command):
+        commands.append(tuple(command))
+        if len(commands) == 1:
+            return SimpleNamespace(returncode=0)
+        if rollback_raises:
+            raise OSError(secret)
+        return SimpleNamespace(
+            returncode=1,
+            stdout=secret * 1_000,
+            stderr=secret * 1_000,
+        )
+
+    with pytest.raises(AutostartControlError) as exc_info:
+        set_hotspot_autostart(
+            True,
+            runner=runner,
+            config_loader=lambda: {"autostart": False},
+            config_writer=lambda _updates: (_ for _ in ()).throw(
+                OSError("config-secret-must-not-escape")
+            ),
+        )
+
+    assert exc_info.value.code == AUTOSTART_ROLLBACK_FAILED
+    assert str(exc_info.value) == AUTOSTART_ROLLBACK_FAILED
+    assert secret not in str(exc_info.value)
+    assert commands == [
+        ("systemctl", "enable", AUTOSTART_UNIT),
+        ("systemctl", "disable", "--now", AUTOSTART_UNIT),
+    ]
+
+
+def test_autostart_service_failure_does_not_change_config():
+    writes = []
+
+    with pytest.raises(AutostartControlError) as exc_info:
+        set_hotspot_autostart(
+            True,
+            runner=lambda _command: SimpleNamespace(returncode=1),
+            config_loader=lambda: {"autostart": False},
+            config_writer=lambda updates: writes.append(updates),
+        )
+
+    assert exc_info.value.code == "autostart_service_update_failed"
+    assert writes == []
+
+
+def test_autostart_config_read_failure_is_fixed_and_runs_no_service_command():
+    commands = []
+
+    with pytest.raises(AutostartControlError) as exc_info:
+        set_hotspot_autostart(
+            True,
+            runner=lambda command: commands.append(tuple(command)),
+            config_loader=lambda: (_ for _ in ()).throw(
+                OSError("sensitive config path")
+            ),
+        )
+
+    assert exc_info.value.code == "autostart_config_read_failed"
+    assert "sensitive config path" not in str(exc_info.value)
+    assert commands == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        {},
+        {"enabled": 1},
+        {"enabled": "true"},
+        {"enabled": None},
+        {"enabled": True, "other": False},
+    ),
+)
+def test_autostart_api_strictly_rejects_non_boolean_or_extra_input(
+    monkeypatch,
+    body,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-token")
+    calls = []
+    monkeypatch.setattr(
+        api,
+        "set_hotspot_autostart",
+        lambda enabled: calls.append(enabled),
+    )
+    handler = _handler(body)
+
+    handler.do_POST()
+    payload = _payload(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == "invalid_request"
+    assert payload["warnings"] == ["boolean_enabled_required"]
+    assert calls == []
+
+
+@pytest.mark.parametrize("enabled", (True, False))
+def test_authenticated_autostart_api_updates_only_canonical_setting(
+    monkeypatch,
+    enabled,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-token")
+    calls = []
+    monkeypatch.setattr(
+        api,
+        "set_hotspot_autostart",
+        lambda value: calls.append(value) or value,
+    )
+    handler = _handler({"enabled": enabled})
+
+    handler.do_POST()
+    payload = _payload(handler)
+
+    assert handler._last_code == 200
+    assert payload["result_code"] == (
+        "autostart_enabled" if enabled else "autostart_disabled"
+    )
+    assert payload["data"] == {"autostart": enabled}
+    assert calls == [enabled]
+
+
+def test_autostart_api_returns_fixed_failure_without_command_output(
+    monkeypatch,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-token")
+
+    def fail(_enabled):
+        raise AutostartControlError("autostart_service_update_failed")
+
+    monkeypatch.setattr(api, "set_hotspot_autostart", fail)
+    handler = _handler({"enabled": True})
+
+    handler.do_POST()
+    payload_text = handler.wfile.getvalue().decode("utf-8")
+    payload = json.loads(payload_text)
+
+    assert handler._last_code == 500
+    assert payload["result_code"] == "autostart_update_failed"
+    assert payload["warnings"] == ["autostart_service_update_failed"]
+    assert "systemctl" not in payload_text
+
+
+def test_autostart_api_reports_failed_rollback_as_inconsistent_without_details(
+    monkeypatch,
+):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "configured-token")
+    secret = "rollback-command-secret-must-not-escape"
+
+    def fail(_enabled):
+        try:
+            raise OSError(secret * 1_000)
+        except OSError:
+            raise AutostartControlError(AUTOSTART_ROLLBACK_FAILED) from None
+
+    monkeypatch.setattr(api, "set_hotspot_autostart", fail)
+    handler = _handler({"enabled": True})
+
+    handler.do_POST()
+    payload_text = handler.wfile.getvalue().decode("utf-8")
+    payload = json.loads(payload_text)
+
+    assert handler._last_code == 500
+    assert payload["result_code"] == "autostart_state_inconsistent"
+    assert payload["warnings"] == [AUTOSTART_ROLLBACK_FAILED]
+    assert len(payload_text.encode("utf-8")) < 1_024
+    assert secret not in payload_text
+    assert "systemctl" not in payload_text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -97,6 +97,7 @@ def test_public_get_routes_remain_public_without_configured_token(
         ("POST", "/v1/stop"),
         ("POST", "/v1/repair"),
         ("POST", "/v1/restart"),
+        ("POST", "/v1/autostart"),
         ("POST", "/v1/config"),
         ("POST", "/v1/config/reveal_passphrase"),
         ("POST", "/v1/diagnostics/ping"),

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -1935,11 +1935,20 @@ def test_manifest_has_only_minimal_display_and_loopback_client_permissions():
         "--share=ipc",
         "--socket=wayland",
         "--socket=fallback-x11",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.secrets",
     }
     assert not any("filesystem=" in argument for argument in finish_args)
     assert not any("system-bus" in argument for argument in finish_args)
     assert not any("session-bus" in argument for argument in finish_args)
-    assert not any("talk-name" in argument for argument in finish_args)
+    assert {
+        argument
+        for argument in finish_args
+        if argument.startswith("--talk-name=")
+    } == {
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.secrets",
+    }
     assert "--filesystem=host" not in finish_args
     assert "--device=all" not in finish_args
     assert "--socket=system-bus" not in finish_args
@@ -1979,7 +1988,7 @@ def test_desktop_file_matches_app_id_name_and_launcher():
     assert DESKTOP_PATH.stem == APP_ID
     assert entry["Type"] == "Application"
     assert entry["Name"] == APP_NAME
-    assert entry["Exec"] == LAUNCHER_PATH.name
+    assert entry["Exec"] == f"{LAUNCHER_PATH.name} --tray"
     assert entry["Icon"] == APP_ID
     assert entry["Terminal"] == "false"
     assert not any(key.startswith("Actions") for key in entry)

--- a/tests/test_flatpak_local_api_client.py
+++ b/tests/test_flatpak_local_api_client.py
@@ -57,6 +57,28 @@ def test_default_origin_is_loopback_only_and_health_is_unauthenticated():
 
 
 @pytest.mark.parametrize(
+    ("include_logs", "path"),
+    (
+        (False, "/v1/status"),
+        (True, "/v1/status?include_logs=1"),
+    ),
+)
+def test_status_uses_only_fixed_privacy_compatible_routes(include_logs, path):
+    transport = FakeTransport(
+        HttpResponse(status=200, body=_envelope({"phase": "stopped"}))
+    )
+    client = LocalApiClient(token="status-token", transport=transport)
+
+    client.status(include_logs=include_logs)
+
+    request = transport.requests[0]
+    assert request.url == f"http://127.0.0.1:8732{path}"
+    assert request.method == "GET"
+    assert request.body == b""
+    assert "status-token" not in request.url
+
+
+@pytest.mark.parametrize(
     "base_url",
     (
         "http://localhost:8732",
@@ -248,7 +270,7 @@ def test_success_response_reflecting_token_is_discarded():
     assert secret not in repr(exc_info.value)
 
 
-def test_client_has_no_mutation_methods_or_generic_public_request_method():
+def test_client_exposes_only_reviewed_routes_and_no_generic_public_request_method():
     public_methods = {
         name
         for name, value in inspect.getmembers(LocalApiClient, inspect.isfunction)
@@ -256,19 +278,127 @@ def test_client_has_no_mutation_methods_or_generic_public_request_method():
     }
 
     assert public_methods == {
+        "adapter_readiness",
+        "config",
         "health",
         "preflight_report",
-        "adapter_readiness",
+        "repair_network",
+        "restart_service",
+        "set_hotspot_autostart",
+        "set_share_internet",
+        "start_hotspot",
+        "status",
+        "stop_hotspot",
     }
     assert public_methods.isdisjoint(
         {
+            "delete",
+            "get",
+            "patch",
+            "post",
+            "put",
+            "request",
+            "save_config",
             "start",
             "stop",
             "restart",
             "repair",
-            "save_config",
             "update_config",
-            "request",
-            "post",
         }
     )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "result_code", "path"),
+    (
+        ("start_hotspot", "started", "/v1/start"),
+        ("stop_hotspot", "stopped", "/v1/stop"),
+        ("restart_service", "restarted:started", "/v1/restart"),
+        ("repair_network", "repaired", "/v1/repair"),
+    ),
+)
+def test_reviewed_lifecycle_methods_use_exact_authenticated_post_routes(
+    method_name,
+    result_code,
+    path,
+):
+    secret = "exact-route-token"
+    transport = FakeTransport(
+        HttpResponse(
+            status=200,
+            body=_envelope({"phase": "running"}, result_code=result_code),
+        )
+    )
+    client = LocalApiClient(token=secret, transport=transport)
+
+    response = getattr(client, method_name)()
+
+    assert response.result_code == result_code
+    assert len(transport.requests) == 1
+    request = transport.requests[0]
+    assert request.url == f"http://127.0.0.1:8732{path}"
+    assert request.method == "POST"
+    assert json.loads(request.body) == {}
+    assert request.headers["X-Api-Token"] == secret
+    assert secret not in request.url
+    assert secret not in repr(request)
+    assert secret not in repr(response)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "enabled", "path", "expected_body", "result_code"),
+    (
+        (
+            "set_share_internet",
+            False,
+            "/v1/config",
+            {"config": {"enable_internet": False}},
+            "config_saved",
+        ),
+        (
+            "set_hotspot_autostart",
+            True,
+            "/v1/autostart",
+            {"enabled": True},
+            "autostart_enabled",
+        ),
+    ),
+)
+def test_reviewed_boolean_settings_use_only_their_canonical_api_representation(
+    method_name,
+    enabled,
+    path,
+    expected_body,
+    result_code,
+):
+    transport = FakeTransport(
+        HttpResponse(
+            status=200,
+            body=_envelope(expected_body, result_code=result_code),
+        )
+    )
+    client = LocalApiClient(token="setting-token", transport=transport)
+
+    response = getattr(client, method_name)(enabled)
+
+    request = transport.requests[0]
+    assert response.result_code == result_code
+    assert request.url == f"http://127.0.0.1:8732{path}"
+    assert request.method == "POST"
+    assert json.loads(request.body) == expected_body
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ("set_share_internet", "set_hotspot_autostart"),
+)
+def test_reviewed_boolean_settings_reject_non_boolean_values(method_name):
+    client = LocalApiClient(
+        token="setting-token",
+        transport=FakeTransport([]),
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        getattr(client, method_name)("true")
+
+    assert "boolean" in str(exc_info.value).casefold()

--- a/tests/test_flatpak_token_pairing.py
+++ b/tests/test_flatpak_token_pairing.py
@@ -254,9 +254,17 @@ def test_pairing_flow_wires_only_health_and_adapter_readiness():
     assert result.state is FirstRunState.TOKEN_ACCEPTED
     assert calls == [("health", False), ("adapter_readiness", True)]
     assert public_client_methods == {
+        "adapter_readiness",
+        "config",
         "health",
         "preflight_report",
-        "adapter_readiness",
+        "repair_network",
+        "restart_service",
+        "set_hotspot_autostart",
+        "set_share_internet",
+        "start_hotspot",
+        "status",
+        "stop_hotspot",
     }
     assert public_client_methods.isdisjoint(
         {

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -1,0 +1,756 @@
+import json
+from pathlib import Path
+import threading
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from flatpak_app.tray import (
+    ICON_NAMES,
+    StatusNotifierBackend,
+    TrayRuntime,
+    WindowLifecycleController,
+    build_tray_menu_model,
+)
+from flatpak_client import (
+    ActionOutcome,
+    ApiResponse,
+    AuthenticationError,
+    ConnectionFailure,
+    TrayControlController,
+    TrayState,
+    TrayStatus,
+)
+
+
+def _response(data=None, *, result_code="ok"):
+    return ApiResponse(
+        correlation_id="tray-test",
+        result_code=result_code,
+        warnings=(),
+        data=data or {},
+    )
+
+
+class TokenProvider:
+    def __init__(self, token="explicit-token"):
+        self.token = token
+
+    def token_for_operation(self):
+        return self.token
+
+
+class FakeControlClient:
+    def __init__(
+        self,
+        *,
+        phase="stopped",
+        running=False,
+        share_internet=True,
+        autostart=False,
+        status_error=None,
+        blocker=None,
+    ):
+        self.phase = phase
+        self.running = running
+        self.share_internet = share_internet
+        self.autostart = autostart
+        self.status_error = status_error
+        self.blocker = blocker
+        self.calls = []
+        self.status_log_requests = []
+
+    def status(self, *, include_logs=False):
+        self.calls.append(("status",))
+        self.status_log_requests.append(include_logs)
+        if self.status_error is not None:
+            raise self.status_error
+        return _response({"phase": self.phase, "running": self.running})
+
+    def config(self):
+        self.calls.append(("config",))
+        return _response(
+            {
+                "enable_internet": self.share_internet,
+                "autostart": self.autostart,
+            }
+        )
+
+    def start_hotspot(self):
+        self.calls.append(("start_hotspot",))
+        if self.blocker is not None:
+            self.blocker[0].set()
+            self.blocker[1].wait(timeout=5)
+        self.phase = "running"
+        self.running = True
+        return _response(result_code="started")
+
+    def stop_hotspot(self):
+        self.calls.append(("stop_hotspot",))
+        self.phase = "stopped"
+        self.running = False
+        return _response(result_code="stopped")
+
+    def restart_service(self):
+        self.calls.append(("restart_service",))
+        self.phase = "running"
+        self.running = True
+        return _response(result_code="restarted:started")
+
+    def repair_network(self):
+        self.calls.append(("repair_network",))
+        return _response(result_code="repaired")
+
+    def set_share_internet(self, enabled):
+        self.calls.append(("set_share_internet", enabled))
+        self.share_internet = enabled
+        return _response(result_code="config_saved")
+
+    def set_hotspot_autostart(self, enabled):
+        self.calls.append(("set_hotspot_autostart", enabled))
+        self.autostart = enabled
+        return _response(
+            result_code=(
+                "autostart_enabled" if enabled else "autostart_disabled"
+            )
+        )
+
+
+def _controller(client, *, token="explicit-token"):
+    return TrayControlController(
+        TokenProvider(token),
+        client_factory=lambda *, token: client,
+    )
+
+
+def test_tray_menu_contains_every_required_action():
+    model = build_tray_menu_model(
+        TrayState(
+            status=TrayStatus.RUNNING,
+            status_label="Running",
+            phase="running",
+            running=True,
+            daemon_available=True,
+            authenticated=True,
+            share_internet=True,
+            hotspot_autostart=False,
+        ),
+        window_visible=True,
+    )
+
+    assert model.action_labels() == (
+        "Show VR Hotspot",
+        "Hide VR Hotspot",
+        "Current status: Running",
+        "Start Hotspot",
+        "Stop Hotspot",
+        "Restart Service",
+        "Repair Network",
+        "Refresh Status",
+        "Share Internet Connection",
+        "Privacy Mode",
+        "Start Hotspot Automatically",
+        "Authentication…",
+        "Open Diagnostics",
+        "Open Web Portal Shell",
+        "Quit VR Hotspot",
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "label", "notifier_status"),
+    (
+        (TrayStatus.RUNNING, "Running", "Active"),
+        (TrayStatus.STOPPED, "Stopped", "Active"),
+        (TrayStatus.TRANSITIONING, "Transitioning", "Active"),
+        (TrayStatus.ERROR, "Error", "NeedsAttention"),
+    ),
+)
+def test_tray_status_labels_and_icon_variants_reflect_daemon_state(
+    status,
+    label,
+    notifier_status,
+):
+    model = build_tray_menu_model(
+        TrayState(status=status, status_label=label),
+        window_visible=False,
+    )
+
+    assert f"Current status: {label}" in model.action_labels()
+    assert model.icon_name == ICON_NAMES[status]
+    assert model.notifier_status == notifier_status
+
+
+class FakeWindow:
+    def __init__(self):
+        self.present_calls = 0
+        self.hide_calls = 0
+
+    def present(self):
+        self.present_calls += 1
+
+    def hide(self):
+        self.hide_calls += 1
+
+
+class FakeApplication:
+    def __init__(self):
+        self.quit_calls = 0
+
+    def quit(self):
+        self.quit_calls += 1
+
+
+def test_show_hide_toggle_and_close_to_tray_behavior():
+    window = FakeWindow()
+    application = FakeApplication()
+    lifecycle = WindowLifecycleController(
+        application=application,
+        window=window,
+        tray_active=True,
+    )
+
+    lifecycle.show()
+    lifecycle.toggle()
+    lifecycle.toggle()
+    close_handled = lifecycle.close_request()
+
+    assert window.present_calls == 2
+    assert window.hide_calls == 2
+    assert lifecycle.visible is False
+    assert close_handled is True
+    assert application.quit_calls == 0
+
+
+def test_close_is_not_intercepted_when_tray_backend_is_unavailable():
+    lifecycle = WindowLifecycleController(
+        application=FakeApplication(),
+        window=FakeWindow(),
+        tray_active=False,
+    )
+
+    assert lifecycle.close_request() is False
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    (
+        ("start", ("start_hotspot",)),
+        ("stop", ("stop_hotspot",)),
+        ("restart", ("restart_service",)),
+        ("repair", ("repair_network",)),
+    ),
+)
+def test_lifecycle_actions_call_only_their_intended_authenticated_method(
+    action,
+    expected,
+):
+    client = FakeControlClient(phase="running", running=True)
+    controller = _controller(client)
+
+    outcome = controller.perform(action)
+
+    assert outcome.succeeded is True
+    assert client.calls[0] == expected
+    assert client.calls[1:] == [("status",), ("config",)]
+
+
+def test_repeated_mutation_click_is_blocked_while_first_action_is_pending():
+    started = threading.Event()
+    release = threading.Event()
+    client = FakeControlClient(blocker=(started, release))
+    controller = _controller(client)
+    results = []
+
+    thread = threading.Thread(
+        target=lambda: results.append(controller.perform("start"))
+    )
+    thread.start()
+    assert started.wait(timeout=2)
+
+    repeated = controller.perform("repair")
+    release.set()
+    thread.join(timeout=3)
+
+    assert repeated.accepted is False
+    assert repeated.code == "operation_in_progress"
+    assert [call for call in client.calls if call[0] == "repair_network"] == []
+    assert results[0].succeeded is True
+
+
+def test_successful_mutation_refreshes_status_and_configuration():
+    client = FakeControlClient()
+    controller = _controller(client)
+
+    outcome = controller.perform("start")
+
+    assert outcome.state.status is TrayStatus.RUNNING
+    assert outcome.state.status_label == "Running"
+    assert client.calls == [
+        ("start_hotspot",),
+        ("status",),
+        ("config",),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error", "detail_code", "message"),
+    (
+        (
+            AuthenticationError(401),
+            "authentication_rejected",
+            "Authentication was rejected.",
+        ),
+        (
+            ConnectionFailure("secret transport detail"),
+            "daemon_unavailable",
+            "The local daemon is unavailable.",
+        ),
+    ),
+)
+def test_auth_rejected_and_daemon_unavailable_states_are_bounded(
+    error,
+    detail_code,
+    message,
+):
+    secret = "must-not-escape-tray-errors"
+    client = FakeControlClient(status_error=error)
+    controller = _controller(client, token=secret)
+
+    state = controller.refresh()
+    exposed = repr(state) + state.message + state.detail_code
+
+    assert state.status is TrayStatus.ERROR
+    assert state.detail_code == detail_code
+    assert state.message == message
+    assert secret not in exposed
+    assert "secret transport detail" not in exposed
+
+
+def test_missing_token_disables_mutations_with_fixed_state():
+    controller = _controller(FakeControlClient(), token=None)
+
+    state = controller.refresh()
+    outcome = controller.perform("start")
+
+    assert state.detail_code == "token_missing"
+    assert outcome.succeeded is False
+    assert outcome.code == "token_missing"
+    assert "Authentication" in outcome.message
+
+
+def test_share_internet_toggle_uses_only_canonical_enable_internet_method():
+    client = FakeControlClient(share_internet=True)
+    controller = _controller(client)
+
+    outcome = controller.perform("share_internet", enabled=False)
+
+    assert outcome.succeeded is True
+    assert client.calls == [
+        ("set_share_internet", False),
+        ("status",),
+        ("config",),
+    ]
+    assert outcome.state.share_internet is False
+
+
+def test_hotspot_autostart_toggle_uses_only_canonical_daemon_method():
+    client = FakeControlClient(autostart=False)
+    controller = _controller(client)
+
+    outcome = controller.perform("hotspot_autostart", enabled=True)
+
+    assert outcome.succeeded is True
+    assert client.calls == [
+        ("set_hotspot_autostart", True),
+        ("status",),
+        ("config",),
+    ]
+    assert outcome.state.hotspot_autostart is True
+
+
+def test_privacy_mode_is_companion_local_and_never_mutates_daemon_config():
+    client = FakeControlClient()
+    controller = _controller(client)
+
+    state = controller.set_privacy_mode(False)
+    refreshed = controller.refresh()
+
+    assert state.privacy_mode is False
+    assert refreshed.privacy_mode is False
+    assert client.status_log_requests == [True]
+    assert client.calls == [("status",), ("config",)]
+
+
+def test_privacy_mode_defaults_to_status_without_logs():
+    client = FakeControlClient()
+    controller = _controller(client)
+
+    controller.refresh()
+
+    assert client.status_log_requests == [False]
+
+
+def test_pending_operation_immediately_disables_mutations_in_menu_model():
+    controller = _controller(FakeControlClient())
+    controller.mark_operation_pending("start")
+
+    model = build_tray_menu_model(controller.state, window_visible=True)
+
+    assert controller.state.status is TrayStatus.TRANSITIONING
+    assert controller.state.busy_action == "start"
+    assert all(
+        not item.enabled
+        for item in model.items
+        if item.action in {"start", "stop", "restart", "repair"}
+    )
+
+
+def test_hotspot_autostart_and_desktop_login_autostart_are_not_conflated():
+    model = build_tray_menu_model(TrayState(), window_visible=False)
+    manifest = json.loads(
+        Path(
+            "packaging/flatpak/io.github.josethevrtech.VRhotspot.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert "Start Hotspot Automatically" in model.action_labels()
+    assert "Launch VR Hotspot at login" not in model.action_labels()
+    assert not any(
+        argument.startswith("--filesystem=")
+        for argument in manifest["finish-args"]
+    )
+
+
+class FakeBackend:
+    def __init__(self):
+        self.stop_calls = 0
+        self.models = []
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def update(self, model):
+        self.models.append(model)
+
+
+class FakeControls:
+    state = TrayState()
+
+    def perform(self, *_args, **_kwargs):
+        raise AssertionError("Quit must not perform a hotspot action")
+
+
+def _menu_enabled(model, action):
+    return next(item.enabled for item in model.items if item.action == action)
+
+
+def test_close_to_tray_immediately_refreshes_exported_show_hide_state():
+    application = FakeApplication()
+    lifecycle = WindowLifecycleController(
+        application=application,
+        window=FakeWindow(),
+        tray_active=True,
+    )
+    backend = FakeBackend()
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=lifecycle,
+        controls=FakeControls(),
+        authentication=object(),
+        backend=backend,
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=object(),
+        open_diagnostics=lambda: None,
+        open_web_portal=lambda: None,
+    )
+
+    runtime.show()
+    assert _menu_enabled(backend.models[-1], "show") is False
+    assert _menu_enabled(backend.models[-1], "hide") is True
+
+    runtime.dispatch_action("hide")
+    assert _menu_enabled(backend.models[-1], "show") is True
+    assert _menu_enabled(backend.models[-1], "hide") is False
+
+    runtime.dispatch_action("show")
+    assert _menu_enabled(backend.models[-1], "show") is False
+    assert _menu_enabled(backend.models[-1], "hide") is True
+
+    assert runtime.close_request(lifecycle.window) is True
+    assert lifecycle.visible is False
+    assert _menu_enabled(backend.models[-1], "show") is True
+    assert _menu_enabled(backend.models[-1], "hide") is False
+
+
+def test_tray_window_close_event_uses_runtime_state_refresh_path():
+    from flatpak_app import app
+
+    source = Path(app.__file__).read_text(encoding="utf-8")
+
+    assert 'window.connect("close-request", runtime.close_request)' in source
+    assert 'window.connect("close-request", lifecycle.close_request)' not in source
+
+
+def test_explicit_quit_exits_only_the_companion_without_hotspot_stop():
+    application = FakeApplication()
+    lifecycle = WindowLifecycleController(
+        application=application,
+        window=FakeWindow(),
+        tray_active=True,
+    )
+    backend = FakeBackend()
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=lifecycle,
+        controls=FakeControls(),
+        authentication=object(),
+        backend=backend,
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=object(),
+        open_diagnostics=lambda: None,
+        open_web_portal=lambda: None,
+    )
+
+    runtime.dispatch_action("quit")
+
+    assert application.quit_calls == 1
+    assert backend.stop_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("succeeded", "code", "expected_title", "expected_body"),
+    (
+        (True, "hotspot_started", "VR Hotspot", "Hotspot started."),
+        (True, "hotspot_stopped", "VR Hotspot", "Hotspot stopped."),
+        (
+            False,
+            "daemon_unavailable",
+            "VR Hotspot unavailable",
+            "The local daemon is unavailable.",
+        ),
+        (
+            False,
+            "operation_failed",
+            "VR Hotspot operation failed",
+            "The requested operation failed.",
+        ),
+    ),
+)
+def test_significant_notifications_are_fixed_bounded_and_secret_free(
+    succeeded,
+    code,
+    expected_title,
+    expected_body,
+):
+    secret = "notification-secret-must-not-escape"
+
+    class Notification:
+        def __init__(self, title):
+            self.title = title
+            self.body = ""
+            self.icon = None
+
+        @classmethod
+        def new(cls, title):
+            return cls(title)
+
+        def set_body(self, body):
+            self.body = body
+
+        def set_icon(self, icon):
+            self.icon = icon
+
+    class ThemedIcon:
+        @staticmethod
+        def new(name):
+            return name
+
+    Gio = type(
+        "Gio",
+        (),
+        {"Notification": Notification, "ThemedIcon": ThemedIcon},
+    )
+
+    class NotificationApplication(FakeApplication):
+        def __init__(self):
+            super().__init__()
+            self.notifications = []
+
+        def send_notification(self, notification_id, notification):
+            self.notifications.append((notification_id, notification))
+
+    application = NotificationApplication()
+    lifecycle = WindowLifecycleController(
+        application=application,
+        window=FakeWindow(),
+    )
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=lifecycle,
+        controls=FakeControls(),
+        authentication=object(),
+        backend=FakeBackend(),
+        Gtk=object(),
+        Gdk=object(),
+        Gio=Gio,
+        GLib=object(),
+        open_diagnostics=lambda: None,
+        open_web_portal=lambda: None,
+    )
+    outcome = ActionOutcome(
+        accepted=True,
+        succeeded=succeeded,
+        code=code,
+        message=secret,
+        state=TrayState(),
+    )
+
+    runtime._notify(outcome)
+
+    assert len(application.notifications) == 1
+    notification_id, notification = application.notifications[0]
+    exposed = "\n".join(
+        (notification_id, notification.title, notification.body)
+    )
+    assert notification.title == expected_title
+    assert notification.body == expected_body
+    assert len(notification.body) < 100
+    assert secret not in exposed
+
+
+def test_status_notifier_backend_unavailable_returns_false_without_crash():
+    class BrokenGio:
+        class BusType:
+            SESSION = 1
+
+        @staticmethod
+        def bus_get_sync(*_args):
+            raise RuntimeError("watcher unavailable")
+
+    backend = StatusNotifierBackend(
+        Gio=BrokenGio,
+        GLib=object(),
+        model=build_tray_menu_model(TrayState(), window_visible=True),
+        on_action=lambda _action: None,
+        on_activate=lambda: None,
+    )
+
+    assert backend.start() is False
+
+
+def test_dbus_menu_get_property_preserves_false_boolean_values():
+    class Variant:
+        def __init__(self, signature, value):
+            self.signature = signature
+            self.value = value
+
+    GLib = type("GLib", (), {"Variant": Variant})
+
+    class Parameters:
+        @staticmethod
+        def unpack():
+            return 2, "enabled"
+
+    class Invocation:
+        returned = None
+
+        def return_value(self, value):
+            self.returned = value
+
+    invocation = Invocation()
+    backend = StatusNotifierBackend(
+        Gio=object(),
+        GLib=GLib,
+        model=build_tray_menu_model(TrayState(), window_visible=False),
+        on_action=lambda _action: None,
+        on_activate=lambda: None,
+    )
+
+    backend._handle_menu_method(
+        None,
+        None,
+        None,
+        None,
+        "GetProperty",
+        Parameters(),
+        invocation,
+    )
+
+    value = invocation.returned.value[0]
+    assert value.signature == "b"
+    assert value.value is False
+
+
+def test_tray_mode_falls_back_to_normal_native_app_when_desktop_modules_missing(
+    monkeypatch,
+):
+    from flatpak_app import app
+
+    calls = []
+    monkeypatch.setattr(
+        app,
+        "run_tray",
+        lambda: (_ for _ in ()).throw(app.GuiUnavailableError("missing")),
+    )
+    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 0)
+
+    assert app.main(["--tray"]) == 0
+    assert calls == ["native"]
+
+
+def test_flatpak_tray_sources_launch_no_host_service_or_network_commands():
+    sources = "\n".join(
+        Path(path).read_text(encoding="utf-8")
+        for path in (
+            "flatpak_app/app.py",
+            "flatpak_app/tray.py",
+            "flatpak_client/client.py",
+            "flatpak_client/control.py",
+            "flatpak_client/wallet.py",
+        )
+    )
+
+    for forbidden in (
+        "subprocess.run",
+        "systemctl",
+        "nmcli",
+        "NetworkManager",
+        "iwd",
+        "hostapd",
+        "dnsmasq",
+        "firewall-cmd",
+        "iptables",
+        "nft ",
+        "ip route",
+    ):
+        assert forbidden not in sources
+
+
+def test_cyan_black_icon_variants_are_valid_scalable_and_packaged():
+    icon_dir = Path("packaging/flatpak")
+    names = (
+        "io.github.josethevrtech.VRhotspot.svg",
+        "io.github.josethevrtech.VRhotspot-running.svg",
+        "io.github.josethevrtech.VRhotspot-working.svg",
+        "io.github.josethevrtech.VRhotspot-error.svg",
+    )
+    manifest_text = (
+        icon_dir / "io.github.josethevrtech.VRhotspot.json"
+    ).read_text(encoding="utf-8")
+
+    for name in names:
+        path = icon_dir / name
+        root = ET.parse(path).getroot()
+        source = path.read_text(encoding="utf-8").casefold()
+        assert root.tag.endswith("svg")
+        assert root.attrib["viewBox"] == "0 0 128 128"
+        assert "#00eaff" in source
+        assert "#05070a" in source
+        assert "#6d4aff" not in source
+        assert "#1466cc" not in source
+        assert name in manifest_text

--- a/tests/test_flatpak_wallet.py
+++ b/tests/test_flatpak_wallet.py
@@ -1,0 +1,292 @@
+import inspect
+from pathlib import Path
+import sys
+
+import pytest
+
+from flatpak_app import build_smoke_payload, render_smoke_json
+from flatpak_client import (
+    ApiResponse,
+    AuthenticationController,
+    FirstRunState,
+    SECRET_ATTRIBUTES,
+    SECRET_SCHEMA_NAME,
+    WalletUnavailableError,
+)
+
+
+class FakeWallet:
+    def __init__(self, *, available=True, token=None, fail=False):
+        self.is_available = available
+        self.token = token
+        self.fail = fail
+        self.stored = []
+        self.clear_calls = 0
+
+    def available(self):
+        if self.fail:
+            raise RuntimeError("wallet failure with a-secret-value")
+        return self.is_available
+
+    def load(self):
+        if self.fail or not self.is_available:
+            raise WalletUnavailableError()
+        return self.token
+
+    def store(self, token):
+        if self.fail or not self.is_available:
+            raise WalletUnavailableError()
+        self.token = token
+        self.stored.append(token)
+
+    def clear(self):
+        if self.fail or not self.is_available:
+            raise WalletUnavailableError()
+        self.clear_calls += 1
+        removed = self.token is not None
+        self.token = None
+        return removed
+
+
+class AuthClient:
+    def __init__(self, token):
+        self.token_present = bool(token)
+
+    def health(self):
+        return True
+
+    def adapter_readiness(self):
+        if not self.token_present:
+            raise AssertionError("authenticated request requires the token")
+        return ApiResponse(
+            correlation_id="wallet-test",
+            result_code="ok",
+            warnings=(),
+            data={},
+        )
+
+
+def client_factory(*, token):
+    if not isinstance(token, str):
+        raise TypeError
+    if any(ord(character) < 0x20 for character in token):
+        from flatpak_client import LocalApiClientError
+
+        raise LocalApiClientError("invalid token")
+    return AuthClient(token)
+
+
+def test_manual_token_is_retained_only_in_memory_when_not_saved():
+    wallet = FakeWallet(token="old-wallet-token")
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+
+    result = controller.save_or_replace(
+        "manual-session-token",
+        save_securely=False,
+    )
+
+    assert result.code == "saved_in_memory"
+    assert result.token_available is True
+    assert result.securely_saved is False
+    assert wallet.token is None
+    assert controller.token_for_operation() == "manual-session-token"
+    assert "manual-session-token" not in repr(controller)
+    assert "manual-session-token" not in repr(result)
+
+
+def test_token_can_be_saved_retrieved_and_replaced_through_fake_wallet():
+    wallet = FakeWallet()
+    first = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+
+    saved = first.save_or_replace("first-token", save_securely=True)
+    replaced = first.save_or_replace("replacement-token", save_securely=True)
+    second = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+
+    assert saved.code == "saved_securely"
+    assert replaced.code == "saved_securely"
+    assert wallet.stored == ["first-token", "replacement-token"]
+    assert second.token_for_operation() == "replacement-token"
+    assert second.securely_saved is True
+
+
+def test_clear_removes_only_the_vr_hotspot_wallet_entry_and_memory_copy():
+    wallet = FakeWallet(token="saved-token")
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+    assert controller.token_for_operation() == "saved-token"
+
+    result = controller.clear()
+
+    assert result.code == "cleared"
+    assert wallet.clear_calls == 1
+    assert wallet.token is None
+    assert controller.token_for_operation() is None
+
+
+def test_wallet_unavailable_falls_back_to_memory_only_with_fixed_message():
+    secret = "memory-only-secret"
+    controller = AuthenticationController(
+        wallet=FakeWallet(available=False),
+        client_factory=client_factory,
+    )
+
+    result = controller.save_or_replace(secret, save_securely=True)
+
+    assert result.code == "wallet_unavailable"
+    assert result.token_available is True
+    assert result.securely_saved is False
+    assert "memory" in result.message.casefold()
+    assert secret not in result.message
+    assert controller.token_for_operation() == secret
+
+
+def test_memory_only_replace_reports_when_old_wallet_entry_cannot_be_removed():
+    secret = "replacement-memory-secret"
+    controller = AuthenticationController(
+        wallet=FakeWallet(fail=True),
+        client_factory=client_factory,
+    )
+
+    result = controller.save_or_replace(secret, save_securely=False)
+
+    assert result.code == "saved_in_memory_wallet_unavailable"
+    assert result.securely_saved is False
+    assert "could not be checked or removed" in result.message
+    assert secret not in result.message
+    assert controller.token_for_operation() == secret
+
+
+def test_copy_and_reveal_require_explicit_methods_and_do_not_auto_disclose():
+    secret = "explicit-copy-reveal-token"
+    controller = AuthenticationController(
+        wallet=FakeWallet(token=secret),
+        client_factory=client_factory,
+    )
+
+    automatic_surfaces = (
+        repr(controller),
+        str(controller),
+        repr(controller.wallet_available()),
+        repr(controller.securely_saved),
+    )
+
+    assert all(secret not in surface for surface in automatic_surfaces)
+    assert controller.reveal_token() == secret
+    assert controller.copy_token() == secret
+
+
+def test_authentication_test_uses_saved_token_without_returning_it():
+    secret = "saved-auth-test-token"
+    controller = AuthenticationController(
+        wallet=FakeWallet(token=secret),
+        client_factory=client_factory,
+    )
+
+    result = controller.test_authentication()
+
+    assert result.state is FirstRunState.TOKEN_ACCEPTED
+    assert secret not in repr(result)
+    assert secret not in result.message
+    assert secret not in result.detail_code
+
+
+def test_authentication_can_test_explicit_entry_without_saving_it():
+    secret = "explicit-auth-test-token"
+    controller = AuthenticationController(
+        wallet=FakeWallet(),
+        client_factory=client_factory,
+    )
+
+    result = controller.test_authentication(explicit_token=secret)
+
+    assert result.state is FirstRunState.TOKEN_ACCEPTED
+    assert controller.copy_token() is None
+    assert secret not in repr(result)
+
+
+def test_secret_service_schema_and_attributes_are_stable_and_non_secret():
+    assert SECRET_SCHEMA_NAME == "io.github.josethevrtech.VRhotspot.ApiToken"
+    assert SECRET_ATTRIBUTES == {
+        "application": "io.github.josethevrtech.VRhotspot",
+        "credential": "daemon-api-token",
+    }
+    assert set(SECRET_ATTRIBUTES) == {"application", "credential"}
+    assert all("secret-value" not in value for value in SECRET_ATTRIBUTES.values())
+
+
+def test_token_never_enters_smoke_json_urls_argv_logs_or_exceptions(
+    caplog,
+):
+    secret = "never-export-this-api-token"
+    wallet = FakeWallet(fail=True)
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+    result = controller.save_or_replace(secret, save_securely=True)
+    clear_result = controller.clear()
+    exposed = "\n".join(
+        (
+            repr(controller),
+            repr(result),
+            repr(clear_result),
+            repr(build_smoke_payload()),
+            render_smoke_json(),
+            caplog.text,
+            repr(sys.argv),
+        )
+    )
+
+    assert secret not in exposed
+    assert secret not in result.message
+    assert secret not in clear_result.message
+
+
+def test_wallet_and_tray_sources_never_read_privileged_token_files():
+    sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            Path("flatpak_client/wallet.py"),
+            Path("flatpak_client/control.py"),
+            Path("flatpak_app/tray.py"),
+        )
+    )
+
+    assert "/etc/vr-hotspot/env" not in sources
+    assert "/var/lib/vr-hotspot" not in sources
+    assert "VR_HOTSPOTD_API_TOKEN" not in sources
+    assert "subprocess" not in sources
+    assert "systemctl" not in sources
+
+
+def test_authentication_controller_has_no_implicit_print_or_export_method():
+    public_methods = {
+        name
+        for name, value in inspect.getmembers(
+            AuthenticationController,
+            inspect.isfunction,
+        )
+        if not name.startswith("_")
+    }
+
+    assert {
+        "clear",
+        "copy_token",
+        "reveal_token",
+        "save_or_replace",
+        "test_authentication",
+        "token_for_operation",
+        "wallet_available",
+    } <= public_methods
+    assert public_methods.isdisjoint({"print_token", "export_token", "token_url"})

--- a/tests/test_flatpak_wallet.py
+++ b/tests/test_flatpak_wallet.py
@@ -2,7 +2,6 @@ import inspect
 from pathlib import Path
 import sys
 
-import pytest
 
 from flatpak_app import build_smoke_payload, render_smoke_json
 from flatpak_client import (

--- a/tests/test_installer_flatpak_companion.py
+++ b/tests/test_installer_flatpak_companion.py
@@ -346,14 +346,23 @@ def test_flatpak_manifest_permissions_remain_minimal_and_unchanged():
         "--share=ipc",
         "--socket=wayland",
         "--socket=fallback-x11",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.secrets",
     ]
     assert not any(
         argument.startswith("--filesystem=")
         or "system-bus" in argument
-        or "talk-name" in argument
         or argument.startswith("--device=")
         for argument in manifest["finish-args"]
     )
+    assert {
+        argument
+        for argument in manifest["finish-args"]
+        if argument.startswith("--talk-name=")
+    } == {
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.secrets",
+    }
 
 
 def test_daemon_uninstallers_do_not_remove_user_flatpaks_or_remotes():


### PR DESCRIPTION
# Summary
- Add a functional Flatpak tray/control-surface MVP.
- Add KDE-compatible StatusNotifierItem/DBusMenu tray integration.
- Add cyan/black VR Hotspot icon variants for base, running, working, and error states.
- Add tray show/hide, close-to-tray, status refresh, hotspot controls, Share Internet Connection, hotspot autostart, and authentication actions.

# Tray behavior
- Tray icon appears in KDE Plasma.
- Primary activation restores the window.
- Closing the window hides it to tray when tray mode is active.
- Show/Hide menu state updates correctly after close, Show, Hide, and primary activation.
- Quit exits only the companion and does not stop a running hotspot.
- Mutating controls serialize operations and block repeated clicks while pending.

# Authentication and wallet
- Adds an Authentication dialog with hidden manual token entry.
- Supports explicit save/replace, test, copy, reveal, and clear actions.
- Uses app-specific Secret Service/libsecret storage when available.
- Falls back safely to memory-only behavior when wallet storage is unavailable.
- Does not discover, print, log, expose, or return the daemon token.

# Autostart and network controls
- Reuses the existing hotspot autostart model: canonical `config["autostart"]` plus installer-owned `vr-hotspot-autostart.service`.
- Adds strict authenticated `/v1/autostart` synchronization without creating a competing mechanism.
- Rollback failures now return bounded inconsistent-state errors instead of pretending consistency was restored.
- Surfaces Share Internet Connection through canonical `enable_internet` config.
- Desktop companion login-autostart is intentionally deferred and kept distinct from hotspot autostart.

# Boundaries
- Adds only narrow session-bus permissions: `org.kde.StatusNotifierWatcher=talk` and `org.freedesktop.secrets=talk`.
- No filesystem, system-bus, host, device, wildcard bus, or direct host-mutation permissions added.
- Flatpak tray controls do not shell out to systemctl, NetworkManager, iwd, hostapd, dnsmasq, firewall, routes, or kernel networking commands.
- Privileged host mutation remains owned by the daemon.
- Native GTK remains default/fallback.
- `--web-portal-shell` remains opt-in with fixed loopback origin, navigation lock, CSP, ephemeral session, and 1.75× zoom intact.

# Validation
- Initial PR #91 focused validation: 280 passed.
- Initial full suite: 875 passed, 4 subtests passed.
- Blocker-fix targeted validation: 51 passed.
- Blocker-fix focused validation: 285 passed.
- Final full suite: 880 passed, 4 subtests passed.
- Real Flatpak build/install and smoke validation passed.
- Manual KDE tray validation passed using real StatusNotifierWatcher/DBusMenu and KWin close request.
- No token was supplied, discovered, read, or printed during review.

# Review
- Initial review found two blockers: stale DBusMenu Show/Hide state after close-to-tray, and ignored autostart rollback failure.
- Both blockers were fixed and re-reviewed.
- Final focused review verdict: approve; no blockers.
- Final review file: `/tmp/vrhotspot-flatpak-tray-control-surface-blocker-fix-final-review.md`
- Final review SHA-256: `7966a2ff738b754e474ff8df6a82903e28d0e29fd2509cb23148577a66633480`
