### PR TITLE
Delete native Flatpak dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,26 @@ runtime/SDK to already be available. It does not add Flathub or another Flatpak
 remote. Missing prerequisites or a failed build are reported clearly, temporary
 build files are removed, and the daemon install continues.
 
-The desktop launcher starts the companion in tray mode. It opens a native
-dashboard initially, stays available through a cyan-and-black system-tray icon,
-and hides the window to the tray when the window is closed. The tray provides
-live status, lifecycle controls, Share Internet Connection, Privacy Mode, and
-the existing Start Hotspot Automatically setting. Explicit Quit exits only the
-desktop companion and does not stop an already-running hotspot.
+The desktop launcher starts the companion in tray mode. Its only graphical UI
+is the daemon-served Web Portal in a locked WebKitGTK window. Primary tray
+activation and **Show VR Hotspot** open or restore that same window;
+**Hide VR Hotspot** and the window close action hide it to the tray without
+creating another window. If WebKit cannot be constructed, the companion shows
+a bounded GTK error surface and does not open another interface. The tray
+provides live status, lifecycle controls, Share Internet Connection, Privacy
+Mode, and the existing Start Hotspot Automatically setting. Explicit Quit exits
+only the desktop companion and does not stop an already-running hotspot.
 
 Use **Authentication…** to enter the existing daemon API token. Saving it is an
 explicit choice and uses the desktop Secret Service provider (including a
 compatible KDE Wallet setup); otherwise it remains in memory only. The
-installer and Flatpak never discover the token from daemon host files. The Web
-Portal shell remains a separate opt-in launch mode:
+installer and Flatpak never discover the token from `/etc/vr-hotspot`,
+`/var/lib/vr-hotspot`, daemon configuration, environment variables, or command
+arguments. Missing or rejected credentials are reported as
+**Needs Authentication**, separately from **Daemon Unavailable** and unexpected
+**Error** states. Start, Stop, Restart, and Repair remain disabled until an
+explicitly entered or saved token authenticates successfully. The historical
+flag remains a compatibility alias for the same default graphical behavior:
 
 ```bash
 flatpak run io.github.josethevrtech.VRhotspot --web-portal-shell

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,25 +1,29 @@
 # Flatpak control app architecture plan
 
-Status: PR #91 Flatpak system-tray control surface and desktop identity; PRs #77-#90 retained
+Status: PR #92 Web Portal-only Flatpak graphical UI; PRs #77-#91 retained
 
 Date: 2026-07-24
 
 This document defines the boundary for the VRhotspot Flatpak control
-application. PR #91 adds a functional Plasma-compatible system-tray control
-surface, close-to-tray lifecycle, current hotspot status, narrowly scoped
-daemon controls, explicit authentication UI, optional Secret Service storage,
-and cyan/black desktop identity. PR #90's fixed, bounded WebKit display zoom
-and PR #88's origin-locked Web Portal shell remain unchanged. The browser
-`/ui` route continues to use the shared assets at normal browser scale. The
-native GTK dashboard remains the default window and fallback; switching the
-default to the Web Portal shell is separately reviewed future work.
+application. PR #92 makes the origin-locked, daemon-served Web Portal the only
+Flatpak graphical UI. Normal launch, tray primary activation, and
+**Show VR Hotspot** all open or restore one locked WebKitGTK window;
+**Hide VR Hotspot** and close-to-tray hide that same window. The pre-PR #92 GTK
+content implementation, its token-entry flow, and every launch or failure path
+that could reach it have been removed from active code. GTK remains only for
+the WebKit host window, tray integration, the explicit authentication dialog,
+bounded error surfaces, and small desktop utility dialogs.
 
-The shell retains PR #86's installed GTK `PasswordEntry` compatibility fix,
-PR #82's native in-memory first-run token entry, PR #83's explicit terminal-only
-live daemon pairing smoke path, and PR #84's optional installer prompt. PR #91
-does not inject a token into WebKit, change the shared Web Portal assets, add
-direct host command execution, add host filesystem access, or move privileged
-network ownership out of the daemon.
+PR #90's fixed 1.75x WebKit display zoom and PR #88's exact loopback origin,
+navigation lock, CSP, and ephemeral session remain unchanged. If WebKit is
+unavailable or construction fails, the host window shows fixed bounded error
+copy; it never opens another graphical surface. The browser `/ui` route
+continues to use the shared assets at normal browser scale.
+
+PR #83's explicit terminal-only live daemon pairing smoke path and PR #84's
+optional installer prompt remain. PR #92 does not inject a token into WebKit,
+change the shared Web Portal assets, add direct host command execution, add host
+filesystem access, or move privileged network ownership out of the daemon.
 
 ## Architectural decision
 
@@ -313,24 +317,25 @@ require separate review.
 
 ## PR #82 first-run/token entry UI prototype
 
-PR #82 adds one intentional credential input to the GTK shell: a hidden
-password-style entry and a `Connect / Validate token` button. The button gives
-the caller-provided text to a shell-level `FirstRunTokenEntryController`, which
-uses the existing `TokenPairingController` and its loopback-only
-`LocalApiClient` factory. When pairing succeeds, a short-lived client is passed
-to the existing `DiagnosticsControlUiController` to build the display model.
-There is no network call outside `LocalApiClient`.
+Historical record: PR #82 added a hidden password-style entry and a
+`Connect / Validate token` action to the then-current GTK content surface.
+PR #92 deleted that graphical credential flow and its shell controller
+together with the retired surface. The terminal-only live smoke still uses the
+existing `TokenPairingController`, loopback-only `LocalApiClient`, and
+`DiagnosticsControlUiController`; there is no network call outside
+`LocalApiClient`.
 
-The entered token exists only in process memory for the current validation and
-model-build call. The GTK entry is cleared as soon as the click is handled, the
-shell controller has no token field, and the temporary token-bearing client is
-discarded after the model is built. The token is not written, logged, placed in
-a process argument, copied into the model, or included in smoke JSON,
-representations, exceptions, diagnostics, or window labels. This prototype
-does not discover tokens from environment variables, files, keyrings, portals,
-daemon configuration, `/etc`, `/var/lib`, or any other host location.
+The live smoke token exists only in process memory for its current validation
+and model-build call, and its temporary token-bearing client is discarded
+afterward. The tray Authentication dialog accepts explicit user entry and can
+retain it only in memory or, by explicit choice, in Secret Service. Tokens are
+not written to plaintext, logged, placed in process arguments, copied into
+models, or included in smoke JSON, representations, exceptions, diagnostics,
+URLs, or window labels. The companion does not discover tokens from environment
+variables, daemon configuration, `/etc`, `/var/lib`, or any other host
+location.
 
-The GTK shell renders only the existing bounded display models:
+The historical GTK surface rendered only the existing bounded display models:
 
 - daemon status and safe reachability state;
 - pairing accepted, rejected, unavailable, missing-daemon-token, or unknown
@@ -463,8 +468,11 @@ does not read daemon credentials from environment variables, files, keyrings,
 portals, daemon configuration, `/etc`, `/var/lib`, or another filesystem
 location. Known daemon-token environment variable names are removed from the
 builder process environment without inspecting their values. After install, the
-user pairs manually by entering the existing daemon token in the companion's
-hidden field; the existing in-memory-only handling remains unchanged.
+Web Portal shell is the Flatpak graphical UI. The retired GTK content surface
+remains absent; GTK provides only WebKit, tray, explicit authentication,
+bounded-error, and small utility UI infrastructure. Tray controls require a
+daemon token explicitly entered for the session or explicitly saved through
+Secret Service. The companion never discovers a token from `/etc` or `/var/lib`.
 
 Daemon uninstallers do not automatically remove the user-owned companion or any
 Flatpak remote. A user may separately remove only this app with:
@@ -473,16 +481,19 @@ Flatpak remote. A user may separately remove only this app with:
 flatpak uninstall --user io.github.josethevrtech.VRhotspot
 ```
 
-Token persistence/keyring storage, lifecycle/configuration controls,
-support-bundle portal export, Flathub production polish, Steam Frame, VR Direct
-Link, and adapter-registry work remain separately reviewed future work.
+PR #91 provides the tray lifecycle/configuration controls and optional Secret
+Service wallet storage. Missing or rejected credentials produce `Needs
+Authentication`, distinct from unexpected `Error` failures. Support-bundle
+portal export, Flathub production polish, Steam Frame, VR Direct Link, and
+adapter-registry work remain separately reviewed future work.
 
-## PR #85 native dashboard foundation
+## PR #85 retired GTK read-only surface (historical)
 
-PR #85 replaces the GTK window's linear placeholder presentation with a native
-GTK 4 read-only dashboard. The existing hidden token entry remains the only
-graphical credential source. After the daemon accepts the caller-entered token,
-the app renders the already-sanitized `DiagnosticsControlUiModel` as a clear
+Historical record only: PR #92 deleted all implementation and tests described
+in PRs #85-#87. PR #85 had replaced the GTK window's linear placeholder with a
+GTK 4 read-only card surface. Its hidden token entry was the only graphical
+credential source at that time. After the daemon accepted caller-entered text,
+the app rendered the already-sanitized `DiagnosticsControlUiModel` as a
 two-column card layout containing:
 
 - daemon status;
@@ -523,7 +534,7 @@ not expanded.
 
 PR #86 preserves PR #85's behavior while making placeholder setup compatible
 with the GTK 4 `PasswordEntry` binding shipped by the installed GNOME runtime.
-The native shell prefers the direct placeholder setter when available and
+The historical GTK surface preferred the direct placeholder setter when available and
 falls back to the supported GObject property API. If neither form is available,
 the optional placeholder is skipped instead of crashing activation.
 
@@ -532,10 +543,10 @@ intentional, and the entry is still cleared before validation. The hotfix adds
 no token source, retention, storage, logging, model field, daemon call,
 permission, or mutation control.
 
-## PR #87 native dashboard Web Portal parity pass
+## PR #87 retired GTK surface parity pass (historical)
 
 PR #87 uses the existing Web Portal only as a design and product reference for
-the native GTK dashboard. It adopts the Portal's safe hierarchy and terminology
+the retired GTK card surface. It adopted the Portal's safe hierarchy and terminology
 where they describe the same daemon-provided read-only information:
 
 - a clearer application header and connection/pairing area;
@@ -551,7 +562,7 @@ Every `ok`, `warning`, `blocked`, `error`, and `unknown` state is rendered with
 a consistent uppercase severity badge. Paired state and the daemon-recommended
 adapter receive separate, visible emphasis. Disabled sections use honest
 unavailable copy and insensitive widgets rather than appearing broken. The
-layout remains scrollable and uses native GTK frames, boxes, grids, labels,
+layout remains scrollable and uses GTK frames, boxes, grids, labels,
 buttons, and one small bounded GTK stylesheet for spacing, badge shape, and
 card emphasis.
 
@@ -605,15 +616,14 @@ JavaScript, WebKit user script, Local Storage, Session Storage, cookie, model,
 exception, representation, or smoke JSON. It does not read a daemon token from
 the environment, daemon configuration, files, keyrings, portals, `/etc`,
 `/var/lib`, or another filesystem location. Token entry, validation, and use
-remain the existing Web Portal's behavior. The native dashboard's separate
-manual-entry path remains unchanged.
+remain the existing Web Portal's behavior. PR #92 removed the separate GTK
+manual-entry path.
 
 If the `WebKit` 6.0 namespace or required ephemeral-session API is unavailable,
-the explicit spike mode launches the retained native GTK dashboard. If WebKit
-construction fails during activation, that window is also populated with the
-native dashboard instead of crashing. If the fixed local Portal load fails, the
-shell displays a bounded token-free local-daemon error with a retry button that
-reloads only the same fixed URL.
+or WebKit construction fails during activation, PR #92 populates the host
+window with fixed bounded GTK error copy and no alternate interface. If the
+fixed local Portal load fails, the shell displays a bounded token-free
+local-daemon error with a retry button that reloads only the same fixed URL.
 
 The manifest continues to use only its existing network, IPC, Wayland, and
 fallback X11 finish arguments. WebKitGTK is supplied by the selected GNOME 50
@@ -649,12 +659,11 @@ no JavaScript, downloaded dependency, control-semantic change, or API change.
 In particular, the Basic-mode USB Wi-Fi Adapter select remains the same
 `ap_adapter` control and continues through the existing portal behavior.
 
-PR #89 does not change the Flatpak entry point, WebView construction, exact
-origin/navigation policy, Content Security Policy, token behavior, native GTK
-dashboard or fallback, manifest permissions, daemon behavior, or installer.
-`--web-portal-shell` remains explicit and opt-in. A default UI switch and any
-additional WebKit hardening review and prerequisites for that switch remain
-separately approved future work.
+PR #89 did not change the Flatpak entry point, WebView construction, exact
+origin/navigation policy, Content Security Policy, token behavior, then-current
+GTK surface, manifest permissions, daemon behavior, or installer. PR #92 later
+made the locked Web Portal shell the default while preserving those WebKit
+security boundaries.
 
 ## PR #90 Flatpak Web Portal shell display scaling/density polish
 
@@ -664,28 +673,29 @@ CLI, URL, query string, configuration, or environment. A 1.75x value provides a
 substantial desktop-app density increase in the 1200x900 shell without reducing
 the effective viewport as aggressively as 2.0x.
 
-The scaling is a WebKit presentation property on the opt-in
+The scaling is a WebKit presentation property on the Flatpak
 `--web-portal-shell` WebView. The browser Portal remains backed by the same
 shared visual assets but is not forced into the Flatpak shell scale. PR #90
 does not change shared CSS, Web UI JavaScript, daemon-served routes, or browser
 behavior.
 
 The exact local daemon URL pinning, external and new-window navigation blocking,
-ephemeral WebKit network session, token boundaries, manifest permissions, and
-native GTK default/fallback remain unchanged. Switching the default UI and the
-additional WebKit hardening and prerequisite review for such a switch remain
-separately approved future work.
+ephemeral WebKit network session, token boundaries, and manifest permissions
+remain unchanged in PR #92. The 1.75x scale now applies to the only Flatpak
+graphical shell.
 
 ## PR #91 system-tray control surface and desktop identity
 
 PR #91 makes the optional Flatpak companion a persistent desktop utility while
 keeping `vr-hotspotd` as the sole privileged host-mutation boundary. An explicit
-`--tray` launch mode owns a StatusNotifierItem and DBusMenu, shows the native GTK
-dashboard initially, restores it on primary tray activation, and hides it when
-the user closes the window. `Quit VR Hotspot` exits only the companion; it does
-not issue a hotspot stop request. If the tray backend cannot register, the
-normal native application still opens and closes normally instead of crashing
-or becoming hidden without a reachable tray icon.
+`--tray` launch mode owns a StatusNotifierItem and DBusMenu. PR #92 changes its
+lifecycle-owned window to the locked Web Portal shell: it is shown initially,
+restored on primary tray activation or **Show VR Hotspot**, and hidden by
+**Hide VR Hotspot** or close-to-tray. Repeated activation reuses the same
+window. `Quit VR Hotspot` exits only the companion; it does not issue a hotspot
+stop request. If the tray backend cannot register, the Web Portal window still
+opens and closes normally instead of crashing or becoming hidden without a
+reachable tray icon.
 
 The GNOME 50 runtime provides Gio/GDBus and libsecret but does not provide an
 AppIndicator/Ayatana binding. The tray therefore implements the standard
@@ -754,11 +764,24 @@ command permission. The app retains ordinary `--share=network` only for its
 fixed authenticated loopback API origin. Notifications contain fixed bounded
 operation summaries and never include credentials or raw daemon errors.
 
-`--smoke-json`, `--live-pairing-smoke-json`, and the opt-in
-`--web-portal-shell` remain compatible. The Web Portal shell retains its 1.75x
-zoom, ephemeral session, exact loopback origin, CSP, and navigation lock.
-Native GTK remains the default/fallback outside explicit tray mode. A future
-default Web Portal switch remains a separate review.
+`--smoke-json`, `--live-pairing-smoke-json`, and
+`--web-portal-shell` remain compatible. The last is now an alias for the
+default graphical behavior. The Web Portal shell retains its 1.75x zoom,
+ephemeral session, exact loopback origin, CSP, and navigation lock.
+
+Tray status distinguishes `Running`, `Stopped`, `Transitioning`,
+`Needs Authentication`, `Daemon Unavailable`, and `Error`. Missing, rejected,
+or daemon-missing credentials map to `Needs Authentication`; connection
+failure maps to `Daemon Unavailable`; only unexpected or malformed failures
+map to `Error`. Authentication remains enabled while credentials are needed.
+Start, Stop, Restart, and Repair require an authenticated state, and saving or
+testing an explicitly entered token triggers a status refresh.
+
+The exported menu uses deterministic separator-delimited sections in this
+order: Window (Show, Hide), Status (current status, refresh), Hotspot Controls
+(Start, Stop, Restart, Repair), Settings (internet sharing, privacy, hotspot
+autostart), Authentication, Tools (Diagnostics), and Quit. There is no second
+menu action for opening the already-default graphical shell.
 
 ## Sandbox and portal expectations
 
@@ -850,13 +873,14 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #82 | First-run/token entry UI prototype. Add a hidden GTK token entry, an explicit validation action, and shell-level orchestration through the existing local client, pairing controller, and diagnostics UI controller. Keep tokens in memory only, keep GTK optional for tests, and add no persistence, mutation, portal, daemon, installer, or permission behavior. | Offline tests cover accepted, rejected, unreachable, missing-daemon-token, and malformed outcomes; safe display model updates; token non-disclosure/non-persistence; unchanged smoke behavior; static Flatpak packaging; and the absence of discovery or mutation controls. |
 | PR #83 | Live daemon pairing smoke path. Add an explicit terminal-only installed-Flatpak command with strict hidden manual token entry and bounded sanitized JSON assembled through the existing pairing, local-client, and diagnostics UI boundaries. Add no token argument or discovery/storage path, mutation control, daemon/installer behavior, or permission. | Offline tests cover TTY and hidden-input refusal, success, token rejection, daemon unreachability, missing daemon token, malformed data, output bounds and redaction, unchanged offline/GUI behavior, and the absence of discovery or mutation controls. A real-daemon run of the documented command is required before live pairing is claimed. |
 | PR #84 | Optional installer companion prompt. Add a default-No guided choice and an explicit `--install-flatpak-companion` unattended opt-in for a best-effort user-scoped local build/install. Add no remote configuration, token transfer/storage, smoke execution, daemon/runtime behavior, uninstaller mutation, or permission change. | Deterministic installer tests cover guided No/Yes, unattended default/opt-in, missing tools, bounded build failure, cleanup, credential-environment scrubbing, unchanged manifest permissions, and non-destructive uninstall boundaries. Existing Flatpak tests and real packaging validation remain required. |
-| PR #85 | Native dashboard foundation. Replace the linear GTK placeholder presentation with a two-column read-only dashboard that renders the existing safe daemon, pairing, adapter-readiness, preflight, disabled support-bundle, and empty controls models after pairing. Add no refresh, token retention/storage, mutation control, portal behavior, direct networking, or permission. | Deterministic tests prove all six cards render, token input clears before validation, adapter and preflight detail remains bounded and sanitized, rejected/unreachable/malformed states remain safe, support export stays disabled, mutation actions stay empty, GTK remains optional, both smoke commands remain compatible, and the manifest permissions remain unchanged. |
-| PR #86 | Installed GTK PasswordEntry compatibility hotfix. Preserve the hidden password-style field while supporting both the direct placeholder setter and the GTK property API, and safely omit the optional placeholder when neither is available. Add no token, client, model, permission, or control behavior. | Deterministic activation and helper tests cover the installed binding shape, direct setter, supported fallback property, and unsupported-property no-op without weakening token clearing or lazy GTK loading. |
-| PR #87 | Native dashboard Web Portal parity pass. Use the Portal as a design/product reference to improve the native GTK header, connection/pairing hierarchy, readiness summary, recommended-adapter emphasis, preflight facts/issues/actions, severity badges, and honest unavailable sections. Do not embed the Portal, add a WebView or frontend runtime, retain tokens, add actions/export, change Web UI or daemon behavior, or expand permissions. | Deterministic model/view tests prove parity labels, all five severity badges, paired and recommended emphasis, disabled support export, empty controls, absent lifecycle/configuration buttons, hidden/cleared token entry, placeholder compatibility, lazy GTK, token-free smoke contracts, redaction, and unchanged manifest permissions. |
-| PR #88 | Locked Web Portal shell spike. Add an explicit WebKitGTK 6.0 mode that loads only the daemon-served `http://127.0.0.1:8732/ui` Portal in an ephemeral, origin-locked WebView. Keep the native dashboard as default and fallback. Add no copied frontend, arbitrary URL, token injection/discovery/persistence, Web UI or daemon behavior, installer behavior, or permission. | Deterministic tests pin the route and exact origin, deny external and new-window navigation, prove ephemeral/no-injection construction and bounded load failure, exercise WebKit-unavailable and construction fallback, preserve both smoke contracts and native token-entry compatibility, and verify unchanged manifest permissions. Real packaging and manual shell validation remain required. |
-| PR #89 | Web Portal shell layout and theme polish. Improve the shared Portal CSS so Basic mode uses wide, medium, and narrow windows effectively and WebKitGTK renders select/input controls with readable dark, focused, and disabled states. Preserve Pro behavior, WebView security, opt-in launch, native fallback, tokens, APIs, runtime, installer, vendor files, and permissions. | Deterministic asset tests prove flexible Basic card/container rules, wide and narrow breakpoints, dark native-form overrides, focus/disabled contrast, retained Basic/Pro selectors and USB adapter control; the #88 shell/security/token/manifest tests remain green; browser `/ui` and the Flatpak shell consume the same daemon-served assets. |
-| PR #90 | Flatpak Web Portal shell display scaling/density polish. Apply a fixed, bounded 1.75x WebKit zoom only to the opt-in locked shell. Preserve the normal-scale browser Portal, shared assets, exact origin and navigation lock, ephemeral session, token boundaries, native default/fallback, daemon/runtime/installer behavior, vendor files, and permissions. | Deterministic shell tests prove the fixed zoom and clamp, absence of user-controlled zoom inputs, unchanged shared-CSS scaling, retained opt-in/default/fallback behavior, and the existing navigation, token, smoke, and manifest boundaries. Real packaging and manual shell/browser validation remain required. |
-| PR #91 | Flatpak system-tray control surface and desktop identity (current phase). Add a Plasma-compatible StatusNotifierItem/DBusMenu backend, close-to-tray lifecycle, typed live-state model, fixed lifecycle/config controls, existing hotspot boot-autostart control, explicit Secret Service authentication UI, and cyan/black icon variants. | Deterministic tests prove complete menu/state mapping, serialized authenticated mutations, refresh-after-success, canonical `enable_internet` and hotspot-autostart behavior, companion-only quit, safe wallet fallback and token handling, optional desktop imports, retained shell/native/smoke contracts, narrow D-Bus grants, and installed icon identity. Real packaging and manual tray validation remain required. |
+| PR #85 | Historical GTK read-only card surface, removed by PR #92. | Historical tests covered bounded rendering and secret-safe explicit entry; PR #92 deletes that implementation and those view tests. |
+| PR #86 | Historical installed `PasswordEntry` compatibility hotfix, removed by PR #92. | The password field and compatibility helper no longer exist in active shell code. |
+| PR #87 | Historical GTK/Web Portal visual-parity pass, removed by PR #92. | The removed surface no longer competes with the daemon-served Portal. |
+| PR #88 | Locked Web Portal shell spike. Add an explicit WebKitGTK 6.0 mode loading only `http://127.0.0.1:8732/ui` through an ephemeral, origin-locked WebView. | Deterministic tests pin the exact origin, deny external/new-window navigation, prove ephemeral construction and no injection, and retain bounded load-failure handling. |
+| PR #89 | Web Portal shell layout and theme polish. Improve shared Portal CSS across viewport sizes and WebKitGTK form controls. | Asset tests prove responsive layout, dark control states, retained Basic/Pro behavior, and one daemon-served asset source for browser and Flatpak. |
+| PR #90 | Flatpak Web Portal shell scaling/density polish. Apply fixed bounded 1.75x WebKit zoom to the locked shell. | Tests prove fixed zoom/clamping, no user-controlled scale, normal browser scale, and unchanged origin/session/token boundaries. |
+| PR #91 | Flatpak system-tray control surface and desktop identity. Add StatusNotifierItem/DBusMenu, close-to-tray, typed live state, fixed controls, explicit Secret Service authentication, and cyan/black icons. | Tests prove complete menu/state mapping, serialized mutations, refresh-after-success, companion-only quit, safe wallet behavior, narrow D-Bus grants, and installed icon identity. |
+| PR #92 | Web Portal-only Flatpak graphical UI. Delete the retired GTK content surface and all routes/tests supporting it; make default and tray window behavior use one locked Web Portal shell; classify authentication and daemon availability separately; organize the tray menu. | Tests prove default/alias/tray activation, show/hide/close and single-window behavior, bounded WebKit errors with no alternate surface, retained origin/CSP/session/zoom locks, six status classes, explicit-auth refresh, deterministic menu sections, no credential leakage, unchanged permissions, and zero forbidden active references. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -937,10 +961,10 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #91
+## Explicit non-goals for PR #92
 
-- No default Web Portal UI switch or native-dashboard removal. The locked
-  WebView remains explicit and opt-in; native GTK remains the default/fallback.
+- No second graphical shell, alternate failure UI, legacy launch route, or
+  development-only route for the removed GTK content surface.
 - No Web UI JavaScript, CSS, route, CSP, origin, navigation, token, or session
   behavior change.
 - No arbitrary URL argument, address bar, external/new-window navigation,
@@ -962,8 +986,10 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No Steam Frame, VR Direct Link, known-adapter registry, or
   HostFactsSnapshot work.
 
-PR #91 authorizes only the tray lifecycle/control/authentication surface, its
-fixed autostart API, narrowly scoped session-bus grants, cyan/black desktop
-identity, deterministic tests, and documentation above. A real daemon pairing
-or live lifecycle result is claimed only when exercised with an explicitly
-entered credential; no credential is printed or exported in validation.
+PR #92 authorizes only deletion of the retired GTK content surface, the default
+and tray-window Web Portal cutover, status classification correction, menu
+organization, deterministic tests, and documentation above. It does not change
+the fixed autostart API, session-bus grants, desktop identity, or permissions.
+A real daemon pairing or live lifecycle result is claimed only when exercised
+with an explicitly entered credential; no credential is printed or exported in
+validation.

--- a/flatpak_app/__init__.py
+++ b/flatpak_app/__init__.py
@@ -1,19 +1,14 @@
-"""Unprivileged native and locked Web Portal shells for the VRhotspot Flatpak."""
+"""Unprivileged locked Web Portal shell for the VRhotspot Flatpak."""
 
 from .app import (
     APP_ID,
     APP_NAME,
-    DashboardControlsBoundary,
-    DashboardSectionLabels,
-    FirstRunTokenEntryController,
     MAX_LIVE_SMOKE_JSON_BYTES,
     MAX_SMOKE_JSON_BYTES,
-    NativeDashboardModel,
     WEBKIT_GI_NAMESPACE,
     WEBKIT_GI_VERSION,
     WEB_PORTAL_ORIGIN,
     WEB_PORTAL_URL,
-    build_dashboard_model,
     build_initial_model,
     build_smoke_payload,
     is_approved_web_portal_uri,
@@ -36,17 +31,12 @@ from .tray import (
 __all__ = [
     "APP_ID",
     "APP_NAME",
-    "DashboardControlsBoundary",
-    "DashboardSectionLabels",
-    "FirstRunTokenEntryController",
     "MAX_LIVE_SMOKE_JSON_BYTES",
     "MAX_SMOKE_JSON_BYTES",
-    "NativeDashboardModel",
     "WEBKIT_GI_NAMESPACE",
     "WEBKIT_GI_VERSION",
     "WEB_PORTAL_ORIGIN",
     "WEB_PORTAL_URL",
-    "build_dashboard_model",
     "build_initial_model",
     "build_smoke_payload",
     "is_approved_web_portal_uri",

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -1,9 +1,9 @@
-"""Launchable Flatpak shell with native and locked Web Portal modes."""
+"""Launchable Flatpak shell for the locked local Web Portal."""
 
 from __future__ import annotations
 
 import argparse
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 import getpass
 import json
 import sys
@@ -12,20 +12,15 @@ from urllib.parse import urlsplit
 import warnings
 
 from flatpak_client import (
-    AdapterReadinessModel,
-    DaemonStatusModel,
+    AuthenticationController,
     DiagnosticsControlUiController,
     DiagnosticsControlUiModel,
     FirstRunResult,
     FirstRunState,
     LocalApiClient,
-    PairingStatusModel,
-    PreflightSummaryModel,
     PresentationMode,
     StatusSeverity,
-    SupportBundleAffordance,
     TokenPairingController,
-    AuthenticationController,
     TrayControlController,
 )
 
@@ -51,22 +46,6 @@ _WEB_PORTAL_CSP = (
     "object-src 'none'; frame-src 'none'; base-uri 'none'; "
     f"form-action {WEB_PORTAL_ORIGIN}"
 )
-_DASHBOARD_CSS = """
-.dashboard-card {
-  border-radius: 10px;
-}
-.status-badge {
-  border-radius: 9999px;
-  padding: 2px 8px;
-}
-.recommended-card {
-  border-width: 2px;
-}
-.unavailable-card {
-  opacity: 0.82;
-}
-"""
-
 _LIVE_SMOKE_SUCCESS = "success"
 _LIVE_SMOKE_INVALID_RESPONSE = "invalid_response"
 _LIVE_SMOKE_INTERACTIVE_INPUT_REQUIRED = "interactive_input_required"
@@ -84,97 +63,8 @@ class WebKitUnavailableError(RuntimeError):
     """The pinned WebKitGTK GI API is unavailable for the portal shell."""
 
 
-@dataclass(frozen=True)
-class DashboardControlsBoundary:
-    """Visible proof that this dashboard has no mutation surface."""
-
-    visible: bool
-    severity: StatusSeverity
-    title: str
-    readiness_label: str
-    summary: str
-    mutation_actions: tuple[str, ...] = ()
-    action_enabled: bool = False
-
-
-@dataclass(frozen=True)
-class DashboardSectionLabels:
-    """Stable product labels shared by the native dashboard sections."""
-
-    overview: str = "Dashboard Overview"
-    connection_pairing: str = "Connection & Pairing"
-    readiness_summary: str = "Readiness & Adapter Summary"
-    adapter_readiness: str = "Adapter Readiness"
-    preflight_diagnostics: str = "Preflight Diagnostics"
-    host_summary: str = "Readiness & Host Summary"
-    facts: str = "Facts"
-    blocking_issues: str = "Blocking Issues"
-    warnings: str = "Warnings"
-    other_issues: str = "Other Issues"
-    recommended_actions: str = "Recommended Actions"
-    support_bundle: str = "Support Bundle"
-    controls_boundary: str = "Controls Boundary"
-    unavailable_features: str = "Unavailable Features"
-
-
-@dataclass(frozen=True)
-class NativeDashboardModel:
-    """Safe sections consumed by the native GTK dashboard."""
-
-    labels: DashboardSectionLabels
-    daemon: DaemonStatusModel
-    pairing: PairingStatusModel
-    adapter_readiness: AdapterReadinessModel
-    preflight: PreflightSummaryModel
-    support_bundle: SupportBundleAffordance
-    controls: DashboardControlsBoundary
-
-
-class FirstRunTokenEntryController:
-    """Build one token-free display model from an explicitly supplied token."""
-
-    def __init__(self, *, client_factory=LocalApiClient, pairing_controller=None):
-        self._client_factory = client_factory
-        self._pairing_controller = (
-            pairing_controller
-            if pairing_controller is not None
-            else TokenPairingController(client_factory)
-        )
-
-    def __repr__(self) -> str:
-        return (
-            "FirstRunTokenEntryController("
-            "client_factory_configured=True, pairing_controller_configured=True)"
-        )
-
-    def connect(self, *, token: str) -> DiagnosticsControlUiModel:
-        """Validate caller-provided text and build read-only UI state in memory."""
-
-        try:
-            pairing_result = self._pairing_controller.evaluate(token=token)
-        except Exception:
-            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
-        if not isinstance(pairing_result, FirstRunResult):
-            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
-
-        client = None
-        if pairing_result.state is FirstRunState.TOKEN_ACCEPTED:
-            try:
-                client = self._client_factory(token=token)
-            except Exception:
-                pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
-
-        try:
-            return DiagnosticsControlUiController(client).build(
-                pairing_result=pairing_result,
-                mode=PresentationMode.BASIC,
-            )
-        finally:
-            client = None
-
-
 def build_initial_model() -> DiagnosticsControlUiModel:
-    """Build a deterministic offline/unpaired model without daemon access."""
+    """Build deterministic offline/unpaired state without daemon access."""
 
     return DiagnosticsControlUiController().build(
         pairing_result=FirstRunResult(FirstRunState.INVALID_RESPONSE),
@@ -182,36 +72,8 @@ def build_initial_model() -> DiagnosticsControlUiModel:
     )
 
 
-def build_dashboard_model(
-    model: DiagnosticsControlUiModel,
-) -> NativeDashboardModel:
-    """Project the existing safe UI model into the native dashboard sections."""
-
-    if not isinstance(model, DiagnosticsControlUiModel):
-        model = build_initial_model()
-    labels = DashboardSectionLabels()
-    return NativeDashboardModel(
-        labels=labels,
-        daemon=model.daemon,
-        pairing=model.pairing,
-        adapter_readiness=model.adapters,
-        preflight=model.preflight,
-        support_bundle=model.support_bundle,
-        controls=DashboardControlsBoundary(
-            visible=True,
-            severity=StatusSeverity.UNKNOWN,
-            title=labels.controls_boundary,
-            readiness_label="Unavailable",
-            summary=(
-                "This foundation is read-only. Lifecycle and configuration "
-                "actions are not available."
-            ),
-        ),
-    )
-
-
 def build_smoke_payload() -> dict[str, Any]:
-    """Return a bounded, non-secret description of the initial shell."""
+    """Return a bounded, non-secret description of the Flatpak shell."""
 
     model = build_initial_model()
     return {
@@ -225,7 +87,8 @@ def build_smoke_payload() -> dict[str, Any]:
             "support_bundle_export_enabled": False,
         },
         "shell": {
-            "graphical_shell": "gtk4_placeholder",
+            "graphical_shell": "web_portal",
+            "origin": WEB_PORTAL_ORIGIN,
             "state": "offline_unpaired",
         },
         "ui": asdict(model),
@@ -233,7 +96,7 @@ def build_smoke_payload() -> dict[str, Any]:
 
 
 def render_smoke_json() -> str:
-    """Serialize the deterministic smoke payload and enforce its size bound."""
+    """Serialize the deterministic smoke payload under its fixed size limit."""
 
     rendered = json.dumps(
         build_smoke_payload(),
@@ -306,10 +169,7 @@ def _live_smoke_status(model: DiagnosticsControlUiModel) -> str:
         "api_token_missing": "daemon_token_missing",
         "unexpected_daemon_response": _LIVE_SMOKE_INVALID_RESPONSE,
     }
-    return statuses.get(
-        model.pairing.detail_code,
-        _LIVE_SMOKE_INVALID_RESPONSE,
-    )
+    return statuses.get(model.pairing.detail_code, _LIVE_SMOKE_INVALID_RESPONSE)
 
 
 def _emit_live_smoke(
@@ -327,6 +187,36 @@ def _emit_live_smoke(
         rendered = _render_live_smoke_json(model=model, status=status)
     print(rendered)
     return exit_code
+
+
+def _build_live_pairing_model(
+    *,
+    token: str,
+    client_factory,
+) -> DiagnosticsControlUiModel:
+    """Build bounded read-only smoke state from one explicit in-memory token."""
+
+    try:
+        pairing_result = TokenPairingController(client_factory).evaluate(token=token)
+    except Exception:
+        pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+    if not isinstance(pairing_result, FirstRunResult):
+        pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+    client = None
+    if pairing_result.state is FirstRunState.TOKEN_ACCEPTED:
+        try:
+            client = client_factory(token=token)
+        except Exception:
+            pairing_result = FirstRunResult(FirstRunState.INVALID_RESPONSE)
+
+    try:
+        return DiagnosticsControlUiController(client).build(
+            pairing_result=pairing_result,
+            mode=PresentationMode.BASIC,
+        )
+    finally:
+        client = None
 
 
 def run_live_pairing_smoke_json(
@@ -379,8 +269,9 @@ def run_live_pairing_smoke_json(
     factory = LocalApiClient if client_factory is None else client_factory
     try:
         try:
-            model = FirstRunTokenEntryController(client_factory=factory).connect(
-                token=token
+            model = _build_live_pairing_model(
+                token=token,
+                client_factory=factory,
             )
         except KeyboardInterrupt:
             model = build_initial_model()
@@ -393,14 +284,12 @@ def run_live_pairing_smoke_json(
     return _emit_live_smoke(
         model=model,
         status=status,
-        exit_code=(
-            0 if status == _LIVE_SMOKE_SUCCESS else _LIVE_SMOKE_FAILURE_EXIT
-        ),
+        exit_code=0 if status == _LIVE_SMOKE_SUCCESS else _LIVE_SMOKE_FAILURE_EXIT,
     )
 
 
 def _load_gtk():
-    """Import GTK only when the graphical entry point is launched."""
+    """Import GTK only when a graphical entry point is launched."""
 
     try:
         import gi
@@ -415,7 +304,7 @@ def _load_gtk():
 
 
 def _load_webkit():
-    """Import the GNOME 50 WebKitGTK namespace only for the opt-in shell."""
+    """Import the pinned WebKitGTK namespace only for the graphical shell."""
 
     try:
         import gi
@@ -580,815 +469,45 @@ def _clear_box(container) -> None:
         child = next_child
 
 
-def _severity_text(severity: StatusSeverity) -> str:
-    if not isinstance(severity, StatusSeverity):
-        severity = StatusSeverity.UNKNOWN
-    return severity.value.replace("_", " ").upper()
+def _populate_web_portal_error(Gtk, window) -> None:
+    """Show a fixed, bounded error surface without rendering exception details."""
 
-
-def _severity_css_class(severity: StatusSeverity) -> str:
-    return {
-        StatusSeverity.OK: "success",
-        StatusSeverity.WARNING: "warning",
-        StatusSeverity.BLOCKED: "error",
-        StatusSeverity.ERROR: "error",
-        StatusSeverity.UNKNOWN: "dim-label",
-    }.get(severity, "dim-label")
-
-
-def _install_dashboard_styles(Gtk, widget) -> None:
-    """Install the small native-dashboard stylesheet when GTK supports it."""
-
-    try:
-        provider = Gtk.CssProvider()
-        provider.load_from_data(_DASHBOARD_CSS)
-        display = widget.get_display()
-        if display is None:
-            return
-        Gtk.StyleContext.add_provider_for_display(
-            display,
-            provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
-        )
-    except (AttributeError, TypeError, ValueError):
-        return
-
-
-def _add_status_badge(
-    Gtk,
-    container,
-    severity: StatusSeverity,
-    *,
-    text: str | None = None,
-):
-    if not isinstance(severity, StatusSeverity):
-        severity = StatusSeverity.UNKNOWN
-    badge = Gtk.Frame()
-    badge.add_css_class("status-badge")
-    badge.add_css_class(f"severity-{severity.value}")
-    badge.add_css_class(_severity_css_class(severity))
-
-    label = Gtk.Label(label=text or _severity_text(severity))
-    label.add_css_class("caption")
-    label.add_css_class("heading")
-    label.add_css_class(_severity_css_class(severity))
-    label.set_margin_top(3)
-    label.set_margin_bottom(3)
-    label.set_margin_start(8)
-    label.set_margin_end(8)
-    badge.set_child(label)
-    container.append(badge)
-    return badge
-
-
-def _add_section_heading(
-    Gtk,
-    container,
-    title: str,
-    description: str,
-) -> None:
-    _add_text_label(Gtk, container, title, css_class="title-2")
-    _add_text_label(
-        Gtk,
-        container,
-        description,
-        css_class="dim-label",
-    )
-
-
-def _new_card(
-    Gtk,
-    *,
-    title: str,
-    severity: StatusSeverity | None,
-    css_classes: Sequence[str] = (),
-):
-    frame = Gtk.Frame()
-    frame.add_css_class("dashboard-card")
-    for css_class in css_classes:
-        frame.add_css_class(css_class)
-    frame.set_hexpand(True)
-
-    body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-    body.set_margin_top(16)
-    body.set_margin_bottom(16)
-    body.set_margin_start(16)
-    body.set_margin_end(16)
-
-    heading = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-    title_label = _add_text_label(
-        Gtk,
-        heading,
-        title,
-        css_class="title-3",
-    )
-    title_label.set_hexpand(True)
-    if severity is not None:
-        _add_status_badge(Gtk, heading, severity)
-    body.append(heading)
-    frame.set_child(body)
-    return frame, body
-
-
-def _new_fact_tile(Gtk, *, label: str, value: str):
-    frame = Gtk.Frame()
-    frame.add_css_class("dashboard-card")
-    body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-    body.set_margin_top(10)
-    body.set_margin_bottom(10)
-    body.set_margin_start(12)
-    body.set_margin_end(12)
-    _add_text_label(Gtk, body, label, css_class="caption")
-    _add_text_label(Gtk, body, value, css_class="heading")
-    frame.set_child(body)
-    return frame
-
-
-def _add_adapter_card(Gtk, container, card) -> None:
-    card_classes = ("recommended-card",) if card.recommended else ()
-    frame, body = _new_card(
-        Gtk,
-        title=card.interface,
-        severity=card.severity,
-        css_classes=card_classes,
-    )
-    if card.recommended:
-        recommendation_row = Gtk.Box(
-            orientation=Gtk.Orientation.HORIZONTAL,
-            spacing=8,
-        )
-        _add_status_badge(
-            Gtk,
-            recommendation_row,
-            StatusSeverity.OK,
-            text="RECOMMENDED",
-        )
-        _add_text_label(
-            Gtk,
-            recommendation_row,
-            "Daemon-recommended adapter",
-            css_class="heading",
-        )
-        body.append(recommendation_row)
-
-    _add_text_label(
-        Gtk,
-        body,
-        f"Readiness: {card.readiness_label}",
-        css_class="title-4",
-    )
-    _add_text_label(Gtk, body, card.summary)
-
-    details = Gtk.Grid(column_spacing=10, row_spacing=10)
-    details.set_column_homogeneous(True)
-    bands = ", ".join(card.supported_bands) or "Not reported"
-    score = (
-        str(card.recommendation_score)
-        if card.recommendation_score is not None
-        else "Not reported"
-    )
-    facts = (
-        ("Supported Bands", bands),
-        ("Recommendation Score", score),
-        ("Driver", card.driver),
-        ("Bus", card.bus_type),
-    )
-    for index, (label, value) in enumerate(facts):
-        details.attach(
-            _new_fact_tile(Gtk, label=label, value=value),
-            index % 2,
-            index // 2,
-            1,
-            1,
-        )
-    body.append(details)
-
-    _add_text_label(Gtk, body, "Top Reasons", css_class="heading")
-    if card.reasons:
-        for reason in card.reasons:
-            _add_text_label(Gtk, body, f"• {reason}")
-    else:
-        _add_text_label(
-            Gtk,
-            body,
-            "No readiness reasons were reported.",
-            css_class="dim-label",
-        )
-
-    container.append(frame)
-
-
-def _populate_daemon_card(Gtk, container, dashboard: NativeDashboardModel) -> None:
-    daemon = dashboard.daemon
-    title = _add_text_label(
-        Gtk,
-        container,
-        daemon.title,
-        css_class="title-2",
-    )
-    title.add_css_class(_severity_css_class(daemon.severity))
-    _add_text_label(Gtk, container, daemon.message)
-
-
-def _populate_pairing_card(Gtk, container, dashboard: NativeDashboardModel) -> None:
-    pairing = dashboard.pairing
-    if pairing.paired:
-        _add_status_badge(
-            Gtk,
-            container,
-            StatusSeverity.OK,
-            text="PAIRED",
-        )
-    title = _add_text_label(
-        Gtk,
-        container,
-        pairing.title,
-        css_class="title-2",
-    )
-    title.add_css_class(_severity_css_class(pairing.severity))
-    _add_text_label(Gtk, container, pairing.message)
-
-
-def _populate_adapter_summary_card(
-    Gtk,
-    container,
-    dashboard: NativeDashboardModel,
-) -> None:
-    adapters = dashboard.adapter_readiness
-    _add_text_label(Gtk, container, adapters.title, css_class="title-3")
-    _add_text_label(Gtk, container, adapters.summary)
-
-    recommendation = Gtk.Frame()
-    recommendation.add_css_class("dashboard-card")
-    recommendation.add_css_class("recommended-card")
-    body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
-    body.set_margin_top(12)
-    body.set_margin_bottom(12)
-    body.set_margin_start(12)
-    body.set_margin_end(12)
-
-    _add_text_label(Gtk, body, "Recommended", css_class="caption")
-    _add_text_label(
-        Gtk,
-        body,
-        adapters.recommended_interface,
-        css_class="title-2",
-    )
-    if adapters.recommended_interface == "Not reported":
-        _add_status_badge(
-            Gtk,
-            body,
-            StatusSeverity.UNKNOWN,
-            text="NOT REPORTED",
-        )
-    else:
-        _add_status_badge(
-            Gtk,
-            body,
-            StatusSeverity.OK,
-            text="DAEMON RECOMMENDED",
-        )
-    recommendation.set_child(body)
-    container.append(recommendation)
-
-
-def _add_issue_group(
-    Gtk,
-    container,
-    *,
-    title: str,
-    issues,
-    empty_text: str,
-) -> None:
-    frame, body = _new_card(Gtk, title=title, severity=None)
-    if issues:
-        for issue in issues:
-            issue_row = Gtk.Box(
-                orientation=Gtk.Orientation.VERTICAL,
-                spacing=4,
-            )
-            issue_heading = Gtk.Box(
-                orientation=Gtk.Orientation.HORIZONTAL,
-                spacing=8,
-            )
-            _add_status_badge(Gtk, issue_heading, issue.severity)
-            _add_text_label(
-                Gtk,
-                issue_heading,
-                issue.code,
-                css_class="caption",
-            )
-            issue_row.append(issue_heading)
-            _add_text_label(Gtk, issue_row, issue.message)
-            body.append(issue_row)
-    else:
-        _add_text_label(Gtk, body, empty_text, css_class="dim-label")
-    container.append(frame)
-
-
-def _populate_preflight_card(
-    Gtk,
-    container,
-    dashboard: NativeDashboardModel,
-) -> None:
-    preflight = dashboard.preflight
-    _add_text_label(
-        Gtk,
-        container,
-        dashboard.labels.host_summary,
-        css_class="title-3",
-    )
-    readiness_row = Gtk.Box(
-        orientation=Gtk.Orientation.HORIZONTAL,
-        spacing=8,
-    )
-    readiness_label = _add_text_label(
-        Gtk,
-        readiness_row,
-        preflight.readiness_label,
-        css_class="title-2",
-    )
-    readiness_label.set_hexpand(True)
-    _add_status_badge(Gtk, readiness_row, preflight.severity)
-    container.append(readiness_row)
-    _add_text_label(Gtk, container, preflight.summary)
-
-    _add_text_label(
-        Gtk,
-        container,
-        dashboard.labels.facts,
-        css_class="heading",
-    )
-    if preflight.facts:
-        facts_grid = Gtk.Grid(column_spacing=10, row_spacing=10)
-        facts_grid.set_column_homogeneous(True)
-        for index, fact in enumerate(preflight.facts):
-            facts_grid.attach(
-                _new_fact_tile(Gtk, label=fact.label, value=fact.value),
-                index % 2,
-                index // 2,
-                1,
-                1,
-            )
-        container.append(facts_grid)
-    else:
-        _add_text_label(
-            Gtk,
-            container,
-            "No preflight facts are available.",
-            css_class="dim-label",
-        )
-
-    blocking = tuple(
-        issue
-        for issue in preflight.issues
-        if issue.severity in {StatusSeverity.BLOCKED, StatusSeverity.ERROR}
-    )
-    warnings = tuple(
-        issue
-        for issue in preflight.issues
-        if issue.severity is StatusSeverity.WARNING
-    )
-    other = tuple(
-        issue
-        for issue in preflight.issues
-        if issue.severity not in {
-            StatusSeverity.BLOCKED,
-            StatusSeverity.ERROR,
-            StatusSeverity.WARNING,
-        }
-    )
-    issues_grid = Gtk.Grid(column_spacing=12, row_spacing=12)
-    issues_grid.set_column_homogeneous(True)
-    blocking_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-    warning_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-    _add_issue_group(
-        Gtk,
-        blocking_box,
-        title=dashboard.labels.blocking_issues,
-        issues=blocking,
-        empty_text="No blocking issues.",
-    )
-    _add_issue_group(
-        Gtk,
-        warning_box,
-        title=dashboard.labels.warnings,
-        issues=warnings,
-        empty_text="No warnings.",
-    )
-    issues_grid.attach(blocking_box, 0, 0, 1, 1)
-    issues_grid.attach(warning_box, 1, 0, 1, 1)
-    if other:
-        other_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        _add_issue_group(
-            Gtk,
-            other_box,
-            title=dashboard.labels.other_issues,
-            issues=other,
-            empty_text="No other issues.",
-        )
-        issues_grid.attach(other_box, 0, 1, 2, 1)
-    container.append(issues_grid)
-
-    actions_frame, actions_body = _new_card(
-        Gtk,
-        title=dashboard.labels.recommended_actions,
-        severity=None,
-    )
-    _add_text_label(
-        Gtk,
-        actions_body,
-        "Display-only guidance; no action can be run from this dashboard.",
-        css_class="dim-label",
-    )
-    if preflight.actions:
-        for action in preflight.actions:
-            _add_text_label(
-                Gtk,
-                actions_body,
-                action.message,
-            )
-            _add_text_label(
-                Gtk,
-                actions_body,
-                action.code,
-                css_class="caption",
-            )
-    else:
-        _add_text_label(
-            Gtk,
-            actions_body,
-            "No actions recommended.",
-            css_class="dim-label",
-        )
-    container.append(actions_frame)
-
-
-def _populate_support_bundle_card(
-    Gtk,
-    container,
-    dashboard: NativeDashboardModel,
-) -> None:
-    support_bundle = dashboard.support_bundle
-    _add_status_badge(
-        Gtk,
-        container,
-        StatusSeverity.UNKNOWN,
-        text="NOT AVAILABLE YET",
-    )
-    _add_text_label(Gtk, container, support_bundle.summary)
-    export_button = Gtk.Button(label=support_bundle.action_label)
-    export_button.set_sensitive(False)
-    container.append(export_button)
-    _add_text_label(
-        Gtk,
-        container,
-        "Export is disabled until the desktop save flow is implemented.",
-        css_class="dim-label",
-    )
-
-
-def _populate_controls_card(
-    Gtk,
-    container,
-    dashboard: NativeDashboardModel,
-) -> None:
-    controls = dashboard.controls
-    _add_status_badge(
-        Gtk,
-        container,
-        controls.severity,
-        text=controls.readiness_label.upper(),
-    )
-    _add_text_label(Gtk, container, controls.summary)
-    _add_text_label(
-        Gtk,
-        container,
-        "Mutation actions: none",
-        css_class="dim-label",
-    )
-
-
-def _render_dashboard_model(
-    Gtk,
-    container,
-    dashboard: NativeDashboardModel,
-) -> None:
-    """Render the bounded native dashboard with no interactive host actions."""
-
-    _clear_box(container)
-    labels = dashboard.labels
-    _add_section_heading(
-        Gtk,
-        container,
-        labels.overview,
-        "Daemon-owned readiness and diagnostics, presented without host mutation.",
-    )
-
-    _add_section_heading(
-        Gtk,
-        container,
-        labels.connection_pairing,
-        "Local daemon reachability and caller-validated pairing state.",
-    )
-    connection_grid = Gtk.Grid(column_spacing=16, row_spacing=16)
-    connection_grid.set_column_homogeneous(True)
-
-    daemon_frame, daemon_body = _new_card(
-        Gtk,
-        title="Daemon Status",
-        severity=dashboard.daemon.severity,
-    )
-    _populate_daemon_card(Gtk, daemon_body, dashboard)
-    connection_grid.attach(daemon_frame, 0, 0, 1, 1)
-
-    pairing_frame, pairing_body = _new_card(
-        Gtk,
-        title="Pairing Status",
-        severity=dashboard.pairing.severity,
-    )
-    _populate_pairing_card(Gtk, pairing_body, dashboard)
-    connection_grid.attach(pairing_frame, 1, 0, 1, 1)
-    container.append(connection_grid)
-
-    summary_frame, summary_body = _new_card(
-        Gtk,
-        title=labels.readiness_summary,
-        severity=dashboard.adapter_readiness.severity,
-    )
-    _populate_adapter_summary_card(Gtk, summary_body, dashboard)
-    container.append(summary_frame)
-
-    _add_section_heading(
-        Gtk,
-        container,
-        labels.adapter_readiness,
-        "Daemon-reported capabilities, readiness, and recommendation details.",
-    )
-    adapters_box = Gtk.Box(
-        orientation=Gtk.Orientation.VERTICAL,
-        spacing=12,
-    )
-    if dashboard.adapter_readiness.cards:
-        for card in dashboard.adapter_readiness.cards:
-            _add_adapter_card(Gtk, adapters_box, card)
-    else:
-        empty_frame, empty_body = _new_card(
-            Gtk,
-            title="No Adapters Reported",
-            severity=StatusSeverity.UNKNOWN,
-        )
-        _add_text_label(
-            Gtk,
-            empty_body,
-            "No adapter cards are available.",
-            css_class="dim-label",
-        )
-        adapters_box.append(empty_frame)
-    container.append(adapters_box)
-
-    _add_section_heading(
-        Gtk,
-        container,
-        labels.preflight_diagnostics,
-        "Read-only readiness report using the canonical daemon response.",
-    )
-    preflight_frame, preflight_body = _new_card(
-        Gtk,
-        title=labels.preflight_diagnostics,
-        severity=dashboard.preflight.severity,
-    )
-    _populate_preflight_card(Gtk, preflight_body, dashboard)
-    container.append(preflight_frame)
-
-    _add_section_heading(
-        Gtk,
-        container,
-        labels.unavailable_features,
-        "Planned capabilities shown explicitly as unavailable.",
-    )
-    unavailable_grid = Gtk.Grid(column_spacing=16, row_spacing=16)
-    unavailable_grid.set_column_homogeneous(True)
-    support_frame, support_body = _new_card(
-        Gtk,
-        title=labels.support_bundle,
-        severity=dashboard.support_bundle.severity,
-        css_classes=("unavailable-card",),
-    )
-    _populate_support_bundle_card(Gtk, support_body, dashboard)
-    unavailable_grid.attach(support_frame, 0, 0, 1, 1)
-
-    controls_frame, controls_body = _new_card(
-        Gtk,
-        title=labels.controls_boundary,
-        severity=dashboard.controls.severity,
-        css_classes=("unavailable-card",),
-    )
-    _populate_controls_card(Gtk, controls_body, dashboard)
-    unavailable_grid.attach(controls_frame, 1, 0, 1, 1)
-
-    container.append(unavailable_grid)
-
-
-def _render_display_model(Gtk, container, model: DiagnosticsControlUiModel) -> None:
-    """Render only bounded, token-free fields from the existing UI model."""
-
-    _render_dashboard_model(Gtk, container, build_dashboard_model(model))
-
-
-def _set_placeholder_text_compat(widget: Any, value: str) -> None:
-    """Set placeholder text when the active GTK binding supports either API."""
-
-    direct_setter = getattr(widget, "set_placeholder_text", None)
-    if callable(direct_setter):
-        try:
-            direct_setter(value)
-        except (AttributeError, TypeError):
-            pass
-        else:
-            return
-
-    property_setter = getattr(widget, "set_property", None)
-    if not callable(property_setter):
-        return
-
-    property_finder = getattr(widget, "find_property", None)
-    if callable(property_finder):
-        try:
-            if property_finder("placeholder-text") is None:
-                return
-        except (AttributeError, TypeError):
-            return
-
-    try:
-        property_setter("placeholder-text", value)
-    except (AttributeError, TypeError):
-        pass
-
-
-def _connect_from_token_entry(
-    *,
-    token_entry,
-    connect_button,
-    controller: FirstRunTokenEntryController,
-    render_model,
-) -> None:
-    """Clear caller input before validating and render only the safe result."""
-
-    token = token_entry.get_text()
-    token_entry.set_text("")
-    connect_button.set_sensitive(False)
-    try:
-        updated_model = controller.connect(token=token)
-        render_model(updated_model)
-    finally:
-        token = ""
-        connect_button.set_sensitive(True)
-
-
-def _populate_native_dashboard_window(Gtk, window) -> None:
-    """Populate one application window with the retained native dashboard."""
-
-    model = build_initial_model()
-    token_entry_controller = FirstRunTokenEntryController()
     window.set_title(APP_NAME)
-    window.set_default_size(1040, 900)
-    _install_dashboard_styles(Gtk, window)
-
-    scroller = Gtk.ScrolledWindow()
-    scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-
-    content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=20)
-    content.set_margin_top(28)
-    content.set_margin_bottom(28)
-    content.set_margin_start(28)
-    content.set_margin_end(28)
-
-    app_header = Gtk.Box(
-        orientation=Gtk.Orientation.HORIZONTAL,
-        spacing=16,
-    )
-    header_copy = Gtk.Box(
-        orientation=Gtk.Orientation.VERTICAL,
-        spacing=4,
-    )
-    header_copy.set_hexpand(True)
-    _add_text_label(Gtk, header_copy, APP_NAME, css_class="title-1")
+    window.set_default_size(720, 360)
+    error_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+    error_box.set_margin_top(36)
+    error_box.set_margin_bottom(36)
+    error_box.set_margin_start(36)
+    error_box.set_margin_end(36)
     _add_text_label(
         Gtk,
-        header_copy,
-        "Native Dashboard",
-        css_class="title-3",
+        error_box,
+        "Web Portal shell unavailable",
+        css_class="title-2",
     )
     _add_text_label(
         Gtk,
-        header_copy,
-        "Local VR readiness and diagnostics at a glance.",
-        css_class="dim-label",
+        error_box,
+        "VR Hotspot could not create its locked local WebKit window. "
+        "Confirm that WebKitGTK 6.0 is installed, then restart the companion. "
+        "No alternate interface or external site was opened.",
     )
-    app_header.append(header_copy)
-    header_badges = Gtk.Box(
-        orientation=Gtk.Orientation.VERTICAL,
-        spacing=6,
-    )
-    _add_status_badge(
-        Gtk,
-        header_badges,
-        StatusSeverity.UNKNOWN,
-        text="NATIVE GTK",
-    )
-    _add_status_badge(
-        Gtk,
-        header_badges,
-        StatusSeverity.OK,
-        text="READ-ONLY",
-    )
-    app_header.append(header_badges)
-    content.append(app_header)
-
-    connection_frame, connection_body = _new_card(
-        Gtk,
-        title="Connect to Local Daemon",
-        severity=None,
-    )
-    _add_text_label(
-        Gtk,
-        connection_body,
-        "Enter the API token configured for the local VRhotspot daemon. "
-        "The token is used in memory for this validation only and is not saved.",
-    )
-
-    connection_row = Gtk.Box(
-        orientation=Gtk.Orientation.HORIZONTAL,
-        spacing=8,
-    )
-    token_entry = Gtk.PasswordEntry()
-    _set_placeholder_text_compat(token_entry, "API token")
-    token_entry.set_show_peek_icon(True)
-    token_entry.set_hexpand(True)
-    connection_row.append(token_entry)
-
-    connect_button = Gtk.Button(label="Connect / Validate token")
-    connection_row.append(connect_button)
-    connection_body.append(connection_row)
-    _add_text_label(
-        Gtk,
-        connection_body,
-        "The entry is cleared before validation. Pairing does not persist a session.",
-        css_class="dim-label",
-    )
-    content.append(connection_frame)
-
-    display_sections = Gtk.Box(
-        orientation=Gtk.Orientation.VERTICAL,
-        spacing=16,
-    )
-    content.append(display_sections)
-    _render_display_model(Gtk, display_sections, model)
-
-    def on_connect(_widget) -> None:
-        _connect_from_token_entry(
-            token_entry=token_entry,
-            connect_button=connect_button,
-            controller=token_entry_controller,
-            render_model=lambda updated_model: _render_display_model(
-                Gtk,
-                display_sections,
-                updated_model,
-            ),
-        )
-
-    connect_button.connect("clicked", on_connect)
-    token_entry.connect("activate", on_connect)
-
-    scroller.set_child(content)
-    window.set_child(scroller)
-
-
-def run_gui() -> int:
-    """Run the retained native read-only dashboard."""
-
-    Gtk = _load_gtk()
-    application = Gtk.Application(application_id=APP_ID)
-
-    def on_activate(app) -> None:
-        window = Gtk.ApplicationWindow(application=app)
-        _populate_native_dashboard_window(Gtk, window)
-        window.present()
-
-    application.connect("activate", on_activate)
-    return int(application.run([]))
+    window.set_child(error_box)
 
 
 def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
-    """Populate a locked portal shell, or report that native fallback is needed."""
+    """Populate the locked portal shell or a bounded error surface."""
 
     window.set_title(APP_NAME)
     window.set_default_size(1200, 900)
     root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+    if WebKit is None:
+        _populate_web_portal_error(Gtk, window)
+        return False
     try:
         web_view = _build_locked_web_portal_view(WebKit)
     except Exception:
+        _populate_web_portal_error(Gtk, window)
         return False
 
     web_view.set_hexpand(True)
@@ -1440,17 +559,38 @@ def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
     return True
 
 
+def _populate_new_portal_window(Gtk, window) -> bool:
+    """Load WebKit lazily and always leave the window with bounded content."""
+
+    try:
+        WebKit = _load_webkit()
+    except Exception:
+        WebKit = None
+    return _populate_web_portal_window(Gtk, WebKit, window)
+
+
 def run_web_portal_shell() -> int:
-    """Run the opt-in daemon-served Web Portal inside a locked WebKit view."""
+    """Run the only Flatpak graphical UI inside a locked WebKit view."""
 
     Gtk = _load_gtk()
-    WebKit = _load_webkit()
     application = Gtk.Application(application_id=APP_ID)
+    window_holder: dict[str, Any] = {}
 
     def on_activate(app) -> None:
+        existing = window_holder.get("window")
+        if existing is not None:
+            existing.present()
+            return
+
         window = Gtk.ApplicationWindow(application=app)
-        if not _populate_web_portal_window(Gtk, WebKit, window):
-            _populate_native_dashboard_window(Gtk, window)
+        _populate_new_portal_window(Gtk, window)
+
+        def clear_window(*_args):
+            window_holder.pop("window", None)
+            return False
+
+        window.connect("close-request", clear_window)
+        window_holder["window"] = window
         window.present()
 
     application.connect("activate", on_activate)
@@ -1458,7 +598,7 @@ def run_web_portal_shell() -> int:
 
 
 def run_tray() -> int:
-    """Run the native app with an optional persistent StatusNotifierItem."""
+    """Run the Web Portal window with a persistent StatusNotifierItem."""
 
     Gtk = _load_gtk()
     Gdk, Gio, GLib = _load_tray_desktop_modules()
@@ -1471,7 +611,6 @@ def run_tray() -> int:
 
     application = Gtk.Application(application_id=APP_ID)
     runtime_holder: dict[str, Any] = {}
-    portal_window_holder: dict[str, Any] = {}
 
     def on_activate(app) -> None:
         existing = runtime_holder.get("runtime")
@@ -1480,7 +619,7 @@ def run_tray() -> int:
             return
 
         window = Gtk.ApplicationWindow(application=app)
-        _populate_native_dashboard_window(Gtk, window)
+        _populate_new_portal_window(Gtk, window)
         authentication = AuthenticationController()
         controls = TrayControlController(authentication)
         lifecycle = WindowLifecycleController(
@@ -1490,33 +629,6 @@ def run_tray() -> int:
 
         def open_diagnostics() -> None:
             lifecycle.show()
-
-        def open_web_portal() -> None:
-            existing_portal = portal_window_holder.get("window")
-            if existing_portal is not None:
-                existing_portal.present()
-                return
-            try:
-                WebKit = _load_webkit()
-                portal_window = Gtk.ApplicationWindow(application=app)
-                if not _populate_web_portal_window(
-                    Gtk,
-                    WebKit,
-                    portal_window,
-                ):
-                    lifecycle.show()
-                    return
-            except Exception:
-                lifecycle.show()
-                return
-
-            def clear_portal(*_args):
-                portal_window_holder.pop("window", None)
-                return False
-
-            portal_window.connect("close-request", clear_portal)
-            portal_window_holder["window"] = portal_window
-            portal_window.present()
 
         initial_menu = build_tray_menu_model(
             controls.state,
@@ -1542,7 +654,6 @@ def run_tray() -> int:
             Gio=Gio,
             GLib=GLib,
             open_diagnostics=open_diagnostics,
-            open_web_portal=open_web_portal,
         )
         runtime_holder["runtime"] = runtime
         window.connect("close-request", runtime.close_request)
@@ -1556,7 +667,7 @@ def run_tray() -> int:
 def _argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="vrhotspot-flatpak",
-        description="VR Hotspot Flatpak app shell prototype",
+        description="VR Hotspot Flatpak Web Portal shell",
     )
     parser.add_argument(
         "--smoke-json",
@@ -1574,7 +685,7 @@ def _argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--web-portal-shell",
         action="store_true",
-        help="launch the locked local daemon Web Portal shell spike",
+        help="compatibility alias for the default graphical shell",
     )
     parser.add_argument(
         "--tray",
@@ -1585,7 +696,7 @@ def _argument_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run a deterministic smoke path or launch the GTK dashboard."""
+    """Run a smoke path, tray companion, or the default Web Portal shell."""
 
     args = _argument_parser().parse_args(argv)
     if args.smoke_json:
@@ -1593,11 +704,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if args.live_pairing_smoke_json:
         return run_live_pairing_smoke_json()
-    if args.web_portal_shell:
-        try:
-            return run_web_portal_shell()
-        except WebKitUnavailableError:
-            pass
     if args.tray:
         try:
             return run_tray()
@@ -1605,10 +711,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             pass
 
     try:
-        return run_gui()
+        return run_web_portal_shell()
     except GuiUnavailableError:
         print(
-            "The native dashboard requires GTK 4 and PyGObject. "
+            "The Web Portal shell requires GTK 4, WebKitGTK 6.0, and PyGObject. "
             "Use --smoke-json for the offline shell check.",
             file=sys.stderr,
         )

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -22,6 +22,8 @@ ICON_NAMES = {
     TrayStatus.STOPPED: APP_ID,
     TrayStatus.RUNNING: f"{APP_ID}-running",
     TrayStatus.TRANSITIONING: f"{APP_ID}-working",
+    TrayStatus.NEEDS_AUTHENTICATION: f"{APP_ID}-error",
+    TrayStatus.DAEMON_UNAVAILABLE: f"{APP_ID}-error",
     TrayStatus.ERROR: f"{APP_ID}-error",
 }
 
@@ -70,32 +72,32 @@ def build_tray_menu_model(
             f"Current status: {state.status_label}",
             enabled=False,
         ),
-        TrayMenuItem(5, "separator-2", "", separator=True),
         TrayMenuItem(
-            6,
+            5,
+            "refresh",
+            "Refresh Status",
+            enabled=state.busy_action is None,
+        ),
+        TrayMenuItem(6, "separator-2", "", separator=True),
+        TrayMenuItem(
+            7,
             "start",
             "Start Hotspot",
             enabled=ready and state.status is TrayStatus.STOPPED,
         ),
         TrayMenuItem(
-            7,
+            8,
             "stop",
             "Stop Hotspot",
             enabled=ready and state.status is TrayStatus.RUNNING,
         ),
         TrayMenuItem(
-            8,
+            9,
             "restart",
             "Restart Service",
             enabled=ready and state.status is TrayStatus.RUNNING,
         ),
-        TrayMenuItem(9, "repair", "Repair Network", enabled=ready),
-        TrayMenuItem(
-            10,
-            "refresh",
-            "Refresh Status",
-            enabled=state.busy_action is None,
-        ),
+        TrayMenuItem(10, "repair", "Repair Network", enabled=ready),
         TrayMenuItem(11, "separator-3", "", separator=True),
         TrayMenuItem(
             12,
@@ -119,16 +121,23 @@ def build_tray_menu_model(
         ),
         TrayMenuItem(15, "separator-4", "", separator=True),
         TrayMenuItem(16, "authentication", "Authentication…"),
-        TrayMenuItem(17, "diagnostics", "Open Diagnostics"),
-        TrayMenuItem(18, "web_portal", "Open Web Portal Shell"),
-        TrayMenuItem(19, "separator-5", "", separator=True),
+        TrayMenuItem(17, "separator-5", "", separator=True),
+        TrayMenuItem(18, "diagnostics", "Open Diagnostics"),
+        TrayMenuItem(19, "separator-6", "", separator=True),
         TrayMenuItem(20, "quit", "Quit VR Hotspot"),
     )
     return TrayMenuModel(
         items=items,
         icon_name=ICON_NAMES[state.status],
         notifier_status=(
-            "NeedsAttention" if state.status is TrayStatus.ERROR else "Active"
+            "NeedsAttention"
+            if state.status
+            in {
+                TrayStatus.NEEDS_AUTHENTICATION,
+                TrayStatus.DAEMON_UNAVAILABLE,
+                TrayStatus.ERROR,
+            }
+            else "Active"
         ),
         tooltip=f"{APP_NAME} — {state.status_label}",
     )
@@ -635,7 +644,6 @@ class TrayRuntime:
         Gio,
         GLib,
         open_diagnostics: Callable[[], None],
-        open_web_portal: Callable[[], None],
     ):
         self._application = application
         self._lifecycle = lifecycle
@@ -647,7 +655,6 @@ class TrayRuntime:
         self._Gio = Gio
         self._GLib = GLib
         self._open_diagnostics = open_diagnostics
-        self._open_web_portal = open_web_portal
         self._worker_lock = threading.Lock()
         self._notification_counter = 0
         self._last_detail_code = ""
@@ -1007,8 +1014,6 @@ class TrayRuntime:
             self._open_authentication()
         elif action == "diagnostics":
             self._open_diagnostics()
-        elif action == "web_portal":
-            self._open_web_portal()
         elif action == "quit":
             self._backend.stop()
             self._lifecycle.quit_companion()

--- a/flatpak_client/control.py
+++ b/flatpak_client/control.py
@@ -21,6 +21,8 @@ class TrayStatus(str, Enum):
     RUNNING = "running"
     STOPPED = "stopped"
     TRANSITIONING = "transitioning"
+    NEEDS_AUTHENTICATION = "needs_authentication"
+    DAEMON_UNAVAILABLE = "daemon_unavailable"
     ERROR = "error"
 
 
@@ -28,8 +30,8 @@ class TrayStatus(str, Enum):
 class TrayState:
     """Bounded, token-free state consumed by any tray backend."""
 
-    status: TrayStatus = TrayStatus.ERROR
-    status_label: str = "Error"
+    status: TrayStatus = TrayStatus.NEEDS_AUTHENTICATION
+    status_label: str = "Needs Authentication"
     phase: str = "unknown"
     running: bool = False
     daemon_available: bool = False
@@ -90,19 +92,27 @@ class TrayControlController:
             self._state = state
             return state
 
-    def _error_state(
+    def _classified_failure_state(
         self,
         *,
+        status: TrayStatus,
         message: str,
         detail_code: str,
         daemon_available: bool,
         authenticated: bool = False,
     ) -> TrayState:
+        labels = {
+            TrayStatus.NEEDS_AUTHENTICATION: "Needs Authentication",
+            TrayStatus.DAEMON_UNAVAILABLE: "Daemon Unavailable",
+            TrayStatus.ERROR: "Error",
+        }
+        if status not in labels:
+            status = TrayStatus.ERROR
         current = self.state
         return TrayState(
-            status=TrayStatus.ERROR,
-            status_label="Error",
-            phase="error",
+            status=status,
+            status_label=labels[status],
+            phase=status.value,
             daemon_available=daemon_available,
             authenticated=authenticated,
             privacy_mode=current.privacy_mode,
@@ -114,10 +124,7 @@ class TrayControlController:
         token = self._token_provider.token_for_operation()
         if not token:
             return None
-        try:
-            return self._client_factory(token=token)
-        except Exception:
-            return None
+        return self._client_factory(token=token)
 
     def _state_from_responses(
         self,
@@ -182,31 +189,36 @@ class TrayControlController:
                 raise TypeError
             return self._state_from_responses(status_response, config_response)
         except AuthenticationError:
-            return self._error_state(
+            return self._classified_failure_state(
+                status=TrayStatus.NEEDS_AUTHENTICATION,
                 message="Authentication was rejected.",
                 detail_code="authentication_rejected",
                 daemon_available=True,
             )
         except DaemonTokenMissingError:
-            return self._error_state(
+            return self._classified_failure_state(
+                status=TrayStatus.NEEDS_AUTHENTICATION,
                 message="The daemon has no configured API token.",
                 detail_code="daemon_token_missing",
                 daemon_available=True,
             )
         except ConnectionFailure:
-            return self._error_state(
+            return self._classified_failure_state(
+                status=TrayStatus.DAEMON_UNAVAILABLE,
                 message="The local daemon is unavailable.",
                 detail_code="daemon_unavailable",
                 daemon_available=False,
             )
         except (LocalApiClientError, TypeError):
-            return self._error_state(
+            return self._classified_failure_state(
+                status=TrayStatus.ERROR,
                 message="The daemon returned an unsupported response.",
                 detail_code="invalid_response",
                 daemon_available=True,
             )
         except Exception:
-            return self._error_state(
+            return self._classified_failure_state(
+                status=TrayStatus.ERROR,
                 message="The tray operation failed safely.",
                 detail_code="operation_failed",
                 daemon_available=False,
@@ -216,10 +228,30 @@ class TrayControlController:
         if not self._operation_lock.acquire(blocking=False):
             return self.state
         try:
-            client = self._client()
+            try:
+                client = self._client()
+            except LocalApiClientError:
+                return self._set_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
+                        message="Enter a valid daemon API token in Authentication.",
+                        detail_code="token_invalid",
+                        daemon_available=False,
+                    )
+                )
+            except Exception:
+                return self._set_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.ERROR,
+                        message="The tray operation failed safely.",
+                        detail_code="operation_failed",
+                        daemon_available=False,
+                    )
+                )
             if client is None:
                 return self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
                         message="Enter the daemon API token in Authentication.",
                         detail_code="token_missing",
                         daemon_available=False,
@@ -261,10 +293,44 @@ class TrayControlController:
 
         self._set_state(self._working_state(action))
         try:
-            client = self._client()
+            try:
+                client = self._client()
+            except LocalApiClientError:
+                state = self._set_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
+                        message="Enter a valid daemon API token in Authentication.",
+                        detail_code="token_invalid",
+                        daemon_available=False,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="token_invalid",
+                    message=state.message,
+                    state=state,
+                )
+            except Exception:
+                state = self._set_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.ERROR,
+                        message="The requested operation failed.",
+                        detail_code="operation_failed",
+                        daemon_available=False,
+                    )
+                )
+                return ActionOutcome(
+                    accepted=True,
+                    succeeded=False,
+                    code="operation_failed",
+                    message=state.message,
+                    state=state,
+                )
             if client is None:
                 state = self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
                         message="Enter the daemon API token in Authentication.",
                         detail_code="token_missing",
                         daemon_available=False,
@@ -305,7 +371,8 @@ class TrayControlController:
                     response = call()
             except AuthenticationError:
                 state = self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
                         message="Authentication was rejected.",
                         detail_code="authentication_rejected",
                         daemon_available=True,
@@ -320,7 +387,8 @@ class TrayControlController:
                 )
             except DaemonTokenMissingError:
                 state = self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.NEEDS_AUTHENTICATION,
                         message="The daemon has no configured API token.",
                         detail_code="daemon_token_missing",
                         daemon_available=True,
@@ -335,7 +403,8 @@ class TrayControlController:
                 )
             except ConnectionFailure:
                 state = self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.DAEMON_UNAVAILABLE,
                         message="The local daemon is unavailable.",
                         detail_code="daemon_unavailable",
                         daemon_available=False,
@@ -350,7 +419,8 @@ class TrayControlController:
                 )
             except Exception:
                 state = self._set_state(
-                    self._error_state(
+                    self._classified_failure_state(
+                        status=TrayStatus.ERROR,
                         message="The requested operation failed.",
                         detail_code="operation_failed",
                         daemon_available=True,

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -1,10 +1,8 @@
 import configparser
-from dataclasses import asdict
 import importlib
 import inspect
 import json
 from pathlib import Path
-import re
 import subprocess
 import sys
 import warnings
@@ -27,12 +25,12 @@ METAINFO_PATH = Path("packaging/flatpak") / f"{APP_ID}.metainfo.xml"
 LAUNCHER_PATH = Path("packaging/flatpak/vrhotspot-flatpak")
 
 
-def _api_response(data):
+def _api_response(data, *, result_code="ok"):
     from flatpak_client import ApiResponse
 
     return ApiResponse(
-        correlation_id="token-entry-ui-test",
-        result_code="ok",
+        correlation_id="flatpak-shell-test",
+        result_code=result_code,
         warnings=(),
         data=data,
     )
@@ -50,10 +48,7 @@ def _readiness_response():
                     "bus_type": "usb",
                     "supports_5ghz": True,
                     "readiness_state": "ready",
-                    "reason_codes": [
-                        "supports_ap_mode",
-                        "daemon_recommended",
-                    ],
+                    "reason_codes": ["supports_ap_mode", "daemon_recommended"],
                     "explanation": "Ready for display-only diagnostics.",
                 }
             ],
@@ -78,12 +73,7 @@ def _preflight_response():
                     "message": "Review the daemon-reported readiness.",
                 }
             ],
-            "recommended_actions": [
-                {
-                    "code": "review_example",
-                    "message": "Review this display-only guidance.",
-                }
-            ],
+            "recommended_actions": [],
         }
     )
 
@@ -141,8 +131,7 @@ class FakeGtkWidget:
         self.parent = None
         self.css_classes = []
         self.signal_handlers = {}
-        self.sensitive = True
-        self.show_peek_icon = False
+        self.visible = False
 
     def append(self, child):
         child.parent = self
@@ -150,9 +139,6 @@ class FakeGtkWidget:
 
     def set_child(self, child):
         self.children = []
-        self.append(child)
-
-    def attach(self, child, *_position):
         self.append(child)
 
     def get_first_child(self):
@@ -172,9 +158,6 @@ class FakeGtkWidget:
     def add_css_class(self, css_class):
         self.css_classes.append(css_class)
 
-    def set_sensitive(self, sensitive):
-        self.sensitive = sensitive
-
     def connect(self, signal, handler):
         self.signal_handlers[signal] = handler
 
@@ -190,9 +173,6 @@ class FakeGtkWidget:
     def set_vexpand(self, _expand):
         pass
 
-    def set_column_homogeneous(self, _homogeneous):
-        pass
-
     def set_margin_top(self, _margin):
         pass
 
@@ -205,26 +185,35 @@ class FakeGtkWidget:
     def set_margin_end(self, _margin):
         pass
 
-    def set_show_peek_icon(self, show):
-        self.show_peek_icon = show
-
 
 class FakeGtkApplication:
+    activations = 1
+    last_created = None
+
     def __init__(self, *, application_id):
         self.application_id = application_id
         self.signal_handlers = {}
+        type(self).last_created = self
 
     def connect(self, signal, handler):
         self.signal_handlers[signal] = handler
 
     def run(self, arguments):
         assert arguments == []
-        self.signal_handlers["activate"](self)
+        for _index in range(type(self).activations):
+            self.signal_handlers["activate"](self)
         return 0
 
 
 class FakeGtkApplicationWindow(FakeGtkWidget):
+    created = []
     last_presented = None
+
+    def __init__(self, **properties):
+        super().__init__(**properties)
+        self.present_calls = 0
+        self.hide_calls = 0
+        type(self).created.append(self)
 
     def set_title(self, _title):
         pass
@@ -233,12 +222,13 @@ class FakeGtkApplicationWindow(FakeGtkWidget):
         pass
 
     def present(self):
+        self.visible = True
+        self.present_calls += 1
         type(self).last_presented = self
 
-
-class FakeGtkScrolledWindow(FakeGtkWidget):
-    def set_policy(self, _horizontal, _vertical):
-        pass
+    def hide(self):
+        self.visible = False
+        self.hide_calls += 1
 
 
 class FakeGtkLabel(FakeGtkWidget):
@@ -253,28 +243,16 @@ class FakeGtkButton(FakeGtkWidget):
         self.label = label
 
 
-class FakeGtkPasswordEntry(FakeGtkWidget):
-    pass
-
-
 class FakeGtk:
     class Orientation:
         VERTICAL = "vertical"
         HORIZONTAL = "horizontal"
 
-    class PolicyType:
-        NEVER = "never"
-        AUTOMATIC = "automatic"
-
     Application = FakeGtkApplication
     ApplicationWindow = FakeGtkApplicationWindow
-    ScrolledWindow = FakeGtkScrolledWindow
     Box = FakeGtkWidget
-    Frame = FakeGtkWidget
-    Grid = FakeGtkWidget
     Label = FakeGtkLabel
     Button = FakeGtkButton
-    PasswordEntry = FakeGtkPasswordEntry
 
 
 class FakeCookieManager:
@@ -322,6 +300,7 @@ class FakeWebKitSettings:
 
 
 class FakeWebKitWebView(FakeGtkWidget):
+    created = []
     last_created = None
 
     def __init__(self, **properties):
@@ -329,6 +308,7 @@ class FakeWebKitWebView(FakeGtkWidget):
         self.properties = properties
         self.loaded_uris = []
         self.zoom_levels = []
+        type(self).created.append(self)
         type(self).last_created = self
 
     def load_uri(self, uri):
@@ -358,12 +338,20 @@ def _walk_fake_widgets(widget):
         yield from _walk_fake_widgets(child)
 
 
-def _fake_labels_under(widget):
+def _labels_under(widget):
     return {
         child.label
         for child in _walk_fake_widgets(widget)
         if isinstance(child, FakeGtkLabel)
     }
+
+
+def _reset_gui_fakes():
+    FakeGtkApplication.activations = 1
+    FakeGtkApplicationWindow.created = []
+    FakeGtkApplicationWindow.last_presented = None
+    FakeWebKitWebView.created = []
+    FakeWebKitWebView.last_created = None
 
 
 def _manifest():
@@ -445,13 +433,12 @@ def test_web_portal_shell_rejects_arbitrary_or_non_pinned_urls(uri):
         ("navigation", "http://127.0.0.1:8732/ui", "use"),
         ("navigation", "https://example.com/", "ignore"),
         ("new-window", "http://127.0.0.1:8732/ui", "ignore"),
-        ("new-window", "https://example.com/", "ignore"),
         ("response", "http://127.0.0.1:8732/assets/ui.js", "use"),
         ("response", "https://example.com/remote.js", "ignore"),
         ("unknown", "http://127.0.0.1:8732/ui", "ignore"),
     ),
 )
-def test_web_portal_policy_explicitly_blocks_external_and_new_window_navigation(
+def test_web_portal_policy_is_origin_locked(
     decision_type,
     uri,
     expected_action,
@@ -500,7 +487,7 @@ def test_web_portal_policy_explicitly_blocks_external_and_new_window_navigation(
     assert decision.actions == [expected_action]
 
 
-def test_locked_web_portal_view_is_ephemeral_and_has_no_injection_surface():
+def test_locked_web_portal_view_is_ephemeral_zoomed_and_has_no_injection():
     from flatpak_app import app
 
     web_view = app._build_locked_web_portal_view(FakeWebKit)
@@ -508,31 +495,20 @@ def test_locked_web_portal_view_is_ephemeral_and_has_no_injection_surface():
     settings = FakeWebKitSettings.last_created
     source = inspect.getsource(app._build_locked_web_portal_view)
 
-    assert session is not None
     assert session.is_ephemeral() is True
     assert session.persistent_credentials is False
     assert session.cookie_manager.accept_policy == "never"
     assert web_view.properties["network_session"] is session
     assert web_view.properties["settings"] is settings
-    assert web_view.zoom_levels == [app.WEB_PORTAL_SHELL_ZOOM]
+    assert web_view.zoom_levels == [1.75]
     assert app.WEB_PORTAL_SHELL_ZOOM == 1.75
-    assert (
-        app._WEB_PORTAL_SHELL_ZOOM_MIN
-        <= app.WEB_PORTAL_SHELL_ZOOM
-        <= app._WEB_PORTAL_SHELL_ZOOM_MAX
-    )
-    assert (
-        web_view.properties["default_content_security_policy"]
-        == app._WEB_PORTAL_CSP
-    )
+    assert web_view.properties["default_content_security_policy"] == app._WEB_PORTAL_CSP
     assert app.WEB_PORTAL_ORIGIN in app._WEB_PORTAL_CSP
     assert "object-src 'none'" in app._WEB_PORTAL_CSP
     assert "frame-src 'none'" in app._WEB_PORTAL_CSP
     assert settings.values["set_enable_dns_prefetching"] is False
     assert settings.values["set_enable_page_cache"] is False
-    assert (
-        settings.values["set_javascript_can_open_windows_automatically"] is False
-    )
+    assert settings.values["set_javascript_can_open_windows_automatically"] is False
     assert {
         "decide-policy",
         "create",
@@ -548,19 +524,15 @@ def test_locked_web_portal_view_is_ephemeral_and_has_no_injection_surface():
         "UserScript",
         "add_script",
         "add_style_sheet",
-        "set_uri(",
     ):
         assert forbidden not in source
 
 
 @pytest.mark.parametrize(
     ("configured_zoom", "expected_zoom"),
-    (
-        (-100.0, 1.0),
-        (100.0, 2.0),
-    ),
+    ((-100.0, 1.0), (100.0, 2.0)),
 )
-def test_web_portal_shell_zoom_is_bounded_and_has_no_runtime_input(
+def test_web_portal_shell_zoom_is_bounded(
     monkeypatch,
     configured_zoom,
     expected_zoom,
@@ -573,51 +545,184 @@ def test_web_portal_shell_zoom_is_bounded_and_has_no_runtime_input(
     assert app._bounded_web_portal_shell_zoom() == expected_zoom
 
 
-def test_web_portal_shell_loads_only_the_fixed_daemon_served_route(monkeypatch):
+def test_default_graphical_launch_uses_one_web_portal_window(monkeypatch):
     from flatpak_app import app
 
-    FakeGtkApplicationWindow.last_presented = None
-    FakeWebKitWebView.last_created = None
+    _reset_gui_fakes()
     monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
     monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
 
-    assert app.run_web_portal_shell() == 0
+    assert app.main([]) == 0
+    assert len(FakeGtkApplicationWindow.created) == 1
+    assert len(FakeWebKitWebView.created) == 1
+    assert FakeWebKitWebView.last_created.loaded_uris == [app.WEB_PORTAL_URL]
 
-    window = FakeGtkApplicationWindow.last_presented
-    web_view = FakeWebKitWebView.last_created
-    assert window is not None
-    assert web_view is not None
-    assert web_view.loaded_uris == [app.WEB_PORTAL_URL]
-    assert "load-failed" in web_view.signal_handlers
-    assert not any(
-        isinstance(widget, FakeGtkPasswordEntry)
-        for widget in _walk_fake_widgets(window)
+
+def test_compatibility_alias_uses_default_web_portal_behavior(monkeypatch):
+    from flatpak_app import app
+
+    calls = []
+    monkeypatch.setattr(
+        app,
+        "run_web_portal_shell",
+        lambda: calls.append("web-portal") or 17,
     )
 
+    assert app.main(["--web-portal-shell"]) == 17
+    assert calls == ["web-portal"]
+    with pytest.raises(SystemExit):
+        app._argument_parser().parse_args(["--web-portal-shell=https://example.com"])
 
-def test_web_portal_load_failure_shows_bounded_safe_retry_ui(monkeypatch):
+
+def test_repeated_activation_restores_without_duplicate_windows(monkeypatch):
     from flatpak_app import app
 
-    FakeGtkApplicationWindow.last_presented = None
+    _reset_gui_fakes()
+    FakeGtkApplication.activations = 3
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+
+    assert app.run_web_portal_shell() == 0
+    assert len(FakeGtkApplicationWindow.created) == 1
+    assert len(FakeWebKitWebView.created) == 1
+    assert FakeGtkApplicationWindow.created[0].present_calls == 3
+
+
+def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
+    from flatpak_app import app
+    from flatpak_app import tray
+    from flatpak_client import TrayState
+
+    _reset_gui_fakes()
+    FakeGtkApplication.activations = 2
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(
+        app,
+        "_load_tray_desktop_modules",
+        lambda: (object(), object(), object()),
+    )
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+    monkeypatch.setattr(app, "AuthenticationController", lambda: object())
+    monkeypatch.setattr(
+        app,
+        "TrayControlController",
+        lambda _authentication: type("Controls", (), {"state": TrayState()})(),
+    )
+    captured = {}
+
+    class Backend:
+        def __init__(self, **kwargs):
+            captured["primary"] = kwargs["on_activate"]
+
+    class Runtime:
+        def __init__(self, *, lifecycle, **_kwargs):
+            self.lifecycle = lifecycle
+            captured["runtime"] = self
+
+        def show(self):
+            self.lifecycle.show()
+
+        def start(self):
+            return True
+
+        def close_request(self, *_args):
+            return self.lifecycle.close_request(*_args)
+
+        def dispatch_action(self, _action):
+            pass
+
+    monkeypatch.setattr(tray, "StatusNotifierBackend", Backend)
+    monkeypatch.setattr(tray, "TrayRuntime", Runtime)
+
+    assert app.run_tray() == 0
+    captured["primary"]()
+
+    assert len(FakeGtkApplicationWindow.created) == 1
+    assert len(FakeWebKitWebView.created) == 1
+    assert FakeWebKitWebView.last_created.loaded_uris == [app.WEB_PORTAL_URL]
+    assert FakeGtkApplicationWindow.created[0].present_calls == 3
+
+
+def test_webkit_unavailable_shows_bounded_error_without_alternate_ui(monkeypatch):
+    from flatpak_app import app
+
+    _reset_gui_fakes()
+    secret = "webkit-detail-must-not-render"
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+
+    def unavailable():
+        raise app.WebKitUnavailableError(secret)
+
+    monkeypatch.setattr(app, "_load_webkit", unavailable)
+
+    assert app.run_web_portal_shell() == 0
+    window = FakeGtkApplicationWindow.last_presented
+    labels = _labels_under(window)
+    assert "Web Portal shell unavailable" in labels
+    assert secret not in repr(labels)
+    assert FakeWebKitWebView.created == []
+
+
+def test_unexpected_webkit_loader_failure_is_also_bounded(monkeypatch):
+    from flatpak_app import app
+
+    _reset_gui_fakes()
+    secret = "unexpected-webkit-detail-must-not-render"
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+
+    def unavailable():
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(app, "_load_webkit", unavailable)
+
+    assert app.run_web_portal_shell() == 0
+    labels = _labels_under(FakeGtkApplicationWindow.last_presented)
+    assert "Web Portal shell unavailable" in labels
+    assert secret not in repr(labels)
+    assert FakeWebKitWebView.created == []
+
+
+def test_webkit_construction_failure_shows_same_bounded_error(monkeypatch):
+    from flatpak_app import app
+
+    _reset_gui_fakes()
+    secret = "construction-detail-must-not-render"
+    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
+    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+
+    def fail_to_construct(_webkit):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(app, "_build_locked_web_portal_view", fail_to_construct)
+
+    assert app.run_web_portal_shell() == 0
+    labels = _labels_under(FakeGtkApplicationWindow.last_presented)
+    assert "Web Portal shell unavailable" in labels
+    assert secret not in repr(labels)
+
+
+def test_web_portal_load_failure_has_bounded_safe_retry(monkeypatch):
+    from flatpak_app import app
+
+    _reset_gui_fakes()
     monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
     monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
     assert app.run_web_portal_shell() == 0
 
     window = FakeGtkApplicationWindow.last_presented
     web_view = FakeWebKitWebView.last_created
-    secret = "failure-detail-must-not-render"
+    secret = "load-detail-must-not-render"
     handled = web_view.signal_handlers["load-failed"](
         web_view,
         "started",
         app.WEB_PORTAL_URL,
         RuntimeError(secret),
     )
-    widgets = tuple(_walk_fake_widgets(window))
-    labels = {
-        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
-    }
+    labels = _labels_under(window)
     buttons = [
-        widget for widget in widgets if isinstance(widget, FakeGtkButton)
+        widget
+        for widget in _walk_fake_widgets(window)
+        if isinstance(widget, FakeGtkButton)
     ]
 
     assert handled is True
@@ -628,215 +733,26 @@ def test_web_portal_load_failure_shows_bounded_safe_retry_ui(monkeypatch):
     assert web_view.loaded_uris == [app.WEB_PORTAL_URL, app.WEB_PORTAL_URL]
 
 
-def test_webkit_unavailable_falls_back_to_native_dashboard(monkeypatch):
+def test_retired_graphical_implementation_symbols_are_absent():
     from flatpak_app import app
 
-    calls = []
-
-    def unavailable():
-        raise app.WebKitUnavailableError("bounded")
-
-    monkeypatch.setattr(app, "run_web_portal_shell", unavailable)
-    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 19)
-
-    assert app.main(["--web-portal-shell"]) == 19
-    assert calls == ["native"]
-
-
-def test_webkit_construction_failure_falls_back_in_the_same_window(monkeypatch):
-    from flatpak_app import app
-
-    FakeGtkApplicationWindow.last_presented = None
-    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
-    monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
-
-    def fail_to_construct(_webkit):
-        raise RuntimeError("bounded")
-
-    monkeypatch.setattr(app, "_build_locked_web_portal_view", fail_to_construct)
-
-    assert app.run_web_portal_shell() == 0
-
-    window = FakeGtkApplicationWindow.last_presented
-    widgets = tuple(_walk_fake_widgets(window))
-    labels = {
-        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
-    }
-    assert isinstance(window.children[0], FakeGtkScrolledWindow)
-    assert {"VR Hotspot", "Native Dashboard", "NATIVE GTK"} <= labels
-
-
-def test_web_portal_shell_has_no_token_injection_or_persistence_path():
-    from flatpak_app import app
-
-    portal_source = "\n".join(
-        inspect.getsource(value)
-        for value in (
-            app._build_locked_web_portal_view,
-            app._populate_web_portal_window,
-            app.run_web_portal_shell,
-        )
+    names = (
+        "run_" + "gui",
+        "_populate_" + "native_" + "dashboard_window",
+        "Native" + "DashboardModel",
+        "Dashboard" + "SectionLabels",
+        "build_" + "dashboard_model",
+        "FirstRun" + "TokenEntryController",
+        "_connect_from_" + "token_entry",
     )
-    exposed = (
-        repr(app.WEB_PORTAL_ORIGIN)
-        + repr(app.WEB_PORTAL_URL)
-        + repr(app._WEB_PORTAL_CSP)
-        + app.render_smoke_json()
-    )
+    source = Path(app.__file__).read_text(encoding="utf-8")
 
-    assert inspect.signature(app.run_web_portal_shell).parameters == {}
-    assert "?" not in app.WEB_PORTAL_URL
-    assert "#" not in app.WEB_PORTAL_URL
-    assert "token" not in exposed.casefold()
-    for forbidden in (
-        "X-Api-Token",
-        "Authorization",
-        "Bearer ",
-        "localStorage",
-        "sessionStorage",
-        "UserScript",
-        "add_script",
-        "set_cookie",
-        "set_http_headers",
-        "getenv",
-        "/etc/",
-        "/var/lib/",
-    ):
-        assert forbidden not in portal_source
+    for name in names:
+        assert not hasattr(app, name)
+        assert name not in source
 
 
-def test_native_dashboard_remains_the_default_fallback(monkeypatch):
-    from flatpak_app import app
-
-    calls = []
-    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 23)
-    monkeypatch.setattr(
-        app,
-        "run_web_portal_shell",
-        lambda: pytest.fail("the spike must remain opt-in"),
-    )
-
-    assert app.main([]) == 23
-    assert calls == ["native"]
-
-
-def test_web_portal_flag_accepts_no_url_or_other_value():
-    from flatpak_app import app
-
-    parser = app._argument_parser()
-    parsed = parser.parse_args(["--web-portal-shell"])
-    portal_action = next(
-        action
-        for action in parser._actions
-        if "--web-portal-shell" in action.option_strings
-    )
-
-    assert parsed.web_portal_shell is True
-    assert portal_action.nargs == 0
-    with pytest.raises(SystemExit):
-        parser.parse_args(["--web-portal-shell", "https://example.com/"])
-
-
-def test_web_portal_shell_has_no_arbitrary_zoom_or_scale_option():
-    from flatpak_app import app
-
-    parser = app._argument_parser()
-    option_strings = {
-        option
-        for action in parser._actions
-        for option in action.option_strings
-    }
-
-    assert all(
-        "zoom" not in option.casefold() and "scale" not in option.casefold()
-        for option in option_strings
-    )
-    with pytest.raises(SystemExit):
-        parser.parse_args(["--web-portal-shell", "--zoom", "2"])
-    with pytest.raises(SystemExit):
-        parser.parse_args(["--web-portal-shell", "--scale", "2"])
-
-
-def test_shared_browser_portal_css_has_no_flatpak_shell_scaling():
-    css = Path("assets/ui.css").read_text(encoding="utf-8")
-
-    assert re.search(r"(?m)^\s*zoom\s*:", css) is None
-    assert "set_zoom_level" not in css
-    assert "web-portal-shell" not in css
-
-
-def test_gui_activation_does_not_require_password_entry_placeholder_setter(
-    monkeypatch,
-):
-    from flatpak_app import app
-
-    assert not hasattr(FakeGtk.PasswordEntry(), "set_placeholder_text")
-    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
-
-    assert app.run_gui() == 0
-
-
-def test_placeholder_helper_prefers_direct_setter():
-    from flatpak_app import app
-
-    calls = []
-
-    class Entry:
-        def set_placeholder_text(self, value):
-            calls.append(("direct", value))
-
-        def set_property(self, name, value):
-            calls.append((name, value))
-
-    app._set_placeholder_text_compat(Entry(), "API token")
-
-    assert calls == [("direct", "API token")]
-
-
-def test_placeholder_helper_falls_back_to_supported_property_setter():
-    from flatpak_app import app
-
-    calls = []
-
-    class Entry:
-        def find_property(self, name):
-            calls.append(("find", name))
-            return object()
-
-        def set_property(self, name, value):
-            calls.append((name, value))
-
-    app._set_placeholder_text_compat(Entry(), "API token")
-
-    assert calls == [
-        ("find", "placeholder-text"),
-        ("placeholder-text", "API token"),
-    ]
-
-
-@pytest.mark.parametrize(
-    "entry",
-    (
-        object(),
-        type(
-            "UnsupportedPropertyEntry",
-            (),
-            {
-                "find_property": lambda self, _name: None,
-                "set_property": lambda self, _name, _value: pytest.fail(
-                    "unsupported property must not be set"
-                ),
-            },
-        )(),
-    ),
-)
-def test_placeholder_helper_noops_when_placeholder_is_unsupported(entry):
-    from flatpak_app import app
-
-    app._set_placeholder_text_compat(entry, "API token")
-
-
-def test_smoke_json_exits_successfully_is_bounded_and_has_expected_sections():
+def test_smoke_json_reports_web_portal_and_is_bounded():
     from flatpak_app import MAX_SMOKE_JSON_BYTES
 
     result = _smoke()
@@ -852,322 +768,147 @@ def test_smoke_json_exits_successfully_is_bounded_and_has_expected_sections():
         "prototype": True,
     }
     assert payload["shell"] == {
-        "graphical_shell": "gtk4_placeholder",
+        "graphical_shell": "web_portal",
+        "origin": "http://127.0.0.1:8732",
         "state": "offline_unpaired",
     }
-    assert set(payload["ui"]) == {
-        "mode",
-        "show_technical_details",
-        "daemon",
-        "pairing",
-        "adapters",
-        "preflight",
-        "support_bundle",
-    }
+    assert payload["controls"]["mutation_actions"] == []
 
 
-def test_smoke_json_contains_no_secret_or_host_path_leak_markers():
-    result = _smoke()
-    rendered = result.stdout.lower()
+def test_smoke_json_contains_no_secret_or_host_path_markers():
+    rendered = _smoke().stdout
 
-    assert result.returncode == 0
     for forbidden in (
-        "token",
+        "X-Api-Token",
+        "Authorization",
+        "Bearer ",
+        "VR_HOTSPOTD_API_TOKEN",
+        "/etc/vr-hotspot",
+        "/var/lib/vr-hotspot",
+        "token_value",
         "passphrase",
         "password",
-        "psk",
-        "bearer",
-        "file://",
-        "/etc/",
-        "/home/",
-        "/run/",
-        "/tmp/",
-        "/var/",
     ):
         assert forbidden not in rendered
 
 
-def test_live_pairing_smoke_command_dispatches_without_importing_gtk(monkeypatch):
+def test_live_pairing_smoke_dispatches_without_importing_gtk(monkeypatch):
     from flatpak_app import app
 
     calls = []
-
-    def fake_live_smoke():
-        calls.append("live_smoke")
-        return 17
-
-    monkeypatch.setattr(app, "run_live_pairing_smoke_json", fake_live_smoke)
+    monkeypatch.setattr(
+        app,
+        "run_live_pairing_smoke_json",
+        lambda: calls.append("live-smoke") or 17,
+    )
     monkeypatch.setitem(sys.modules, "gi", None)
 
     assert app.main(["--live-pairing-smoke-json"]) == 17
-    assert calls == ["live_smoke"]
+    assert calls == ["live-smoke"]
     assert sys.modules.get("gi") is None
 
 
 def test_live_smoke_refuses_noninteractive_input_with_token_free_json(capsys):
     from flatpak_app import app
 
-    def forbidden_prompt(_prompt):
-        raise AssertionError("noninteractive smoke must not prompt")
-
-    def forbidden_factory(*, token):
-        raise AssertionError("noninteractive smoke must not create a client")
-
     exit_code = app.run_live_pairing_smoke_json(
         input_stream=FakeInputStream(interactive=False),
-        token_prompt=forbidden_prompt,
-        client_factory=forbidden_factory,
+        token_prompt=lambda _prompt: pytest.fail("must not prompt"),
+        client_factory=lambda **_kwargs: pytest.fail("must not create client"),
     )
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    payload = json.loads(capsys.readouterr().out)
 
     assert exit_code == 2
-    assert captured.err == ""
     assert payload["live_smoke"]["status"] == "interactive_input_required"
-    assert payload["daemon"]["reachable"] is None
     assert payload["pairing"]["paired"] is False
     assert payload["controls"]["mutation_actions"] == []
-    assert payload["support_bundle"]["action_enabled"] is False
 
 
-def test_live_smoke_success_returns_bounded_sanitized_ui_ready_json(capsys):
+def test_live_smoke_success_is_bounded_and_secret_free(capsys):
     from flatpak_app import MAX_LIVE_SMOKE_JSON_BYTES
     from flatpak_app import app
 
     secret = "live-smoke-success-value-must-not-escape"
-    prompts = []
     factory = ScriptedReadOnlyClientFactory()
-
-    def hidden_prompt(prompt):
-        prompts.append(prompt)
-        return secret
-
     exit_code = app.run_live_pairing_smoke_json(
         input_stream=FakeInputStream(interactive=True),
-        token_prompt=hidden_prompt,
+        token_prompt=lambda _prompt: secret,
         client_factory=factory,
     )
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    rendered = capsys.readouterr().out
+    payload = json.loads(rendered)
 
     assert exit_code == 0
-    assert captured.err == ""
-    assert prompts == ["VRhotspot daemon API token: "]
-    assert len(captured.out.encode("utf-8")) <= MAX_LIVE_SMOKE_JSON_BYTES + 1
-    assert set(payload) == {
-        "application",
-        "live_smoke",
-        "daemon",
-        "pairing",
-        "adapter_readiness",
-        "preflight",
-        "support_bundle",
-        "controls",
-    }
-    assert payload["application"] == {"id": APP_ID, "name": APP_NAME}
+    assert len(rendered.encode("utf-8")) <= MAX_LIVE_SMOKE_JSON_BYTES + 1
     assert payload["live_smoke"]["status"] == "success"
-    assert payload["daemon"]["reachable"] is True
     assert payload["pairing"]["paired"] is True
     assert payload["adapter_readiness"]["recommended_interface"] == "wlan1"
     assert payload["preflight"]["readiness_label"] == "Needs attention"
-    assert payload["support_bundle"]["action_enabled"] is False
-    assert payload["support_bundle"]["request_performed"] is False
-    assert payload["controls"] == {
-        "mutation_actions": [],
-        "support_bundle_export_enabled": False,
-    }
+    assert payload["controls"]["mutation_actions"] == []
     assert factory.token_presence == [False, True, True]
-    assert secret not in captured.out
+    assert secret not in rendered
 
 
 @pytest.mark.parametrize(
-    ("factory", "expected_status", "daemon_reachable", "pairing_title"),
-    [
+    ("factory", "expected_status"),
+    (
         (
             ScriptedReadOnlyClientFactory(
                 readiness_result=AuthenticationError(401)
             ),
             "token_rejected",
-            True,
-            "Token rejected",
         ),
         (
             ScriptedReadOnlyClientFactory(
                 health_result=ConnectionFailure("offline")
             ),
             "daemon_unreachable",
-            False,
-            "Pairing unavailable",
         ),
         (
             ScriptedReadOnlyClientFactory(
                 readiness_result=DaemonTokenMissingError()
             ),
             "daemon_token_missing",
-            True,
-            "Daemon token missing",
         ),
         (
             ScriptedReadOnlyClientFactory(
                 readiness_result={"unexpected": "response"}
             ),
             "invalid_response",
-            None,
-            "Pairing status unknown",
         ),
-    ],
-    ids=(
-        "token-rejected",
-        "daemon-unreachable",
-        "daemon-token-missing",
-        "malformed-pairing-response",
     ),
 )
-def test_live_smoke_failures_are_nonzero_and_token_free(
+def test_live_smoke_failures_are_nonzero_and_secret_free(
     capsys,
     factory,
     expected_status,
-    daemon_reachable,
-    pairing_title,
 ):
     from flatpak_app import app
 
     secret = f"live-smoke-{expected_status}-must-not-escape"
-
     exit_code = app.run_live_pairing_smoke_json(
         input_stream=FakeInputStream(interactive=True),
         token_prompt=lambda _prompt: secret,
         client_factory=factory,
     )
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    rendered = capsys.readouterr().out
+    payload = json.loads(rendered)
 
     assert exit_code == 1
-    assert captured.err == ""
     assert payload["live_smoke"]["status"] == expected_status
-    assert payload["daemon"]["reachable"] is daemon_reachable
-    assert payload["pairing"]["title"] == pairing_title
     assert payload["pairing"]["paired"] is False
     assert payload["controls"]["mutation_actions"] == []
-    assert payload["support_bundle"]["action_enabled"] is False
-    assert secret not in captured.out
+    assert secret not in rendered
 
 
-def test_live_smoke_malformed_preflight_is_unknown_and_nonzero(capsys):
-    from flatpak_app import app
-
-    secret = "live-smoke-malformed-preflight-must-not-escape"
-    factory = ScriptedReadOnlyClientFactory(
-        preflight_result=_api_response(
-            {
-                "schema_version": 99,
-                "overall_readiness": "future",
-            }
-        )
-    )
-
-    exit_code = app.run_live_pairing_smoke_json(
-        input_stream=FakeInputStream(interactive=True),
-        token_prompt=lambda _prompt: secret,
-        client_factory=factory,
-    )
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
-
-    assert exit_code == 1
-    assert payload["live_smoke"]["status"] == "invalid_response"
-    assert payload["pairing"]["paired"] is True
-    assert payload["preflight"]["severity"] == "unknown"
-    assert payload["controls"]["mutation_actions"] == []
-    assert secret not in captured.out
-
-
-def test_live_smoke_drops_secret_and_host_path_values_from_json(capsys):
-    from flatpak_app import app
-
-    entered_token = "entered-live-token-value-must-not-escape"
-    api_token_value = "daemon-api-token-value-must-not-escape"
-    passphrase_value = "wifi-passphrase-value-must-not-escape"
-    password_value = "daemon-password-value-must-not-escape"
-    psk_value = "wifi-psk-value-must-not-escape"
-    bearer_value = "bearer-value-must-not-escape"
-    host_path = "/var/lib/vr-hotspot/private-state.json"
-    factory = ScriptedReadOnlyClientFactory(
-        readiness_result=_api_response(
-            {
-                "recommended": "wlan1",
-                "basic_mode_recommended": "wlan1",
-                "summary": {"readiness_state": "ready"},
-                "adapters": [
-                    {
-                        "interface": "wlan1",
-                        "readiness_state": "ready",
-                        "explanation": (
-                            f"token={api_token_value}; "
-                            f"passphrase={passphrase_value}; "
-                            f"password={password_value}; psk={psk_value}"
-                        ),
-                    }
-                ],
-            }
-        ),
-        preflight_result=_api_response(
-            {
-                "schema_version": 1,
-                "overall_readiness": "warning",
-                "platform": {},
-                "firewall": {},
-                "services": {},
-                "network": {},
-                "wifi": {},
-                "issues": [
-                    {
-                        "severity": "warning",
-                        "code": "redaction_check",
-                        "message": (
-                            f"Authorization: Bearer {bearer_value}; "
-                            f"inspect {host_path}"
-                        ),
-                    }
-                ],
-                "recommended_actions": [],
-            }
-        ),
-    )
-
-    exit_code = app.run_live_pairing_smoke_json(
-        input_stream=FakeInputStream(interactive=True),
-        token_prompt=lambda _prompt: entered_token,
-        client_factory=factory,
-    )
-    captured = capsys.readouterr()
-    rendered = captured.out
-
-    assert exit_code == 0
-    for forbidden_value in (
-        entered_token,
-        api_token_value,
-        passphrase_value,
-        password_value,
-        psk_value,
-        bearer_value,
-        host_path,
-    ):
-        assert forbidden_value not in rendered
-    assert "[redacted]" in rendered
-    assert "[host path]" in rendered
-
-
-def test_live_smoke_rejects_empty_or_unavailable_hidden_input_without_a_client(
-    capsys,
-):
+def test_live_smoke_rejects_empty_or_unavailable_hidden_input(capsys):
     from flatpak_app import app
 
     client_calls = []
 
     def forbidden_factory(*, token):
         client_calls.append(token)
-        raise AssertionError("empty or unavailable input must not create a client")
+        raise AssertionError("client must not be created")
 
     empty_exit = app.run_live_pairing_smoke_json(
         input_stream=FakeInputStream(interactive=True),
@@ -1193,679 +934,64 @@ def test_live_smoke_rejects_empty_or_unavailable_hidden_input_without_a_client(
     assert client_calls == []
 
 
-def test_live_smoke_rejects_getpass_echo_fallback_before_reading_input(capsys):
+def test_live_smoke_rejects_getpass_echo_fallback(capsys):
     from flatpak_app import app
 
     secret = "fallback-must-not-read-or-echo-this-value"
-    client_calls = []
 
     def fallback_prompt(_prompt):
         warnings.warn("hidden input unavailable", app.getpass.GetPassWarning)
         return secret
 
-    def forbidden_factory(*, token):
-        client_calls.append(token)
-        raise AssertionError("unsafe prompt fallback must not create a client")
-
     exit_code = app.run_live_pairing_smoke_json(
         input_stream=FakeInputStream(interactive=True),
         token_prompt=fallback_prompt,
-        client_factory=forbidden_factory,
+        client_factory=lambda **_kwargs: pytest.fail("must not create client"),
     )
-    captured = capsys.readouterr()
-    payload = json.loads(captured.out)
+    rendered = capsys.readouterr().out
+    payload = json.loads(rendered)
 
     assert exit_code == 2
-    assert captured.err == ""
     assert payload["live_smoke"]["status"] == "token_input_cancelled"
-    assert secret not in captured.out
-    assert client_calls == []
+    assert secret not in rendered
 
 
-def test_token_entry_requires_only_a_caller_supplied_token():
-    from flatpak_app import FirstRunTokenEntryController
-
-    factory = ScriptedReadOnlyClientFactory()
-    controller = FirstRunTokenEntryController(client_factory=factory)
-
-    with pytest.raises(TypeError):
-        controller.connect()
-
-    model = controller.connect(token="caller-provided-value")
-
-    assert model.pairing.paired is True
-    assert factory.token_presence == [False, True, True]
-    assert not hasattr(controller, "token")
-    assert not hasattr(controller, "_token")
-
-
-def test_successful_token_validation_updates_all_display_only_sections():
-    from flatpak_app import FirstRunTokenEntryController
-
-    controller = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory()
-    )
-
-    model = controller.connect(token="accepted-in-memory-value")
-
-    assert model.daemon.title == "Daemon connected"
-    assert model.pairing.title == "Paired"
-    assert model.adapters.recommended_interface == "wlan1"
-    assert [card.interface for card in model.adapters.cards] == ["wlan1"]
-    assert model.preflight.readiness_label == "Needs attention"
-    assert [issue.code for issue in model.preflight.issues] == ["review_example"]
-    assert [action.code for action in model.preflight.actions] == ["review_example"]
-    assert model.preflight.actions[0].interactive is False
-    assert model.support_bundle.action_enabled is False
-    assert model.support_bundle.request_performed is False
-
-
-def test_successful_pairing_builds_and_renders_all_native_dashboard_sections():
-    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
+def test_web_portal_shell_has_no_token_injection_or_persistence_path():
     from flatpak_app import app
 
-    display_model = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory()
-    ).connect(token="accepted-dashboard-value")
-
-    dashboard = build_dashboard_model(display_model)
-    container = FakeGtkWidget()
-    app._render_dashboard_model(FakeGtk, container, dashboard)
-
-    assert set(asdict(dashboard)) == {
-        "labels",
-        "daemon",
-        "pairing",
-        "adapter_readiness",
-        "preflight",
-        "support_bundle",
-        "controls",
-    }
-    assert dashboard.adapter_readiness.recommended_interface == "wlan1"
-    assert dashboard.adapter_readiness.cards[0].readiness_label == "Ready"
-    assert dashboard.adapter_readiness.cards[0].severity.value == "ok"
-    assert dashboard.adapter_readiness.cards[0].summary
-    assert dashboard.adapter_readiness.cards[0].reasons == (
-        "Supports Ap Mode",
-        "Daemon Recommended",
-    )
-    assert dashboard.preflight.readiness_label == "Needs attention"
-    assert dashboard.preflight.severity.value == "warning"
-    assert dashboard.preflight.summary
-    assert dashboard.preflight.issues
-    assert dashboard.preflight.facts
-    assert dashboard.preflight.actions
-    assert all(not action.interactive for action in dashboard.preflight.actions)
-    assert dashboard.support_bundle.visible is True
-    assert dashboard.support_bundle.action_enabled is False
-    assert dashboard.controls.visible is True
-    assert dashboard.controls.mutation_actions == ()
-    assert dashboard.controls.action_enabled is False
-    assert tuple(asdict(dashboard.labels).values()) == (
-        "Dashboard Overview",
-        "Connection & Pairing",
-        "Readiness & Adapter Summary",
-        "Adapter Readiness",
-        "Preflight Diagnostics",
-        "Readiness & Host Summary",
-        "Facts",
-        "Blocking Issues",
-        "Warnings",
-        "Other Issues",
-        "Recommended Actions",
-        "Support Bundle",
-        "Controls Boundary",
-        "Unavailable Features",
-    )
-
-    widgets = tuple(_walk_fake_widgets(container))
-    rendered_text = {
-        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
-    }
-    buttons = [
-        widget for widget in widgets if isinstance(widget, FakeGtkButton)
-    ]
-    for section_title in (
-        "Dashboard Overview",
-        "Connection & Pairing",
-        "Daemon Status",
-        "Pairing Status",
-        "Readiness & Adapter Summary",
-        "Adapter Readiness",
-        "Preflight Diagnostics",
-        "Readiness & Host Summary",
-        "Blocking Issues",
-        "Warnings",
-        "Recommended Actions",
-        "Support Bundle",
-        "Controls Boundary",
-        "Unavailable Features",
-    ):
-        assert section_title in rendered_text
-    assert "wlan1" in rendered_text
-    assert "DAEMON RECOMMENDED" in rendered_text
-    assert "RECOMMENDED" in rendered_text
-    assert "PAIRED" in rendered_text
-    assert "Readiness: Ready" in rendered_text
-    assert "OK" in rendered_text
-    assert "WARNING" in rendered_text
-    assert "Top Reasons" in rendered_text
-    assert "Facts" in rendered_text
-    assert "No blocking issues." in rendered_text
-    assert "Mutation actions: none" in rendered_text
-    assert "NOT AVAILABLE YET" in rendered_text
-    assert [(button.label, button.sensitive) for button in buttons] == [
-        ("Export support bundle", False)
-    ]
-
-
-@pytest.mark.parametrize(
-    ("severity_name", "expected_label", "semantic_class"),
-    (
-        ("OK", "OK", "success"),
-        ("WARNING", "WARNING", "warning"),
-        ("BLOCKED", "BLOCKED", "error"),
-        ("ERROR", "ERROR", "error"),
-        ("UNKNOWN", "UNKNOWN", "dim-label"),
-    ),
-)
-def test_native_dashboard_severity_badges_render_consistently(
-    severity_name,
-    expected_label,
-    semantic_class,
-):
-    from flatpak_app import app
-    from flatpak_client import StatusSeverity
-
-    container = FakeGtkWidget()
-    severity = StatusSeverity[severity_name]
-
-    badge = app._add_status_badge(FakeGtk, container, severity)
-
-    assert _fake_labels_under(badge) == {expected_label}
-    assert badge.css_classes == [
-        "status-badge",
-        f"severity-{severity.value}",
-        semantic_class,
-    ]
-
-
-def test_recommended_adapter_has_visible_badge_and_emphasized_card():
-    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
-    from flatpak_app import app
-
-    dashboard = build_dashboard_model(
-        FirstRunTokenEntryController(
-            client_factory=ScriptedReadOnlyClientFactory()
-        ).connect(token="recommended-emphasis-value")
-    )
-    container = FakeGtkWidget()
-
-    app._render_dashboard_model(FakeGtk, container, dashboard)
-
-    emphasized = [
-        widget
-        for widget in _walk_fake_widgets(container)
-        if "recommended-card" in widget.css_classes
-    ]
-    assert emphasized
-    assert any(
-        {"wlan1", "RECOMMENDED"}.issubset(_fake_labels_under(widget))
-        for widget in emphasized
-    )
-
-
-def test_disabled_sections_are_visibly_unavailable_without_mutation_actions():
-    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
-    from flatpak_app import app
-
-    dashboard = build_dashboard_model(
-        FirstRunTokenEntryController(
-            client_factory=ScriptedReadOnlyClientFactory()
-        ).connect(token="disabled-sections-value")
-    )
-    container = FakeGtkWidget()
-
-    app._render_dashboard_model(FakeGtk, container, dashboard)
-    widgets = tuple(_walk_fake_widgets(container))
-    labels = {
-        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
-    }
-    buttons = [
-        widget for widget in widgets if isinstance(widget, FakeGtkButton)
-    ]
-
-    assert "NOT AVAILABLE YET" in labels
-    assert "UNAVAILABLE" in labels
-    assert "Mutation actions: none" in labels
-    assert dashboard.controls.mutation_actions == ()
-    assert dashboard.controls.action_enabled is False
-    assert [(button.label, button.sensitive) for button in buttons] == [
-        ("Export support bundle", False)
-    ]
-    assert all(button.signal_handlers == {} for button in buttons)
-
-
-def test_gui_keeps_hidden_token_entry_scrollable_native_header_and_no_controls(
-    monkeypatch,
-):
-    from flatpak_app import app
-
-    FakeGtkApplicationWindow.last_presented = None
-    monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
-
-    assert app.run_gui() == 0
-
-    window = FakeGtkApplicationWindow.last_presented
-    assert window is not None
-    widgets = tuple(_walk_fake_widgets(window))
-    entries = [
-        widget for widget in widgets if isinstance(widget, FakeGtkPasswordEntry)
-    ]
-    labels = {
-        widget.label for widget in widgets if isinstance(widget, FakeGtkLabel)
-    }
-    buttons = [
-        widget for widget in widgets if isinstance(widget, FakeGtkButton)
-    ]
-    button_labels = {button.label.casefold() for button in buttons}
-
-    assert isinstance(window.children[0], FakeGtkScrolledWindow)
-    assert len(entries) == 1
-    assert entries[0].show_peek_icon is True
-    assert {"VR Hotspot", "Native Dashboard", "NATIVE GTK", "READ-ONLY"} <= labels
-    assert "Connect / Validate token" in {button.label for button in buttons}
-    assert {
-        "start",
-        "stop",
-        "restart",
-        "repair",
-        "save",
-        "apply",
-        "refresh",
-    }.isdisjoint(button_labels)
-
-
-def test_native_dashboard_styles_are_bounded_and_have_no_external_assets():
-    from flatpak_app import app
-
-    stylesheet = app._DASHBOARD_CSS
-
-    assert len(stylesheet.encode("utf-8")) < 512
-    assert "url(" not in stylesheet.casefold()
-    assert "@import" not in stylesheet.casefold()
-    assert {
-        ".dashboard-card",
-        ".status-badge",
-        ".recommended-card",
-        ".unavailable-card",
-    } <= set(line.strip().split(" {", 1)[0] for line in stylesheet.splitlines())
-
-
-def test_web_portal_shell_does_not_copy_or_package_frontend_assets():
-    source = Path("flatpak_app/app.py").read_text(encoding="utf-8").casefold()
-    manifest_text = MANIFEST_PATH.read_text(encoding="utf-8").casefold()
-
-    assert "webkit" in source
-    assert "webview" in source
-    for copied_asset in (
-        "index.html",
-        "ui.js",
-        "ui.css",
-        "../../assets/",
-    ):
-        assert copied_asset not in manifest_text
-
-
-def test_token_entry_is_cleared_before_dashboard_validation():
-    from flatpak_app import app
-
-    events = []
-
-    class Entry:
-        def __init__(self):
-            self.text = "clear-before-validation-value"
-
-        def get_text(self):
-            events.append("entry-read")
-            return self.text
-
-        def set_text(self, text):
-            self.text = text
-            events.append("entry-cleared")
-
-    class Button:
-        def __init__(self):
-            self.sensitive = True
-
-        def set_sensitive(self, sensitive):
-            self.sensitive = sensitive
-            events.append(f"button-{sensitive}")
-
-    class Controller:
-        def connect(self, *, token):
-            assert token == "clear-before-validation-value"
-            assert entry.text == ""
-            assert button.sensitive is False
-            events.append("validated")
-            return "safe-dashboard-model"
-
-    entry = Entry()
-    button = Button()
-    rendered = []
-
-    app._connect_from_token_entry(
-        token_entry=entry,
-        connect_button=button,
-        controller=Controller(),
-        render_model=rendered.append,
-    )
-
-    assert events == [
-        "entry-read",
-        "entry-cleared",
-        "button-False",
-        "validated",
-        "button-True",
-    ]
-    assert entry.text == ""
-    assert button.sensitive is True
-    assert rendered == ["safe-dashboard-model"]
-
-
-@pytest.mark.parametrize(
-    ("factory", "expected_daemon", "expected_pairing"),
-    [
-        (
-            ScriptedReadOnlyClientFactory(
-                readiness_result=AuthenticationError(401)
-            ),
-            "Daemon reachable",
-            "Token rejected",
-        ),
-        (
-            ScriptedReadOnlyClientFactory(
-                health_result=ConnectionFailure("offline")
-            ),
-            "Daemon unavailable",
-            "Pairing unavailable",
-        ),
-        (
-            ScriptedReadOnlyClientFactory(
-                readiness_result={"unexpected": "response"}
-            ),
-            "Daemon status unknown",
-            "Pairing status unknown",
-        ),
-        (
-            ScriptedReadOnlyClientFactory(
-                preflight_result=_api_response(
-                    {
-                        "schema_version": 99,
-                        "overall_readiness": "future",
-                    }
-                )
-            ),
-            "Daemon connected",
-            "Paired",
-        ),
-    ],
-    ids=(
-        "rejected",
-        "unreachable",
-        "invalid-pairing",
-        "malformed-diagnostics",
-    ),
-)
-def test_native_dashboard_uses_safe_states_for_pairing_and_response_failures(
-    factory,
-    expected_daemon,
-    expected_pairing,
-):
-    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
-
-    display_model = FirstRunTokenEntryController(
-        client_factory=factory
-    ).connect(token="safe-failure-state-value")
-    dashboard = build_dashboard_model(display_model)
-
-    assert dashboard.daemon.title == expected_daemon
-    assert dashboard.pairing.title == expected_pairing
-    assert dashboard.support_bundle.action_enabled is False
-    assert dashboard.controls.mutation_actions == ()
-    if expected_pairing != "Paired":
-        assert dashboard.adapter_readiness.cards == ()
-        assert dashboard.preflight.issues == ()
-    else:
-        assert dashboard.preflight.severity.value == "unknown"
-        assert dashboard.preflight.issues == ()
-
-
-def test_native_dashboard_exposes_no_secret_or_host_path_values():
-    from flatpak_app import FirstRunTokenEntryController, build_dashboard_model
-    from flatpak_app import app
-
-    entered_value = "entered-dashboard-value-must-not-escape"
-    token_value = "daemon-token-value-must-not-escape"
-    passphrase_value = "passphrase-value-must-not-escape"
-    password_value = "password-value-must-not-escape"
-    psk_value = "psk-value-must-not-escape"
-    bearer_value = "bearer-value-must-not-escape"
-    secret_value = "secret-value-must-not-escape"
-    host_path = "/var/lib/vr-hotspot/private-dashboard-state.json"
-    factory = ScriptedReadOnlyClientFactory(
-        readiness_result=_api_response(
-            {
-                "recommended": "wlan1",
-                "basic_mode_recommended": "wlan1",
-                "summary": {"readiness_state": "ready"},
-                "adapters": [
-                    {
-                        "interface": "wlan1",
-                        "readiness_state": "ready",
-                        "explanation": (
-                            f"token={token_value}; "
-                            f"passphrase={passphrase_value}; "
-                            f"password={password_value}; psk={psk_value}; "
-                            f"secret={secret_value}"
-                        ),
-                    }
-                ],
-            }
-        ),
-        preflight_result=_api_response(
-            {
-                "schema_version": 1,
-                "overall_readiness": "warning",
-                "platform": {},
-                "firewall": {},
-                "services": {},
-                "network": {},
-                "wifi": {},
-                "issues": [
-                    {
-                        "severity": "warning",
-                        "code": "redaction_check",
-                        "message": (
-                            f"Authorization: Bearer {bearer_value}; "
-                            f"inspect {host_path}"
-                        ),
-                    }
-                ],
-                "recommended_actions": [],
-            }
-        ),
-    )
-
-    dashboard = build_dashboard_model(
-        FirstRunTokenEntryController(client_factory=factory).connect(
-            token=entered_value
+    source = "\n".join(
+        inspect.getsource(value)
+        for value in (
+            app._build_locked_web_portal_view,
+            app._populate_web_portal_window,
+            app.run_web_portal_shell,
         )
-    )
-    container = FakeGtkWidget()
-    app._render_dashboard_model(FakeGtk, container, dashboard)
-    rendered_labels = tuple(
-        widget.label
-        for widget in _walk_fake_widgets(container)
-        if isinstance(widget, (FakeGtkLabel, FakeGtkButton))
     )
     exposed = (
-        repr(asdict(dashboard))
-        + repr(dashboard)
-        + repr(rendered_labels)
+        repr(app.WEB_PORTAL_ORIGIN)
+        + repr(app.WEB_PORTAL_URL)
+        + repr(app._WEB_PORTAL_CSP)
+        + app.render_smoke_json()
     )
 
-    for forbidden_value in (
-        entered_value,
-        token_value,
-        passphrase_value,
-        password_value,
-        psk_value,
-        bearer_value,
-        secret_value,
-        host_path,
+    assert inspect.signature(app.run_web_portal_shell).parameters == {}
+    assert "?" not in app.WEB_PORTAL_URL
+    assert "#" not in app.WEB_PORTAL_URL
+    assert "token" not in exposed.casefold()
+    for forbidden in (
+        "X-Api-Token",
+        "Authorization",
+        "Bearer ",
+        "localStorage",
+        "sessionStorage",
+        "keyring",
+        "SecretService",
+        "/etc/",
+        "/var/lib/",
+        "os.environ",
+        "getenv(",
     ):
-        assert forbidden_value not in exposed
-    assert "[redacted]" in exposed
-    assert "[host path]" in exposed
-
-
-def test_rejected_token_is_safe_and_never_enters_output_or_logs(caplog):
-    from flatpak_app import FirstRunTokenEntryController
-    from flatpak_client import AuthenticationError
-
-    secret = "rejected-ui-value-must-not-escape"
-    controller = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory(
-            readiness_result=AuthenticationError(401)
-        )
-    )
-
-    model = controller.connect(token=secret)
-    exposed = repr(model) + repr(asdict(model)) + repr(controller) + caplog.text
-
-    assert model.daemon.reachable is True
-    assert model.pairing.title == "Token rejected"
-    assert model.pairing.paired is False
-    assert secret not in exposed
-
-
-def test_unreachable_daemon_updates_the_safe_offline_display_state():
-    from flatpak_app import FirstRunTokenEntryController
-    from flatpak_client import ConnectionFailure
-
-    controller = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory(
-            health_result=ConnectionFailure("offline")
-        )
-    )
-
-    model = controller.connect(token="in-memory-offline-value")
-
-    assert model.daemon.title == "Daemon unavailable"
-    assert model.daemon.reachable is False
-    assert model.pairing.title == "Pairing unavailable"
-    assert model.adapters.cards == ()
-    assert model.preflight.issues == ()
-
-
-def test_missing_daemon_token_updates_the_safe_blocked_display_state():
-    from flatpak_app import FirstRunTokenEntryController
-    from flatpak_client import DaemonTokenMissingError
-
-    controller = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory(
-            readiness_result=DaemonTokenMissingError()
-        )
-    )
-
-    model = controller.connect(token="caller-provided-missing-config-value")
-
-    assert model.daemon.reachable is True
-    assert model.pairing.title == "Daemon token missing"
-    assert model.pairing.detail_code == "api_token_missing"
-    assert model.pairing.paired is False
-
-
-def test_malformed_pairing_response_degrades_the_entire_display_to_unknown():
-    from flatpak_app import FirstRunTokenEntryController
-    from flatpak_client import StatusSeverity
-
-    controller = FirstRunTokenEntryController(
-        client_factory=ScriptedReadOnlyClientFactory(
-            readiness_result={"unexpected": "response"}
-        )
-    )
-
-    model = controller.connect(token="caller-provided-malformed-value")
-
-    assert model.daemon.severity is StatusSeverity.UNKNOWN
-    assert model.pairing.severity is StatusSeverity.UNKNOWN
-    assert model.adapters.severity is StatusSeverity.UNKNOWN
-    assert model.preflight.severity is StatusSeverity.UNKNOWN
-
-
-def test_token_entry_flow_does_not_retain_persist_log_or_emit_token(
-    caplog,
-    monkeypatch,
-    tmp_path,
-):
-    from flatpak_app import (
-        FirstRunTokenEntryController,
-        build_smoke_payload,
-        render_smoke_json,
-    )
-
-    secret = "ephemeral-ui-value-never-persist"
-    factory = ScriptedReadOnlyClientFactory()
-    controller = FirstRunTokenEntryController(client_factory=factory)
-    monkeypatch.chdir(tmp_path)
-    before = tuple(tmp_path.rglob("*"))
-
-    model = controller.connect(token=secret)
-    exposed = (
-        repr(controller)
-        + repr(model)
-        + repr(asdict(model))
-        + repr(build_smoke_payload())
-        + render_smoke_json()
-        + caplog.text
-    )
-
-    assert tuple(tmp_path.rglob("*")) == before
-    assert secret not in exposed
-    assert secret not in repr(vars(controller))
-    assert not hasattr(controller, "token")
-    assert not hasattr(controller, "_token")
-
-
-def test_shell_exposes_no_mutation_controls_or_actions():
-    from flatpak_app import build_smoke_payload
-    from flatpak_app import app
-
-    payload = build_smoke_payload()
-    public_methods = {
-        name
-        for name, value in inspect.getmembers(app, inspect.isfunction)
-        if not name.startswith("_")
-    }
-
-    assert payload["controls"]["mutation_actions"] == []
-    assert payload["controls"]["support_bundle_export_enabled"] is False
-    assert payload["ui"]["support_bundle"]["action_enabled"] is False
-    assert public_methods.isdisjoint(
-        {
-            "start",
-            "stop",
-            "restart",
-            "repair",
-            "save_config",
-            "update_config",
-            "request",
-            "post",
-            "export",
-        }
-    )
+        assert forbidden not in source
 
 
 def test_app_shell_has_no_direct_host_secret_or_network_access():
@@ -1911,10 +1037,21 @@ def test_shell_has_no_token_cli_argument_or_discovery_source():
     assert "--web-portal-shell" in option_strings
     assert "getpass.getpass" in source
     assert "isatty()" in source
-    assert "FirstRunTokenEntryController" in source
     assert "LocalApiClient" in source
     assert "TokenPairingController" in source
     assert "DiagnosticsControlUiController" in source
+
+
+def test_web_portal_shell_does_not_copy_or_package_frontend_assets():
+    shell_source = Path("flatpak_app/app.py").read_text(encoding="utf-8")
+    manifest_paths = {
+        source["path"] for source in _manifest()["modules"][0]["sources"]
+    }
+
+    assert "index.html" not in shell_source
+    assert "ui.js" not in shell_source
+    assert "ui.css" not in shell_source
+    assert not any(path.startswith("../../assets/") for path in manifest_paths)
 
 
 def test_manifest_is_valid_json_and_matches_app_id_command_and_runtime():
@@ -1941,14 +1078,6 @@ def test_manifest_has_only_minimal_display_and_loopback_client_permissions():
     assert not any("filesystem=" in argument for argument in finish_args)
     assert not any("system-bus" in argument for argument in finish_args)
     assert not any("session-bus" in argument for argument in finish_args)
-    assert {
-        argument
-        for argument in finish_args
-        if argument.startswith("--talk-name=")
-    } == {
-        "--talk-name=org.kde.StatusNotifierWatcher",
-        "--talk-name=org.freedesktop.secrets",
-    }
     assert "--filesystem=host" not in finish_args
     assert "--device=all" not in finish_args
     assert "--socket=system-bus" not in finish_args

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -17,6 +17,9 @@ from flatpak_client import (
     ApiResponse,
     AuthenticationError,
     ConnectionFailure,
+    DaemonTokenMissingError,
+    FirstRunResult,
+    FirstRunState,
     TrayControlController,
     TrayState,
     TrayStatus,
@@ -142,19 +145,37 @@ def test_tray_menu_contains_every_required_action():
         "Show VR Hotspot",
         "Hide VR Hotspot",
         "Current status: Running",
+        "Refresh Status",
         "Start Hotspot",
         "Stop Hotspot",
         "Restart Service",
         "Repair Network",
-        "Refresh Status",
         "Share Internet Connection",
         "Privacy Mode",
         "Start Hotspot Automatically",
         "Authentication…",
         "Open Diagnostics",
-        "Open Web Portal Shell",
         "Quit VR Hotspot",
     )
+    assert all(item.action != "web_portal" for item in model.items)
+    groups = []
+    current = []
+    for item in model.items:
+        if item.separator:
+            groups.append(tuple(current))
+            current = []
+        else:
+            current.append(item.action)
+    groups.append(tuple(current))
+    assert groups == [
+        ("show", "hide"),
+        ("status", "refresh"),
+        ("start", "stop", "restart", "repair"),
+        ("share_internet", "privacy", "hotspot_autostart"),
+        ("authentication",),
+        ("diagnostics",),
+        ("quit",),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -163,6 +184,16 @@ def test_tray_menu_contains_every_required_action():
         (TrayStatus.RUNNING, "Running", "Active"),
         (TrayStatus.STOPPED, "Stopped", "Active"),
         (TrayStatus.TRANSITIONING, "Transitioning", "Active"),
+        (
+            TrayStatus.NEEDS_AUTHENTICATION,
+            "Needs Authentication",
+            "NeedsAttention",
+        ),
+        (
+            TrayStatus.DAEMON_UNAVAILABLE,
+            "Daemon Unavailable",
+            "NeedsAttention",
+        ),
         (TrayStatus.ERROR, "Error", "NeedsAttention"),
     ),
 )
@@ -294,17 +325,31 @@ def test_successful_mutation_refreshes_status_and_configuration():
 
 
 @pytest.mark.parametrize(
-    ("error", "detail_code", "message"),
+    ("error", "detail_code", "message", "expected_status"),
     (
         (
             AuthenticationError(401),
             "authentication_rejected",
             "Authentication was rejected.",
+            TrayStatus.NEEDS_AUTHENTICATION,
+        ),
+        (
+            DaemonTokenMissingError(),
+            "daemon_token_missing",
+            "The daemon has no configured API token.",
+            TrayStatus.NEEDS_AUTHENTICATION,
         ),
         (
             ConnectionFailure("secret transport detail"),
             "daemon_unavailable",
             "The local daemon is unavailable.",
+            TrayStatus.DAEMON_UNAVAILABLE,
+        ),
+        (
+            RuntimeError("unexpected detail"),
+            "operation_failed",
+            "The tray operation failed safely.",
+            TrayStatus.ERROR,
         ),
     ),
 )
@@ -312,6 +357,7 @@ def test_auth_rejected_and_daemon_unavailable_states_are_bounded(
     error,
     detail_code,
     message,
+    expected_status,
 ):
     secret = "must-not-escape-tray-errors"
     client = FakeControlClient(status_error=error)
@@ -320,7 +366,7 @@ def test_auth_rejected_and_daemon_unavailable_states_are_bounded(
     state = controller.refresh()
     exposed = repr(state) + state.message + state.detail_code
 
-    assert state.status is TrayStatus.ERROR
+    assert state.status is expected_status
     assert state.detail_code == detail_code
     assert state.message == message
     assert secret not in exposed
@@ -333,10 +379,47 @@ def test_missing_token_disables_mutations_with_fixed_state():
     state = controller.refresh()
     outcome = controller.perform("start")
 
+    assert state.status is TrayStatus.NEEDS_AUTHENTICATION
     assert state.detail_code == "token_missing"
     assert outcome.succeeded is False
     assert outcome.code == "token_missing"
     assert "Authentication" in outcome.message
+
+    menu = build_tray_menu_model(state, window_visible=True)
+    assert _menu_enabled(menu, "authentication") is True
+    assert all(
+        not _menu_enabled(menu, action)
+        for action in ("start", "stop", "restart", "repair")
+    )
+
+
+def test_authenticated_running_refresh_maps_to_running():
+    controller = _controller(
+        FakeControlClient(phase="running", running=True)
+    )
+
+    state = controller.refresh()
+
+    assert state.status is TrayStatus.RUNNING
+    assert state.status_label == "Running"
+    assert state.authenticated is True
+    assert state.daemon_available is True
+
+
+def test_unexpected_client_construction_failure_maps_to_error():
+    controller = TrayControlController(
+        TokenProvider(),
+        client_factory=lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("secret construction detail")
+        ),
+    )
+
+    state = controller.refresh()
+
+    assert state.status is TrayStatus.ERROR
+    assert state.status_label == "Error"
+    assert state.detail_code == "operation_failed"
+    assert "secret construction detail" not in repr(state)
 
 
 def test_share_internet_toggle_uses_only_canonical_enable_internet_method():
@@ -445,6 +528,192 @@ def _menu_enabled(model, action):
     return next(item.enabled for item in model.items if item.action == action)
 
 
+def test_saving_and_testing_authentication_refreshes_status_without_leakage():
+    secret = "authentication-refresh-secret"
+
+    class Entry:
+        def __init__(self):
+            self.text = secret
+
+        def get_text(self):
+            return self.text
+
+        def set_text(self, text):
+            self.text = text
+
+    class SaveSecurely:
+        def __init__(self):
+            self.active = True
+
+        def get_active(self):
+            return self.active
+
+        def set_active(self, active):
+            self.active = active
+
+    class Status:
+        def __init__(self):
+            self.text = ""
+
+        def set_text(self, text):
+            self.text = text
+
+    class Authentication:
+        def __init__(self):
+            self.supplied = []
+
+        def save_or_replace(self, token, *, save_securely):
+            self.supplied.append(("save", bool(token), save_securely))
+            return type(
+                "Result",
+                (),
+                {
+                    "message": "API token saved in memory.",
+                    "securely_saved": False,
+                },
+            )()
+
+        def test_authentication(self, *, explicit_token):
+            self.supplied.append(("test", bool(explicit_token)))
+            return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+
+    authentication = Authentication()
+    runtime = TrayRuntime(
+        application=FakeApplication(),
+        lifecycle=WindowLifecycleController(
+            application=FakeApplication(),
+            window=FakeWindow(),
+        ),
+        controls=FakeControls(),
+        authentication=authentication,
+        backend=FakeBackend(),
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=object(),
+        open_diagnostics=lambda: None,
+    )
+    refreshes = []
+    runtime.refresh_async = lambda: refreshes.append("refresh")
+    entry = Entry()
+    save_securely = SaveSecurely()
+    status = Status()
+
+    runtime._auth_save(entry, save_securely, status)
+    assert entry.text == ""
+    assert refreshes == ["refresh"]
+    assert secret not in status.text
+
+    entry.text = secret
+    runtime._auth_test(entry, status)
+    assert entry.text == ""
+    assert refreshes == ["refresh", "refresh"]
+    assert status.text == "Authentication succeeded."
+    assert authentication.supplied == [
+        ("save", True, True),
+        ("test", True),
+    ]
+    assert secret not in repr(authentication.supplied)
+
+
+def test_clearing_authentication_refreshes_needs_authentication_menu():
+    noncredential = "clear-refresh-test-placeholder"
+
+    class Entry:
+        def __init__(self):
+            self.text = noncredential
+
+        def set_text(self, text):
+            self.text = text
+
+    class Status:
+        def __init__(self):
+            self.text = ""
+
+        def set_text(self, text):
+            self.text = text
+
+    class Authentication:
+        def __init__(self):
+            self.clear_calls = 0
+
+        def clear(self):
+            self.clear_calls += 1
+            return type(
+                "Result",
+                (),
+                {"message": "VR Hotspot test credential was cleared."},
+            )()
+
+    class RefreshingControls:
+        def __init__(self):
+            self.refresh_calls = 0
+            self.state = TrayState(
+                status=TrayStatus.RUNNING,
+                status_label="Running",
+                phase="running",
+                running=True,
+                daemon_available=True,
+                authenticated=True,
+            )
+
+        def refresh(self):
+            self.refresh_calls += 1
+            self.state = TrayState(
+                status=TrayStatus.NEEDS_AUTHENTICATION,
+                status_label="Needs Authentication",
+                detail_code="token_missing",
+                message="Authentication is required.",
+                daemon_available=True,
+                authenticated=False,
+            )
+
+    application = FakeApplication()
+    authentication = Authentication()
+    controls = RefreshingControls()
+    backend = FakeBackend()
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=WindowLifecycleController(
+            application=application,
+            window=FakeWindow(),
+        ),
+        controls=controls,
+        authentication=authentication,
+        backend=backend,
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=object(),
+        open_diagnostics=lambda: None,
+    )
+
+    def refresh_now():
+        controls.refresh()
+        runtime._update_menu()
+
+    runtime.refresh_async = refresh_now
+    runtime._update_menu()
+    assert _menu_enabled(backend.models[-1], "stop") is True
+
+    entry = Entry()
+    status = Status()
+    runtime._auth_clear(entry, status)
+
+    refreshed_menu = backend.models[-1]
+    assert authentication.clear_calls == 1
+    assert controls.refresh_calls == 1
+    assert entry.text == ""
+    assert "Current status: Needs Authentication" in refreshed_menu.action_labels()
+    assert _menu_enabled(refreshed_menu, "authentication") is True
+    assert all(
+        not _menu_enabled(refreshed_menu, action)
+        for action in ("start", "stop", "restart", "repair")
+    )
+    assert noncredential not in status.text
+    assert noncredential not in repr(refreshed_menu)
+
+
 def test_close_to_tray_immediately_refreshes_exported_show_hide_state():
     application = FakeApplication()
     lifecycle = WindowLifecycleController(
@@ -464,7 +733,6 @@ def test_close_to_tray_immediately_refreshes_exported_show_hide_state():
         Gio=object(),
         GLib=object(),
         open_diagnostics=lambda: None,
-        open_web_portal=lambda: None,
     )
 
     runtime.show()
@@ -513,7 +781,6 @@ def test_explicit_quit_exits_only_the_companion_without_hotspot_stop():
         Gio=object(),
         GLib=object(),
         open_diagnostics=lambda: None,
-        open_web_portal=lambda: None,
     )
 
     runtime.dispatch_action("quit")
@@ -600,7 +867,6 @@ def test_significant_notifications_are_fixed_bounded_and_secret_free(
         Gio=Gio,
         GLib=object(),
         open_diagnostics=lambda: None,
-        open_web_portal=lambda: None,
     )
     outcome = ActionOutcome(
         accepted=True,
@@ -686,7 +952,7 @@ def test_dbus_menu_get_property_preserves_false_boolean_values():
     assert value.value is False
 
 
-def test_tray_mode_falls_back_to_normal_native_app_when_desktop_modules_missing(
+def test_tray_mode_uses_web_portal_shell_when_desktop_modules_are_missing(
     monkeypatch,
 ):
     from flatpak_app import app
@@ -697,10 +963,14 @@ def test_tray_mode_falls_back_to_normal_native_app_when_desktop_modules_missing(
         "run_tray",
         lambda: (_ for _ in ()).throw(app.GuiUnavailableError("missing")),
     )
-    monkeypatch.setattr(app, "run_gui", lambda: calls.append("native") or 0)
+    monkeypatch.setattr(
+        app,
+        "run_web_portal_shell",
+        lambda: calls.append("web-portal") or 0,
+    )
 
     assert app.main(["--tray"]) == 0
-    assert calls == ["native"]
+    assert calls == ["web-portal"]
 
 
 def test_flatpak_tray_sources_launch_no_host_service_or_network_commands():


### PR DESCRIPTION
# Summary
- Delete the old native GTK dashboard code entirely.
- Make the Web Portal shell the only Flatpak graphical UI.
- Make normal graphical launch, `--web-portal-shell`, tray primary activation, and Show VR Hotspot use the same reusable Web Portal shell window.
- Remove the redundant Open Web Portal Shell tray item.
- Fix tray status classification so missing/rejected auth maps to Needs Authentication instead of Error.
- Reorganize the tray menu into deterministic Window, Status, Hotspot Controls, Settings, Authentication, Tools, and Quit sections.

# Product decision
- Web Portal shell is the Flatpak UI.
- Old native GTK dashboard is deleted from active code.
- GTK remains only as infrastructure for WebKitGTK hosting, tray lifecycle, authentication, bounded errors, and small utility UI.
- WebKit failure shows bounded token-free GTK error content, not a fallback dashboard.

# Security boundaries
- No token discovery added.
- No token CLI flags added.
- No `/etc/vr-hotspot/env` or `/var/lib/vr-hotspot` token reads added.
- No token logging/output/menu/notification/WebKit injection added.
- Flatpak manifest permissions unchanged.
- WebKit origin, navigation lock, CSP, ephemeral session, and fixed 1.75x zoom preserved.
- Backend, vendor, installer, wallet, and autostart behavior unchanged except tray/client presentation semantics.

# Validation
- Targeted tray validation: 42 passed.
- Focused validation: 176 passed.
- Full validation: 857 passed, 4 subtests passed.
- py_compile passed.
- git diff --check passed.
- Forbidden-reference grep passed with zero matches.
- Real Flatpak build/install and both smoke paths passed.
- KDE D-Bus/process checks passed without token access.
- Ruff was unavailable during Codex review; run locally before PR and CI will verify.

# Review
- Initial review: needs changes due stale docs and missing clear-token refresh regression coverage.
- Blocker fix: docs corrected and clear-token refresh regression test added.
- Final blocker-fix review verdict: approve; no blockers.
- Final review file: `/tmp/vrhotspot-flatpak-delete-native-dashboard-blocker-fix-final-review.md`
- Final review SHA-256: `768f4d2b5ea16467299adb52ea15d76527158e34adb571c9bfb6b0bd75804213`
