### PR TITLE
Sync Flatpak portal and tray authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ build files are removed, and the daemon install continues.
 
 The desktop launcher starts the companion in tray mode. Its only graphical UI
 is the daemon-served Web Portal in a locked WebKitGTK window. Primary tray
-activation and **Show VR Hotspot** open or restore that same window;
-**Hide VR Hotspot** and the window close action hide it to the tray without
-creating another window. If WebKit cannot be constructed, the companion shows
-a bounded GTK error surface and does not open another interface. The tray
-keeps live status and refresh near the top. **Hotspot Commands** groups Start,
+activation opens or restores that same window, and the window close action
+hides it to the tray without creating another window. Redundant Show and Hide
+menu commands are not exported. If WebKit cannot be constructed, the companion
+shows a bounded GTK error surface and does not open another interface. The tray
+keeps **Current status** visible at the top. **Hotspot Commands** groups Start,
 Stop, Restart, and Repair; **Network** contains Share Internet Connection; and
-**Advanced** contains Authentication, Open Diagnostics, Privacy Mode, and the
-existing Start Hotspot Automatically setting. That setting controls daemon
-hotspot autostart, not desktop-companion login autostart. Launching VR Hotspot
-at desktop login remains deferred and is not shown as a tray item. Explicit
-Quit exits only the desktop companion and does not stop an already-running
-hotspot.
+**Advanced** contains Authentication, Refresh Status, Open Diagnostics,
+Privacy Mode, and the existing Start Hotspot Automatically setting. That
+setting controls daemon hotspot autostart, not desktop-companion login
+autostart. Launching VR Hotspot at desktop login remains deferred and is not
+shown as a tray item. Explicit Quit exits only the desktop companion and does
+not stop an already-running hotspot.
 
 The Web Portal shell and tray are one companion and share authentication state.
 An API token accepted after explicit entry in the Portal is adopted immediately

--- a/README.md
+++ b/README.md
@@ -62,9 +62,14 @@ activation and **Show VR Hotspot** open or restore that same window;
 **Hide VR Hotspot** and the window close action hide it to the tray without
 creating another window. If WebKit cannot be constructed, the companion shows
 a bounded GTK error surface and does not open another interface. The tray
-provides live status, lifecycle controls, Share Internet Connection, Privacy
-Mode, and the existing Start Hotspot Automatically setting. Explicit Quit exits
-only the desktop companion and does not stop an already-running hotspot.
+keeps live status and refresh near the top. **Hotspot Commands** groups Start,
+Stop, Restart, and Repair; **Network** contains Share Internet Connection; and
+**Advanced** contains Authentication, Open Diagnostics, Privacy Mode, and the
+existing Start Hotspot Automatically setting. That setting controls daemon
+hotspot autostart, not desktop-companion login autostart. Launching VR Hotspot
+at desktop login remains deferred and is not shown as a tray item. Explicit
+Quit exits only the desktop companion and does not stop an already-running
+hotspot.
 
 The Web Portal shell and tray are one companion and share authentication state.
 An API token accepted after explicit entry in the Portal is adopted immediately

--- a/README.md
+++ b/README.md
@@ -66,16 +66,25 @@ provides live status, lifecycle controls, Share Internet Connection, Privacy
 Mode, and the existing Start Hotspot Automatically setting. Explicit Quit exits
 only the desktop companion and does not stop an already-running hotspot.
 
-Use **Authentication…** to enter the existing daemon API token. Saving it is an
-explicit choice and uses the desktop Secret Service provider (including a
-compatible KDE Wallet setup); otherwise it remains in memory only. The
-installer and Flatpak never discover the token from `/etc/vr-hotspot`,
-`/var/lib/vr-hotspot`, daemon configuration, environment variables, or command
-arguments. Missing or rejected credentials are reported as
-**Needs Authentication**, separately from **Daemon Unavailable** and unexpected
-**Error** states. Start, Stop, Restart, and Repair remain disabled until an
-explicitly entered or saved token authenticates successfully. The historical
-flag remains a compatibility alias for the same default graphical behavior:
+The Web Portal shell and tray are one companion and share authentication state.
+An API token accepted after explicit entry in the Portal is adopted immediately
+by the tray. When Secret Service is available, the accepted token is saved in
+the app-specific wallet; otherwise it remains in memory for the current
+companion process only. A valid saved wallet token authenticates the tray at
+launch and is supplied to the Portal only through a bounded, fixed-origin,
+in-memory WebKit bridge—not through a URL, file, or command argument.
+
+**Authentication…** remains available for explicit token entry, replacement,
+testing, and clearing. The companion never uses sudo to obtain a token and
+never discovers one from `/etc/vr-hotspot/env`, `/var/lib/vr-hotspot`, daemon
+configuration, environment variables, or command arguments. Missing or
+rejected credentials are reported as **Needs Authentication**, separately from
+**Daemon Unavailable** and unexpected **Error** states. Needs Authentication is
+a static icon state; working/pulsing indication is reserved for active
+transitions. Start, Stop, Restart, and Repair remain disabled until the shared
+token authenticates successfully and then become available according to the
+real daemon state. The historical flag remains a compatibility alias for the
+same default graphical behavior:
 
 ```bash
 flatpak run io.github.josethevrtech.VRhotspot --web-portal-shell

--- a/assets/index.html
+++ b/assets/index.html
@@ -22,7 +22,7 @@
     <div class="login-splash-inner">
       <img class="login-logo" src="/assets/logo.png" alt="VR Hotspot" />
       <form id="loginForm" class="login-form" autocomplete="off">
-        <input id="loginToken" type="password" placeholder="API Token" />
+        <input id="loginToken" type="password" maxlength="4096" placeholder="API Token" />
         <button class="btn primary" id="btnLoginSubmit" type="submit">Continue</button>
       </form>
       <div id="loginError" class="small mt-10 error-text" role="alert"></div>

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -5,6 +5,11 @@ const STORE = (function () {
 })();
 const TOKEN_KEY = 'vr_hotspot_token';
 const LEGACY_TOKEN_KEY = 'vr_hotspot_api_token';
+const COMPANION_AUTH_ORIGIN = 'http://127.0.0.1:8732';
+const COMPANION_AUTH_HANDLER = 'vrHotspotCompanionAuth';
+const COMPANION_AUTH_PROTOCOL_VERSION = 1;
+const MAX_COMPANION_AUTH_MESSAGE_CHARS = 8192;
+const MAX_COMPANION_AUTH_TOKEN_CHARS = 4096;
 const DEBUG_TOKEN = false;
 const LS = {
   token: TOKEN_KEY,
@@ -75,6 +80,7 @@ let activeTipTarget = null;
 let floatingTipWired = false;
 let isAuthenticated = false;
 let authFlowLocked = false;
+let companionSessionToken = '';
 let uiBootstrapped = false;
 let refreshTimer = null;
 const BASIC_REFRESH_INTERVAL_MS = 2000;
@@ -873,6 +879,76 @@ function getLocalStorageSafe() {
   try { return localStorage; } catch { return null; }
 }
 
+function getCompanionAuthHandler() {
+  try {
+    if (!window.location || window.location.origin !== COMPANION_AUTH_ORIGIN) return null;
+    const path = window.location.pathname || '';
+    if (path !== '/ui' && path !== '/ui/' && !path.startsWith('/assets/')) return null;
+    const handlers = window.webkit && window.webkit.messageHandlers;
+    const handler = handlers && handlers[COMPANION_AUTH_HANDLER];
+    return (handler && typeof handler.postMessage === 'function') ? handler : null;
+  } catch {
+    return null;
+  }
+}
+
+function companionAuthBridgeAvailable() {
+  return getCompanionAuthHandler() !== null;
+}
+
+async function postCompanionAuthMessage(message) {
+  const handler = getCompanionAuthHandler();
+  if (!handler) return { available: false, reply: '' };
+  let raw = '';
+  try {
+    raw = JSON.stringify(message);
+  } catch {
+    return { available: true, reply: '' };
+  }
+  if (!raw || raw.length > MAX_COMPANION_AUTH_MESSAGE_CHARS) {
+    return { available: true, reply: '' };
+  }
+  try {
+    const reply = await handler.postMessage(raw);
+    return {
+      available: true,
+      reply: (typeof reply === 'string') ? reply : '',
+    };
+  } catch {
+    return { available: true, reply: '' };
+  } finally {
+    raw = '';
+  }
+}
+
+async function requestCompanionAuthToken() {
+  const result = await postCompanionAuthMessage({
+    version: COMPANION_AUTH_PROTOCOL_VERSION,
+    type: 'token_request',
+  });
+  if (!result.available) return null;
+  const token = result.reply.trim();
+  if (!token || token.length > MAX_COMPANION_AUTH_TOKEN_CHARS) return '';
+  return token;
+}
+
+async function notifyCompanionAuthAccepted(token) {
+  const result = await postCompanionAuthMessage({
+    version: COMPANION_AUTH_PROTOCOL_VERSION,
+    type: 'auth_accepted',
+    token,
+  });
+  if (!result.available) return null;
+  return result.reply === 'accepted';
+}
+
+function notifyCompanionAuthCleared() {
+  void postCompanionAuthMessage({
+    version: COMPANION_AUTH_PROTOCOL_VERSION,
+    type: 'auth_cleared',
+  });
+}
+
 function getStoredToken() {
   const ls = getLocalStorageSafe();
   if (ls) return (ls.getItem(TOKEN_KEY) || '').trim();
@@ -923,7 +999,7 @@ function debugTokenLog(injected) {
 }
 
 function getToken() {
-  return getStoredToken();
+  return companionSessionToken || getStoredToken();
 }
 
 function setToken(v) {
@@ -940,14 +1016,21 @@ function isUnauthorizedStatus(status) {
   return status === 401 || status === 403;
 }
 
-function clearStoredTokenEverywhere() {
+function clearStoredTokenEverywhere(opts = {}) {
+  companionSessionToken = '';
   setStoredToken('');
   const ls = getLocalStorageSafe();
   try { if (ls) ls.removeItem(TOKEN_KEY); } catch { /* ignore */ }
   try { if (ls) ls.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
   try { STORE.removeItem(TOKEN_KEY); } catch { /* ignore */ }
   try { STORE.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
+  if (opts.notifyCompanion !== false) notifyCompanionAuthCleared();
 }
+
+window.vrHotspotCompanionAuthCleared = function () {
+  clearStoredTokenEverywhere({ notifyCompanion: false });
+  renderLoginSplash();
+};
 
 function clearLoggedOutRouteState() {
   if (!window.location.hash) return;
@@ -1033,6 +1116,23 @@ async function submitLoginSplashToken() {
 
   const result = await validateTokenCandidate(token);
   if (result.ok) {
+    const companionAccepted = await notifyCompanionAuthAccepted(token);
+    if (companionAccepted === true) {
+      companionSessionToken = token;
+      input.value = '';
+      showAuthenticatedApp();
+      bootstrapAuthenticatedUi();
+      return;
+    }
+    if (companionAccepted === false) {
+      clearStoredTokenEverywhere({ notifyCompanion: false });
+      input.value = '';
+      setLoginError('Invalid token');
+      input.disabled = false;
+      submit.disabled = false;
+      input.focus();
+      return;
+    }
     setToken(token);
     window.location.reload();
     return;
@@ -3760,7 +3860,15 @@ async function init() {
     if (!isAuthenticated) clearLoggedOutRouteState();
   });
 
-  const tok = migrateLegacyToken() || getStoredToken();
+  const companionBridge = companionAuthBridgeAvailable();
+  let tok = '';
+  if (companionBridge) {
+    clearStoredTokenEverywhere({ notifyCompanion: false });
+    tok = (await requestCompanionAuthToken()) || '';
+    companionSessionToken = tok;
+  } else {
+    tok = migrateLegacyToken() || getStoredToken();
+  }
   if (!tok) {
     renderLoginSplash();
     return;
@@ -3780,7 +3888,8 @@ async function init() {
     return;
   }
 
-  setToken(tok);
+  if (companionBridge) companionSessionToken = tok;
+  else setToken(tok);
   showAuthenticatedApp();
   bootstrapAuthenticatedUi();
 }

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -6,12 +6,12 @@ Date: 2026-07-24
 
 This document defines the boundary for the VRhotspot Flatpak control
 application. PR #92 makes the origin-locked, daemon-served Web Portal the only
-Flatpak graphical UI. Normal launch, tray primary activation, and
-**Show VR Hotspot** all open or restore one locked WebKitGTK window;
-**Hide VR Hotspot** and close-to-tray hide that same window. The pre-PR #92 GTK
-content implementation, its token-entry flow, and every launch or failure path
-that could reach it have been removed from active code. GTK remains only for
-the WebKit host window, tray integration, the explicit authentication dialog,
+Flatpak graphical UI. Normal launch and tray primary activation open or restore
+one locked WebKitGTK window; close-to-tray hides that same window. Redundant
+Show and Hide menu commands are not exported. The pre-PR #92 GTK content
+implementation, its token-entry flow, and every launch or failure path that
+could reach it have been removed from active code. GTK remains only for the
+WebKit host window, tray integration, the explicit authentication dialog,
 bounded error surfaces, and small desktop utility dialogs.
 
 PR #90's fixed 1.75x WebKit display zoom and PR #88's exact loopback origin,
@@ -692,12 +692,12 @@ PR #91 makes the optional Flatpak companion a persistent desktop utility while
 keeping `vr-hotspotd` as the sole privileged host-mutation boundary. An explicit
 `--tray` launch mode owns a StatusNotifierItem and DBusMenu. PR #92 changes its
 lifecycle-owned window to the locked Web Portal shell: it is shown initially,
-restored on primary tray activation or **Show VR Hotspot**, and hidden by
-**Hide VR Hotspot** or close-to-tray. Repeated activation reuses the same
-window. `Quit VR Hotspot` exits only the companion; it does not issue a hotspot
-stop request. If the tray backend cannot register, the Web Portal window still
-opens and closes normally instead of crashing or becoming hidden without a
-reachable tray icon.
+restored on primary tray activation, and hidden by close-to-tray. Repeated
+activation reuses the same window, so redundant Show and Hide menu commands are
+not exported. `Quit VR Hotspot` exits only the companion; it does not issue a
+hotspot stop request. If the tray backend cannot register, the Web Portal
+window still opens and closes normally instead of crashing or becoming hidden
+without a reachable tray icon.
 
 The GNOME 50 runtime provides Gio/GDBus and libsecret but does not provide an
 AppIndicator/Ayatana binding. The tray therefore implements the standard
@@ -775,20 +775,25 @@ Tray status distinguishes `Running`, `Stopped`, `Transitioning`,
 `Needs Authentication`, `Daemon Unavailable`, and `Error`. Missing, rejected,
 or daemon-missing credentials map to `Needs Authentication`; connection
 failure maps to `Daemon Unavailable`; only unexpected or malformed failures
-map to `Error`. Authentication remains enabled while credentials are needed.
-Start, Stop, Restart, and Repair require an authenticated state, and saving or
-testing an explicitly entered token triggers a status refresh.
+map to `Error`. The saved wallet/session state and daemon status are resolved
+before the tray item is registered, so the initial icon, tooltip, and command
+sensitivity use the authenticated live state. Authentication remains enabled
+while credentials are needed. Authenticated `Stopped` enables Start, Restart,
+and Repair; authenticated `Running` enables Stop, Restart, and Repair.
+Transitioning disables conflicting mutations and alone requests the working
+attention state. Needs Authentication and Stopped remain static. Saving or
+testing an explicitly entered token triggers a serialized status refresh.
 
 The exported menu is deterministic and grouped without duplicating submenu
-actions at the top level. Show, Hide, current status, and refresh remain near
-the top. **Hotspot Commands** contains Start, Stop, Restart, and Repair;
-**Network** contains Share Internet Connection; and **Advanced** contains
-Authentication, Open Diagnostics, Privacy Mode, and Start Hotspot
-Automatically. Quit remains top-level and exits only the companion. Start
-Hotspot Automatically controls daemon/hotspot boot autostart, not
-desktop-companion login autostart. Launch at Logon remains deferred and no tray
-item is exported for it. There is no second menu action for opening the
-already-default graphical shell.
+actions at the top level. Current status remains at the top. **Hotspot
+Commands** contains Start, Stop, Restart, and Repair; **Network** contains Share
+Internet Connection; and **Advanced** contains Authentication, Refresh Status,
+Open Diagnostics, Privacy Mode, and Start Hotspot Automatically. Quit remains
+top-level and exits only the companion. Start Hotspot Automatically controls
+daemon/hotspot boot autostart, not desktop-companion login autostart. Launch at
+Logon remains deferred and no tray item is exported for it. Primary activation
+is the only tray action that opens or restores the already-default graphical
+shell.
 
 ## PR #93 shared Portal and tray authentication state
 
@@ -927,7 +932,7 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #89 | Web Portal shell layout and theme polish. Improve shared Portal CSS across viewport sizes and WebKitGTK form controls. | Asset tests prove responsive layout, dark control states, retained Basic/Pro behavior, and one daemon-served asset source for browser and Flatpak. |
 | PR #90 | Flatpak Web Portal shell scaling/density polish. Apply fixed bounded 1.75x WebKit zoom to the locked shell. | Tests prove fixed zoom/clamping, no user-controlled scale, normal browser scale, and unchanged origin/session/token boundaries. |
 | PR #91 | Flatpak system-tray control surface and desktop identity. Add StatusNotifierItem/DBusMenu, close-to-tray, typed live state, fixed controls, explicit Secret Service authentication, and cyan/black icons. | Tests prove complete menu/state mapping, serialized mutations, refresh-after-success, companion-only quit, safe wallet behavior, narrow D-Bus grants, and installed icon identity. |
-| PR #92 | Web Portal-only Flatpak graphical UI. Delete the retired GTK content surface and all routes/tests supporting it; make default and tray window behavior use one locked Web Portal shell; classify authentication and daemon availability separately; organize the tray menu. | Tests prove default/alias/tray activation, show/hide/close and single-window behavior, bounded WebKit errors with no alternate surface, retained origin/CSP/session/zoom locks, six status classes, explicit-auth refresh, deterministic menu sections, no credential leakage, unchanged permissions, and zero forbidden active references. |
+| PR #92 | Web Portal-only Flatpak graphical UI. Delete the retired GTK content surface and all routes/tests supporting it; make default and tray window behavior use one locked Web Portal shell; classify authentication and daemon availability separately; organize the tray menu. | Tests prove default/alias/tray activation, close-to-tray and single-window behavior, bounded WebKit errors with no alternate surface, retained origin/CSP/session/zoom locks, six status classes, explicit-auth refresh, deterministic menu sections, no credential leakage, unchanged permissions, and zero forbidden active references. |
 | PR #93 | Shared Web Portal/tray companion authentication. Connect accepted Portal entry and logout to the existing wallet/in-memory session controller, supply an existing wallet token only through a bounded fixed-origin WebKit reply, refresh tray state immediately, and reserve working attention for transitions. | Tests prove bidirectional sync, wallet and current-process fallback behavior, strict message/origin bounds, clear synchronization, token secrecy, correct auth/running/unavailable state and menu mapping, static auth-needed indication, retained WebKit locks, unchanged permissions, and no native dashboard. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Flatpak control app architecture plan
 
-Status: PR #92 Web Portal-only Flatpak graphical UI; PRs #77-#91 retained
+Status: PR #93 shared Web Portal/tray companion authentication; PRs #77-#92 retained
 
 Date: 2026-07-24
 
@@ -21,9 +21,11 @@ copy; it never opens another graphical surface. The browser `/ui` route
 continues to use the shared assets at normal browser scale.
 
 PR #83's explicit terminal-only live daemon pairing smoke path and PR #84's
-optional installer prompt remain. PR #92 does not inject a token into WebKit,
-change the shared Web Portal assets, add direct host command execution, add host
-filesystem access, or move privileged network ownership out of the daemon.
+optional installer prompt remain. PR #93 connects the Portal and tray through a
+bounded, fixed-origin, in-memory WebKit authentication bridge and the existing
+companion wallet/session controller. It adds no direct host command execution,
+host filesystem access, token argument or discovery path, permission, or change
+to the daemon's privileged network ownership.
 
 ## Architectural decision
 
@@ -783,6 +785,46 @@ order: Window (Show, Hide), Status (current status, refresh), Hotspot Controls
 autostart), Authentication, Tools (Diagnostics), and Quit. There is no second
 menu action for opening the already-default graphical shell.
 
+## PR #93 shared Portal and tray authentication state
+
+PR #93 treats the Web Portal shell and tray as two surfaces of one companion
+process, not as separate authentication clients. Both use the existing
+`AuthenticationController`. An explicitly entered token is still accepted only
+after the Portal's authenticated status request succeeds. The origin-locked
+WebKit page then sends one bounded, versioned message to the host; the host
+adopts the token in memory, stores it in the app-specific Secret Service wallet
+when that provider is available, and requests an immediate tray refresh.
+
+The reverse path is equally narrow. On launch, the existing authentication
+controller may retrieve the matching app-specific wallet item. The Portal can
+request that current wallet/session token only through WebKit's in-memory
+script-message reply mechanism. The credential is not placed in a URL, query
+string, command argument, local file, log, notification, menu label, smoke JSON,
+or exception. The bridge accepts only fixed protocol message shapes, enforces
+token and message-size limits, and responds only while the WebView is at the
+exact loopback origin used by `/ui` and its same-origin assets.
+
+Portal logout and token clearing clear the companion's session and matching
+wallet item and refresh the tray. Clearing through the tray authentication
+dialog also clears the Portal's in-memory session. If Secret Service is
+unavailable, an accepted Portal token remains usable only in the current
+companion process; it is not persisted elsewhere.
+
+The companion never invokes sudo or searches `/etc/vr-hotspot/env`,
+`/var/lib/vr-hotspot`, daemon configuration, environment variables, or command
+arguments for credentials. PR #93 adds no filesystem, host/home, device,
+system-bus, or other Flatpak permission. The exact WebKit origin and navigation
+lock, CSP, ephemeral network session, and 1.75x zoom remain unchanged.
+
+Tray status and icon policy is explicit. Missing or rejected credentials map to
+`Needs Authentication`, not `Error`; the authentication action stays enabled
+and daemon controls stay disabled. Daemon connection failure maps to
+`Daemon Unavailable`. An authenticated running hotspot maps to `Running`, and
+an authenticated stopped hotspot maps to `Stopped`, with controls enabled
+according to those states. `Needs Authentication` is static. The working
+attention/pulsing state is used only for `Transitioning` while Start, Stop,
+Restart, Repair, or another serialized operation is active.
+
 ## Sandbox and portal expectations
 
 The future Flatpak should begin from a minimal permission set and justify every
@@ -881,6 +923,7 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #90 | Flatpak Web Portal shell scaling/density polish. Apply fixed bounded 1.75x WebKit zoom to the locked shell. | Tests prove fixed zoom/clamping, no user-controlled scale, normal browser scale, and unchanged origin/session/token boundaries. |
 | PR #91 | Flatpak system-tray control surface and desktop identity. Add StatusNotifierItem/DBusMenu, close-to-tray, typed live state, fixed controls, explicit Secret Service authentication, and cyan/black icons. | Tests prove complete menu/state mapping, serialized mutations, refresh-after-success, companion-only quit, safe wallet behavior, narrow D-Bus grants, and installed icon identity. |
 | PR #92 | Web Portal-only Flatpak graphical UI. Delete the retired GTK content surface and all routes/tests supporting it; make default and tray window behavior use one locked Web Portal shell; classify authentication and daemon availability separately; organize the tray menu. | Tests prove default/alias/tray activation, show/hide/close and single-window behavior, bounded WebKit errors with no alternate surface, retained origin/CSP/session/zoom locks, six status classes, explicit-auth refresh, deterministic menu sections, no credential leakage, unchanged permissions, and zero forbidden active references. |
+| PR #93 | Shared Web Portal/tray companion authentication. Connect accepted Portal entry and logout to the existing wallet/in-memory session controller, supply an existing wallet token only through a bounded fixed-origin WebKit reply, refresh tray state immediately, and reserve working attention for transitions. | Tests prove bidirectional sync, wallet and current-process fallback behavior, strict message/origin bounds, clear synchronization, token secrecy, correct auth/running/unavailable state and menu mapping, static auth-needed indication, retained WebKit locks, unchanged permissions, and no native dashboard. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -961,17 +1004,16 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #92
+## Explicit non-goals for PR #93
 
 - No second graphical shell, alternate failure UI, legacy launch route, or
   development-only route for the removed GTK content surface.
-- No Web UI JavaScript, CSS, route, CSP, origin, navigation, token, or session
-  behavior change.
+- No Web UI route, CSS, CSP, origin, navigation, ephemeral-session, or zoom
+  change outside the narrow companion authentication bridge.
 - No arbitrary URL argument, address bar, external/new-window navigation,
   remote-site load, or general browser.
 - No token CLI argument, discovery endpoint, direct `/etc` or `/var/lib`
-  secret read, plaintext credential file, automatic copy/reveal, or WebKit
-  token injection.
+  secret read, plaintext credential file, or automatic copy/reveal.
 - No desktop-login companion autostart. It remains distinct from existing
   hotspot boot autostart and requires a separately reviewed reliable mechanism.
 - No generic daemon configuration or systemd-control API. The new endpoint is
@@ -986,10 +1028,11 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No Steam Frame, VR Direct Link, known-adapter registry, or
   HostFactsSnapshot work.
 
-PR #92 authorizes only deletion of the retired GTK content surface, the default
-and tray-window Web Portal cutover, status classification correction, menu
-organization, deterministic tests, and documentation above. It does not change
-the fixed autostart API, session-bus grants, desktop identity, or permissions.
-A real daemon pairing or live lifecycle result is claimed only when exercised
-with an explicitly entered credential; no credential is printed or exported in
-validation.
+PR #93 authorizes only the fixed-origin WebKit authentication bridge, reuse of
+the existing companion wallet/session state, Portal/tray clear synchronization,
+tray status and attention-icon correction, deterministic tests, and
+documentation above. It does not change the fixed autostart API, session-bus
+grants, desktop identity, WebKit security boundaries, or permissions. A real
+daemon pairing or live lifecycle result is claimed only when exercised with an
+explicitly entered or previously saved credential; no credential is printed or
+exported in validation.

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -779,11 +779,16 @@ map to `Error`. Authentication remains enabled while credentials are needed.
 Start, Stop, Restart, and Repair require an authenticated state, and saving or
 testing an explicitly entered token triggers a status refresh.
 
-The exported menu uses deterministic separator-delimited sections in this
-order: Window (Show, Hide), Status (current status, refresh), Hotspot Controls
-(Start, Stop, Restart, Repair), Settings (internet sharing, privacy, hotspot
-autostart), Authentication, Tools (Diagnostics), and Quit. There is no second
-menu action for opening the already-default graphical shell.
+The exported menu is deterministic and grouped without duplicating submenu
+actions at the top level. Show, Hide, current status, and refresh remain near
+the top. **Hotspot Commands** contains Start, Stop, Restart, and Repair;
+**Network** contains Share Internet Connection; and **Advanced** contains
+Authentication, Open Diagnostics, Privacy Mode, and Start Hotspot
+Automatically. Quit remains top-level and exits only the companion. Start
+Hotspot Automatically controls daemon/hotspot boot autostart, not
+desktop-companion login autostart. Launch at Logon remains deferred and no tray
+item is exported for it. There is no second menu action for opening the
+already-default graphical shell.
 
 ## PR #93 shared Portal and tray authentication state
 

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -34,6 +34,10 @@ WEBKIT_GI_VERSION = "6.0"
 WEB_PORTAL_SHELL_ZOOM = 1.75
 MAX_SMOKE_JSON_BYTES = 8_192
 MAX_LIVE_SMOKE_JSON_BYTES = 65_536
+WEB_PORTAL_AUTH_HANDLER = "vrHotspotCompanionAuth"
+WEB_PORTAL_AUTH_PROTOCOL_VERSION = 1
+MAX_WEB_PORTAL_AUTH_MESSAGE_BYTES = 8_192
+MAX_WEB_PORTAL_AUTH_TOKEN_CHARS = 4_096
 _WEB_PORTAL_SHELL_ZOOM_MIN = 1.0
 _WEB_PORTAL_SHELL_ZOOM_MAX = 2.0
 _WEB_PORTAL_CSP = (
@@ -61,6 +65,196 @@ class GuiUnavailableError(RuntimeError):
 
 class WebKitUnavailableError(RuntimeError):
     """The pinned WebKitGTK GI API is unavailable for the portal shell."""
+
+
+class WebPortalAuthBridge:
+    """Share companion authentication with only the locked local Portal."""
+
+    _CLEAR_PORTAL_SCRIPT = (
+        "if (typeof window.vrHotspotCompanionAuthCleared === 'function') {"
+        "window.vrHotspotCompanionAuthCleared();"
+        "}"
+    )
+
+    def __init__(self, authentication: AuthenticationController):
+        self._authentication = authentication
+        self._auth_changed = None
+        self._web_view = None
+
+    def __repr__(self) -> str:
+        return (
+            "WebPortalAuthBridge("
+            f"view_attached={self._web_view is not None!r})"
+        )
+
+    def set_auth_changed_callback(self, callback) -> None:
+        self._auth_changed = callback if callable(callback) else None
+
+    def attach_web_view(self, web_view) -> None:
+        self._web_view = web_view
+
+    @staticmethod
+    def _reply_string(message_value, reply, response: str) -> None:
+        try:
+            context = message_value.get_context()
+            value = type(message_value).new_string(context, response)
+            reply.return_value(value)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _page_uri(web_view) -> str:
+        try:
+            uri = web_view.get_uri()
+        except Exception:
+            return ""
+        return uri if isinstance(uri, str) else ""
+
+    @staticmethod
+    def _raw_message(message_value) -> str | None:
+        try:
+            if message_value.is_string() is not True:
+                return None
+            raw = message_value.to_string()
+        except Exception:
+            return None
+        if not isinstance(raw, str):
+            return None
+        try:
+            size = len(raw.encode("utf-8"))
+        except UnicodeError:
+            return None
+        if size > MAX_WEB_PORTAL_AUTH_MESSAGE_BYTES:
+            return None
+        return raw
+
+    @staticmethod
+    def _parsed_message(raw: str) -> dict[str, Any] | None:
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        if type(payload.get("version")) is not int:
+            return None
+        if payload.get("version") != WEB_PORTAL_AUTH_PROTOCOL_VERSION:
+            return None
+        message_type = payload.get("type")
+        if not isinstance(message_type, str):
+            return None
+        expected_keys = {
+            "token_request": {"version", "type"},
+            "auth_accepted": {"version", "type", "token"},
+            "auth_cleared": {"version", "type"},
+        }.get(message_type)
+        if expected_keys is None or set(payload) != expected_keys:
+            return None
+        if message_type == "auth_accepted":
+            token = payload.get("token")
+            if (
+                not isinstance(token, str)
+                or not token
+                or len(token) > MAX_WEB_PORTAL_AUTH_TOKEN_CHARS
+            ):
+                return None
+        return payload
+
+    def _emit_auth_changed(self) -> None:
+        callback = self._auth_changed
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception:
+            pass
+
+    def handle_message(self, web_view, message_value, reply) -> bool:
+        """Handle one bounded message and always return only a fixed reply."""
+
+        if not is_approved_web_portal_bridge_uri(self._page_uri(web_view)):
+            self._reply_string(message_value, reply, "rejected")
+            return False
+
+        raw = self._raw_message(message_value)
+        payload = self._parsed_message(raw) if raw is not None else None
+        raw = None
+        if payload is None:
+            self._reply_string(message_value, reply, "rejected")
+            return False
+
+        message_type = payload["type"]
+        if message_type == "token_request":
+            token = ""
+            try:
+                candidate = self._authentication.token_for_operation()
+                if (
+                    isinstance(candidate, str)
+                    and 0 < len(candidate) <= MAX_WEB_PORTAL_AUTH_TOKEN_CHARS
+                ):
+                    token = candidate
+            except Exception:
+                token = ""
+            self._reply_string(message_value, reply, token)
+            token = ""
+            candidate = None
+            return True
+
+        if message_type == "auth_cleared":
+            try:
+                self._authentication.clear()
+            except Exception:
+                self._reply_string(message_value, reply, "rejected")
+                return False
+            self._emit_auth_changed()
+            self._reply_string(message_value, reply, "cleared")
+            return True
+
+        token = payload["token"]
+        accepted = False
+        try:
+            result = self._authentication.save_or_replace(
+                token,
+                save_securely=True,
+            )
+            accepted = (
+                result.code in {"saved_securely", "wallet_unavailable"}
+                and result.token_available is True
+            )
+        except Exception:
+            accepted = False
+        finally:
+            payload = None
+            token = ""
+        if accepted:
+            self._emit_auth_changed()
+        self._reply_string(
+            message_value,
+            reply,
+            "accepted" if accepted else "rejected",
+        )
+        return accepted
+
+    def clear_web_portal_session(self) -> None:
+        """Clear only the attached fixed-origin page's in-memory auth state."""
+
+        web_view = self._web_view
+        if web_view is None:
+            return
+        if not is_approved_web_portal_bridge_uri(self._page_uri(web_view)):
+            return
+        try:
+            web_view.evaluate_javascript(
+                self._CLEAR_PORTAL_SCRIPT,
+                -1,
+                None,
+                f"{WEB_PORTAL_ORIGIN}/companion-auth-bridge",
+                None,
+                None,
+                None,
+            )
+        except Exception:
+            pass
 
 
 def build_initial_model() -> DiagnosticsControlUiModel:
@@ -358,6 +552,18 @@ def is_approved_web_portal_uri(uri: object) -> bool:
     )
 
 
+def is_approved_web_portal_bridge_uri(uri: object) -> bool:
+    """Restrict companion auth to the Portal document and its asset namespace."""
+
+    if not is_approved_web_portal_uri(uri):
+        return False
+    try:
+        path = urlsplit(uri).path
+    except (TypeError, ValueError):
+        return False
+    return path in {"/ui", "/ui/"} or path.startswith("/assets/")
+
+
 def _policy_decision_uri(decision, decision_type, WebKit) -> str:
     try:
         if decision_type in (
@@ -399,8 +605,36 @@ def _bounded_web_portal_shell_zoom() -> float:
     )
 
 
-def _build_locked_web_portal_view(WebKit):
-    """Create an ephemeral WebView without credential or script injection."""
+def _attach_web_portal_auth_bridge(web_view, auth_bridge) -> None:
+    """Register one bounded request/reply channel on the locked WebView."""
+
+    try:
+        manager = web_view.get_user_content_manager()
+        manager.connect(
+            f"script-message-with-reply-received::{WEB_PORTAL_AUTH_HANDLER}",
+            lambda _manager, value, reply: auth_bridge.handle_message(
+                web_view,
+                value,
+                reply,
+            ),
+        )
+        registered = manager.register_script_message_handler_with_reply(
+            WEB_PORTAL_AUTH_HANDLER,
+            None,
+        )
+    except Exception:
+        raise WebKitUnavailableError(
+            "WebKitGTK did not provide the required local auth bridge."
+        ) from None
+    if registered is not True:
+        raise WebKitUnavailableError(
+            "WebKitGTK did not provide the required local auth bridge."
+        )
+    auth_bridge.attach_web_view(web_view)
+
+
+def _build_locked_web_portal_view(WebKit, *, auth_bridge=None):
+    """Create an ephemeral fixed-origin WebView with an optional auth bridge."""
 
     network_session = WebKit.NetworkSession.new_ephemeral()
     if network_session.is_ephemeral() is not True:
@@ -448,6 +682,8 @@ def _build_locked_web_portal_view(WebKit):
         return True
 
     web_view.connect("permission-request", deny_permission)
+    if auth_bridge is not None:
+        _attach_web_portal_auth_bridge(web_view, auth_bridge)
     return web_view
 
 
@@ -495,7 +731,13 @@ def _populate_web_portal_error(Gtk, window) -> None:
     window.set_child(error_box)
 
 
-def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
+def _populate_web_portal_window(
+    Gtk,
+    WebKit,
+    window,
+    *,
+    auth_bridge=None,
+) -> bool:
     """Populate the locked portal shell or a bounded error surface."""
 
     window.set_title(APP_NAME)
@@ -505,7 +747,10 @@ def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
         _populate_web_portal_error(Gtk, window)
         return False
     try:
-        web_view = _build_locked_web_portal_view(WebKit)
+        web_view = _build_locked_web_portal_view(
+            WebKit,
+            auth_bridge=auth_bridge,
+        )
     except Exception:
         _populate_web_portal_error(Gtk, window)
         return False
@@ -559,14 +804,19 @@ def _populate_web_portal_window(Gtk, WebKit, window) -> bool:
     return True
 
 
-def _populate_new_portal_window(Gtk, window) -> bool:
+def _populate_new_portal_window(Gtk, window, *, auth_bridge=None) -> bool:
     """Load WebKit lazily and always leave the window with bounded content."""
 
     try:
         WebKit = _load_webkit()
     except Exception:
         WebKit = None
-    return _populate_web_portal_window(Gtk, WebKit, window)
+    return _populate_web_portal_window(
+        Gtk,
+        WebKit,
+        window,
+        auth_bridge=auth_bridge,
+    )
 
 
 def run_web_portal_shell() -> int:
@@ -575,6 +825,8 @@ def run_web_portal_shell() -> int:
     Gtk = _load_gtk()
     application = Gtk.Application(application_id=APP_ID)
     window_holder: dict[str, Any] = {}
+    authentication = AuthenticationController()
+    auth_bridge = WebPortalAuthBridge(authentication)
 
     def on_activate(app) -> None:
         existing = window_holder.get("window")
@@ -583,7 +835,11 @@ def run_web_portal_shell() -> int:
             return
 
         window = Gtk.ApplicationWindow(application=app)
-        _populate_new_portal_window(Gtk, window)
+        _populate_new_portal_window(
+            Gtk,
+            window,
+            auth_bridge=auth_bridge,
+        )
 
         def clear_window(*_args):
             window_holder.pop("window", None)
@@ -619,8 +875,13 @@ def run_tray() -> int:
             return
 
         window = Gtk.ApplicationWindow(application=app)
-        _populate_new_portal_window(Gtk, window)
         authentication = AuthenticationController()
+        auth_bridge = WebPortalAuthBridge(authentication)
+        _populate_new_portal_window(
+            Gtk,
+            window,
+            auth_bridge=auth_bridge,
+        )
         controls = TrayControlController(authentication)
         lifecycle = WindowLifecycleController(
             application=app,
@@ -654,7 +915,9 @@ def run_tray() -> int:
             Gio=Gio,
             GLib=GLib,
             open_diagnostics=open_diagnostics,
+            on_auth_cleared=auth_bridge.clear_web_portal_session,
         )
+        auth_bridge.set_auth_changed_callback(runtime.refresh_after_auth_change)
         runtime_holder["runtime"] = runtime
         window.connect("close-request", runtime.close_request)
         lifecycle.show()

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -131,12 +131,7 @@ def build_tray_menu_model(
         icon_name=ICON_NAMES[state.status],
         notifier_status=(
             "NeedsAttention"
-            if state.status
-            in {
-                TrayStatus.NEEDS_AUTHENTICATION,
-                TrayStatus.DAEMON_UNAVAILABLE,
-                TrayStatus.ERROR,
-            }
+            if state.status is TrayStatus.TRANSITIONING
             else "Active"
         ),
         tooltip=f"{APP_NAME} — {state.status_label}",
@@ -386,6 +381,7 @@ class StatusNotifierBackend:
     def update(self, model: TrayMenuModel) -> None:
         icon_changed = model.icon_name != self._model.icon_name
         status_changed = model.notifier_status != self._model.notifier_status
+        attention_changed = icon_changed or status_changed
         tooltip_changed = model.tooltip != self._model.tooltip
         self._model = model
         self._revision += 1
@@ -406,6 +402,14 @@ class StatusNotifierBackend:
                     self.ITEM_PATH,
                     self.ITEM_INTERFACE,
                     "NewIcon",
+                    None,
+                )
+            if attention_changed:
+                connection.emit_signal(
+                    None,
+                    self.ITEM_PATH,
+                    self.ITEM_INTERFACE,
+                    "NewAttentionIcon",
                     None,
                 )
             if status_changed:
@@ -446,7 +450,10 @@ class StatusNotifierBackend:
             "IconPixmap": Variant("a(iiay)", []),
             "OverlayIconName": Variant("s", ""),
             "OverlayIconPixmap": Variant("a(iiay)", []),
-            "AttentionIconName": Variant("s", f"{APP_ID}-error"),
+            "AttentionIconName": Variant(
+                "s",
+                ICON_NAMES[TrayStatus.TRANSITIONING],
+            ),
             "AttentionIconPixmap": Variant("a(iiay)", []),
             "AttentionMovieName": Variant("s", ""),
             "ToolTip": Variant(
@@ -644,6 +651,7 @@ class TrayRuntime:
         Gio,
         GLib,
         open_diagnostics: Callable[[], None],
+        on_auth_cleared: Callable[[], None] | None = None,
     ):
         self._application = application
         self._lifecycle = lifecycle
@@ -655,7 +663,13 @@ class TrayRuntime:
         self._Gio = Gio
         self._GLib = GLib
         self._open_diagnostics = open_diagnostics
+        self._on_auth_cleared = (
+            on_auth_cleared
+            if callable(on_auth_cleared)
+            else lambda: None
+        )
         self._worker_lock = threading.Lock()
+        self._auth_refresh_pending = False
         self._notification_counter = 0
         self._last_detail_code = ""
         self._auth_window = None
@@ -757,6 +771,10 @@ class TrayRuntime:
         finally:
             if self._worker_lock.locked():
                 self._worker_lock.release()
+        if self._auth_refresh_pending:
+            self._auth_refresh_pending = False
+            if not self._run_worker(self._controls.refresh):
+                self._auth_refresh_pending = True
         return False
 
     def _run_worker(
@@ -764,9 +782,9 @@ class TrayRuntime:
         call: Callable[[], object],
         *,
         pending_action: str | None = None,
-    ) -> None:
+    ) -> bool:
         if not self._worker_lock.acquire(blocking=False):
-            return
+            return False
         if pending_action is not None:
             self._controls.mark_operation_pending(pending_action)
         self._update_menu()
@@ -792,9 +810,18 @@ class TrayRuntime:
             name="vrhotspot-tray-operation",
             daemon=True,
         ).start()
+        return True
 
     def refresh_async(self) -> None:
         self._run_worker(self._controls.refresh)
+
+    def refresh_after_auth_change(self) -> None:
+        """Guarantee one refresh after shared authentication state changes."""
+
+        if self._run_worker(self._controls.refresh):
+            self._auth_refresh_pending = False
+        else:
+            self._auth_refresh_pending = True
 
     def _open_authentication(self) -> None:
         if self._auth_window is not None:
@@ -903,7 +930,7 @@ class TrayRuntime:
             token = ""
         status.set_text(result.message)
         save_securely.set_active(result.securely_saved)
-        self.refresh_async()
+        self.refresh_after_auth_change()
 
     def _auth_test(self, entry, status) -> None:
         token = entry.get_text()
@@ -961,7 +988,11 @@ class TrayRuntime:
         entry.set_text("")
         result = self._authentication.clear()
         status.set_text(result.message)
-        self.refresh_async()
+        try:
+            self._on_auth_cleared()
+        except Exception:
+            pass
+        self.refresh_after_auth_change()
 
     def dispatch_action(self, action: str) -> None:
         state = self._controls.state

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -36,6 +36,7 @@ class TrayMenuItem:
     enabled: bool = True
     checked: bool | None = None
     separator: bool = False
+    children: tuple[TrayMenuItem, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -45,8 +46,18 @@ class TrayMenuModel:
     notifier_status: str
     tooltip: str
 
+    def all_items(self) -> tuple[TrayMenuItem, ...]:
+        def descendants(items: tuple[TrayMenuItem, ...]):
+            for item in items:
+                yield item
+                yield from descendants(item.children)
+
+        return tuple(descendants(self.items))
+
     def action_labels(self) -> tuple[str, ...]:
-        return tuple(item.label for item in self.items if not item.separator)
+        return tuple(
+            item.label for item in self.all_items() if not item.separator
+        )
 
 
 def build_tray_menu_model(
@@ -62,10 +73,71 @@ def build_tray_menu_model(
         and state.busy_action is None
         and state.status is not TrayStatus.TRANSITIONING
     )
+    hotspot_commands = TrayMenuItem(
+        21,
+        "",
+        "Hotspot Commands",
+        children=(
+            TrayMenuItem(
+                7,
+                "start",
+                "Start Hotspot",
+                enabled=ready and state.status is TrayStatus.STOPPED,
+            ),
+            TrayMenuItem(
+                8,
+                "stop",
+                "Stop Hotspot",
+                enabled=ready and state.status is TrayStatus.RUNNING,
+            ),
+            TrayMenuItem(
+                9,
+                "restart",
+                "Restart Service",
+                enabled=ready and state.status is TrayStatus.RUNNING,
+            ),
+            TrayMenuItem(10, "repair", "Repair Network", enabled=ready),
+        ),
+    )
+    network = TrayMenuItem(
+        22,
+        "",
+        "Network",
+        children=(
+            TrayMenuItem(
+                12,
+                "share_internet",
+                "Share Internet Connection",
+                enabled=ready and state.share_internet is not None,
+                checked=state.share_internet is True,
+            ),
+        ),
+    )
+    advanced = TrayMenuItem(
+        23,
+        "",
+        "Advanced",
+        children=(
+            TrayMenuItem(16, "authentication", "Authentication…"),
+            TrayMenuItem(18, "diagnostics", "Open Diagnostics"),
+            TrayMenuItem(
+                13,
+                "privacy",
+                "Privacy Mode",
+                checked=state.privacy_mode,
+            ),
+            TrayMenuItem(
+                14,
+                "hotspot_autostart",
+                "Start Hotspot Automatically",
+                enabled=ready and state.hotspot_autostart is not None,
+                checked=state.hotspot_autostart is True,
+            ),
+        ),
+    )
     items = (
         TrayMenuItem(1, "show", "Show VR Hotspot", not window_visible),
         TrayMenuItem(2, "hide", "Hide VR Hotspot", window_visible),
-        TrayMenuItem(3, "separator-1", "", separator=True),
         TrayMenuItem(
             4,
             "status",
@@ -78,52 +150,9 @@ def build_tray_menu_model(
             "Refresh Status",
             enabled=state.busy_action is None,
         ),
-        TrayMenuItem(6, "separator-2", "", separator=True),
-        TrayMenuItem(
-            7,
-            "start",
-            "Start Hotspot",
-            enabled=ready and state.status is TrayStatus.STOPPED,
-        ),
-        TrayMenuItem(
-            8,
-            "stop",
-            "Stop Hotspot",
-            enabled=ready and state.status is TrayStatus.RUNNING,
-        ),
-        TrayMenuItem(
-            9,
-            "restart",
-            "Restart Service",
-            enabled=ready and state.status is TrayStatus.RUNNING,
-        ),
-        TrayMenuItem(10, "repair", "Repair Network", enabled=ready),
-        TrayMenuItem(11, "separator-3", "", separator=True),
-        TrayMenuItem(
-            12,
-            "share_internet",
-            "Share Internet Connection",
-            enabled=ready and state.share_internet is not None,
-            checked=state.share_internet is True,
-        ),
-        TrayMenuItem(
-            13,
-            "privacy",
-            "Privacy Mode",
-            checked=state.privacy_mode,
-        ),
-        TrayMenuItem(
-            14,
-            "hotspot_autostart",
-            "Start Hotspot Automatically",
-            enabled=ready and state.hotspot_autostart is not None,
-            checked=state.hotspot_autostart is True,
-        ),
-        TrayMenuItem(15, "separator-4", "", separator=True),
-        TrayMenuItem(16, "authentication", "Authentication…"),
-        TrayMenuItem(17, "separator-5", "", separator=True),
-        TrayMenuItem(18, "diagnostics", "Open Diagnostics"),
-        TrayMenuItem(19, "separator-6", "", separator=True),
+        hotspot_commands,
+        network,
+        advanced,
         TrayMenuItem(20, "quit", "Quit VR Hotspot"),
     )
     return TrayMenuModel(
@@ -489,7 +518,11 @@ class StatusNotifierBackend:
 
     def _item_by_id(self, item_id: int) -> TrayMenuItem | None:
         return next(
-            (item for item in self._model.items if item.item_id == item_id),
+            (
+                item
+                for item in self._model.all_items()
+                if item.item_id == item_id
+            ),
             None,
         )
 
@@ -510,23 +543,81 @@ class StatusNotifierBackend:
             if item.checked is not None:
                 values["toggle-type"] = Variant("s", "checkmark")
                 values["toggle-state"] = Variant("i", 1 if item.checked else 0)
+            if item.children:
+                values["children-display"] = Variant("s", "submenu")
         if property_names:
             allowed = set(property_names)
             values = {key: value for key, value in values.items() if key in allowed}
         return values
 
-    def _layout(self):
+    def _layout_item(
+        self,
+        item: TrayMenuItem,
+        recursion_depth: int,
+        property_names: tuple[str, ...],
+    ):
         Variant = self._GLib.Variant
-        children = [
-            Variant(
-                "(ia{sv}av)",
-                (item.item_id, self._menu_properties(item), []),
+        children = []
+        if recursion_depth != 0:
+            child_depth = (
+                recursion_depth - 1
+                if recursion_depth > 0
+                else recursion_depth
             )
-            for item in self._model.items
-        ]
+            children = [
+                Variant(
+                    "(ia{sv}av)",
+                    self._layout_item(child, child_depth, property_names),
+                )
+                for child in item.children
+            ]
         return (
-            0,
-            {"children-display": Variant("s", "submenu")},
+            item.item_id,
+            self._menu_properties(item, property_names),
+            children,
+        )
+
+    def _layout(
+        self,
+        parent_id: int = 0,
+        recursion_depth: int = -1,
+        property_names: tuple[str, ...] = (),
+    ):
+        Variant = self._GLib.Variant
+        if parent_id == 0:
+            child_items = self._model.items
+            properties = {"children-display": Variant("s", "submenu")}
+            if property_names:
+                allowed = set(property_names)
+                properties = {
+                    key: value
+                    for key, value in properties.items()
+                    if key in allowed
+                }
+        else:
+            parent = self._item_by_id(parent_id)
+            if parent is None:
+                return (parent_id, {}, [])
+            child_items = parent.children
+            properties = self._menu_properties(parent, property_names)
+
+        children = []
+        if recursion_depth != 0:
+            child_depth = (
+                recursion_depth - 1
+                if recursion_depth > 0
+                else recursion_depth
+            )
+            children = [
+                Variant(
+                    "(ia{sv}av)",
+                    self._layout_item(item, child_depth, property_names),
+                )
+                for item in child_items
+            ]
+        return (
+            parent_id,
+            properties,
             children,
         )
 
@@ -551,6 +642,8 @@ class StatusNotifierBackend:
         if (
             item is None
             or item.separator
+            or item.children
+            or not item.action
             or not item.enabled
             or event_id not in {"clicked", "activated"}
         ):
@@ -574,8 +667,19 @@ class StatusNotifierBackend:
         Variant = self._GLib.Variant
         values = parameters.unpack()
         if method_name == "GetLayout":
+            parent_id, recursion_depth, property_names = values
             invocation.return_value(
-                Variant("(u(ia{sv}av))", (self._revision, self._layout()))
+                Variant(
+                    "(u(ia{sv}av))",
+                    (
+                        self._revision,
+                        self._layout(
+                            parent_id,
+                            recursion_depth,
+                            tuple(property_names),
+                        ),
+                    ),
+                )
             )
             return
         if method_name == "GetGroupProperties":

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -71,7 +71,7 @@ def build_tray_menu_model(
         state.daemon_available
         and state.authenticated
         and state.busy_action is None
-        and state.status is not TrayStatus.TRANSITIONING
+        and state.status in {TrayStatus.RUNNING, TrayStatus.STOPPED}
     )
     hotspot_commands = TrayMenuItem(
         21,
@@ -94,7 +94,7 @@ def build_tray_menu_model(
                 9,
                 "restart",
                 "Restart Service",
-                enabled=ready and state.status is TrayStatus.RUNNING,
+                enabled=ready,
             ),
             TrayMenuItem(10, "repair", "Repair Network", enabled=ready),
         ),
@@ -119,6 +119,12 @@ def build_tray_menu_model(
         "Advanced",
         children=(
             TrayMenuItem(16, "authentication", "Authentication…"),
+            TrayMenuItem(
+                5,
+                "refresh",
+                "Refresh Status",
+                enabled=state.busy_action is None,
+            ),
             TrayMenuItem(18, "diagnostics", "Open Diagnostics"),
             TrayMenuItem(
                 13,
@@ -136,19 +142,11 @@ def build_tray_menu_model(
         ),
     )
     items = (
-        TrayMenuItem(1, "show", "Show VR Hotspot", not window_visible),
-        TrayMenuItem(2, "hide", "Hide VR Hotspot", window_visible),
         TrayMenuItem(
             4,
             "status",
             f"Current status: {state.status_label}",
             enabled=False,
-        ),
-        TrayMenuItem(
-            5,
-            "refresh",
-            "Refresh Status",
-            enabled=state.busy_action is None,
         ),
         hotspot_commands,
         network,
@@ -408,6 +406,37 @@ class StatusNotifierBackend:
         self._connection = None
 
     def update(self, model: TrayMenuModel) -> None:
+        previous_items = {
+            item.item_id: item for item in self._model.all_items()
+        }
+        property_updates = []
+        removed_properties = []
+        for item in model.all_items():
+            previous = previous_items.get(item.item_id)
+            if previous is None:
+                continue
+            changed = {}
+            if item.label != previous.label:
+                changed["label"] = self._GLib.Variant("s", item.label)
+            if item.enabled != previous.enabled:
+                changed["enabled"] = self._GLib.Variant("b", item.enabled)
+            if item.checked != previous.checked:
+                if item.checked is None:
+                    removed_properties.append(
+                        (item.item_id, ["toggle-type", "toggle-state"])
+                    )
+                else:
+                    changed["toggle-type"] = self._GLib.Variant(
+                        "s",
+                        "checkmark",
+                    )
+                    changed["toggle-state"] = self._GLib.Variant(
+                        "i",
+                        1 if item.checked else 0,
+                    )
+            if changed:
+                property_updates.append((item.item_id, changed))
+
         icon_changed = model.icon_name != self._model.icon_name
         status_changed = model.notifier_status != self._model.notifier_status
         attention_changed = icon_changed or status_changed
@@ -425,6 +454,17 @@ class StatusNotifierBackend:
                 "LayoutUpdated",
                 self._GLib.Variant("(ui)", (self._revision, 0)),
             )
+            if property_updates or removed_properties:
+                connection.emit_signal(
+                    None,
+                    self.MENU_PATH,
+                    self.MENU_INTERFACE,
+                    "ItemsPropertiesUpdated",
+                    self._GLib.Variant(
+                        "(a(ia{sv})a(ias))",
+                        (property_updates, removed_properties),
+                    ),
+                )
             if icon_changed:
                 connection.emit_signal(
                     None,
@@ -786,13 +826,16 @@ class TrayRuntime:
         )
 
     def start(self) -> bool:
+        # Resolve an existing wallet/session token and daemon state before the
+        # StatusNotifierItem is registered so Plasma never caches the default
+        # menu and icon as the tray's initial authoritative state.
+        self._controls.refresh()
+        self._update_menu()
         active = self._backend.start()
         self._lifecycle.set_tray_active(active)
         if active:
             self._application.hold()
             self._GLib.timeout_add_seconds(5, self._periodic_refresh)
-        self._update_menu()
-        self.refresh_async()
         return active
 
     def _periodic_refresh(self) -> bool:
@@ -1100,11 +1143,7 @@ class TrayRuntime:
 
     def dispatch_action(self, action: str) -> None:
         state = self._controls.state
-        if action == "show":
-            self.show()
-        elif action == "hide":
-            self.hide()
-        elif action == "start":
+        if action == "start":
             self._run_worker(
                 lambda: self._controls.perform("start"),
                 pending_action="start",

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -299,6 +299,19 @@ class FakeWebKitSettings:
         raise AttributeError(name)
 
 
+class FakeWebKitUserContentManager:
+    def __init__(self):
+        self.signal_handlers = {}
+        self.registrations = []
+
+    def connect(self, signal, handler):
+        self.signal_handlers[signal] = handler
+
+    def register_script_message_handler_with_reply(self, name, world_name):
+        self.registrations.append((name, world_name))
+        return True
+
+
 class FakeWebKitWebView(FakeGtkWidget):
     created = []
     last_created = None
@@ -308,14 +321,27 @@ class FakeWebKitWebView(FakeGtkWidget):
         self.properties = properties
         self.loaded_uris = []
         self.zoom_levels = []
+        self.current_uri = ""
+        self.user_content_manager = FakeWebKitUserContentManager()
+        self.evaluated_scripts = []
         type(self).created.append(self)
         type(self).last_created = self
 
     def load_uri(self, uri):
         self.loaded_uris.append(uri)
+        self.current_uri = uri
 
     def set_zoom_level(self, zoom_level):
         self.zoom_levels.append(zoom_level)
+
+    def get_uri(self):
+        return self.current_uri
+
+    def get_user_content_manager(self):
+        return self.user_content_manager
+
+    def evaluate_javascript(self, *arguments):
+        self.evaluated_scripts.append(arguments)
 
 
 class FakeWebKit:
@@ -528,6 +554,234 @@ def test_locked_web_portal_view_is_ephemeral_zoomed_and_has_no_injection():
         assert forbidden not in source
 
 
+class FakeJavascriptValue:
+    def __init__(self, value):
+        self.value = value
+
+    @classmethod
+    def new_string(cls, _context, value):
+        return cls(value)
+
+    def get_context(self):
+        return object()
+
+    def is_string(self):
+        return isinstance(self.value, str)
+
+    def to_string(self):
+        return self.value
+
+
+class FakeScriptReply:
+    def __init__(self):
+        self.value = None
+
+    def return_value(self, value):
+        self.value = value.value
+
+
+class FakeBridgeAuthentication:
+    def __init__(self, *, token=None):
+        self.token = token
+        self.saved = []
+        self.clear_calls = 0
+
+    def token_for_operation(self):
+        return self.token
+
+    def save_or_replace(self, token, *, save_securely):
+        self.saved.append((bool(token), save_securely))
+        self.token = token
+        return type(
+            "Result",
+            (),
+            {
+                "code": "saved_securely",
+                "token_available": True,
+            },
+        )()
+
+    def clear(self):
+        self.token = None
+        self.clear_calls += 1
+
+
+def _bridge_message(message):
+    return FakeJavascriptValue(json.dumps(message)), FakeScriptReply()
+
+
+def test_web_portal_auth_success_updates_shared_state_and_refreshes_tray():
+    from flatpak_app import app
+
+    secret = "accepted-portal-value"
+    authentication = FakeBridgeAuthentication()
+    bridge = app.WebPortalAuthBridge(authentication)
+    refreshes = []
+    bridge.set_auth_changed_callback(lambda: refreshes.append("refresh"))
+    web_view = FakeWebKitWebView()
+    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/ui"
+    value, reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "auth_accepted",
+            "token": secret,
+        }
+    )
+
+    assert bridge.handle_message(web_view, value, reply) is True
+
+    assert authentication.saved == [(True, True)]
+    assert refreshes == ["refresh"]
+    assert reply.value == "accepted"
+    assert secret not in repr(bridge)
+    assert secret not in repr(authentication.saved)
+
+
+def test_wallet_token_reply_is_fixed_origin_only_and_never_enters_bridge_repr():
+    from flatpak_app import app
+
+    secret = "wallet-value-for-fixed-origin"
+    authentication = FakeBridgeAuthentication(token=secret)
+    bridge = app.WebPortalAuthBridge(authentication)
+    value, reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "token_request",
+        }
+    )
+    web_view = FakeWebKitWebView()
+    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/assets/ui.js"
+
+    assert bridge.handle_message(web_view, value, reply) is True
+    assert reply.value == secret
+    assert secret not in repr(bridge)
+
+    rejected_value, rejected_reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "token_request",
+        }
+    )
+    web_view.current_uri = "https://example.com/ui"
+    assert bridge.handle_message(
+        web_view,
+        rejected_value,
+        rejected_reply,
+    ) is False
+    assert rejected_reply.value == "rejected"
+
+    same_origin_value, same_origin_reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "token_request",
+        }
+    )
+    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/v1/status"
+    assert bridge.handle_message(
+        web_view,
+        same_origin_value,
+        same_origin_reply,
+    ) is False
+    assert same_origin_reply.value == "rejected"
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        None,
+        [],
+        {"version": True, "type": "token_request"},
+        {"version": 2, "type": "token_request"},
+        {"version": 1, "type": "unknown"},
+        {"version": 1, "type": "token_request", "extra": True},
+        {"version": 1, "type": "auth_accepted"},
+        {"version": 1, "type": "auth_accepted", "token": ""},
+    ),
+)
+def test_web_portal_auth_bridge_rejects_invalid_message_schema(message):
+    from flatpak_app import app
+
+    authentication = FakeBridgeAuthentication()
+    bridge = app.WebPortalAuthBridge(authentication)
+    web_view = FakeWebKitWebView()
+    web_view.current_uri = app.WEB_PORTAL_URL
+    value = FakeJavascriptValue(json.dumps(message))
+    reply = FakeScriptReply()
+
+    assert bridge.handle_message(web_view, value, reply) is False
+    assert reply.value == "rejected"
+    assert authentication.saved == []
+
+
+def test_web_portal_auth_bridge_bounds_message_bytes_before_parsing():
+    from flatpak_app import app
+
+    bridge = app.WebPortalAuthBridge(FakeBridgeAuthentication())
+    web_view = FakeWebKitWebView()
+    web_view.current_uri = app.WEB_PORTAL_URL
+    value = FakeJavascriptValue(
+        "x" * (app.MAX_WEB_PORTAL_AUTH_MESSAGE_BYTES + 1)
+    )
+    reply = FakeScriptReply()
+
+    assert bridge.handle_message(web_view, value, reply) is False
+    assert reply.value == "rejected"
+
+
+def test_web_portal_clear_syncs_shared_auth_and_refreshes_tray():
+    from flatpak_app import app
+
+    authentication = FakeBridgeAuthentication(token="present")
+    bridge = app.WebPortalAuthBridge(authentication)
+    refreshes = []
+    bridge.set_auth_changed_callback(lambda: refreshes.append("refresh"))
+    web_view = FakeWebKitWebView()
+    web_view.current_uri = app.WEB_PORTAL_URL
+    value, reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "auth_cleared",
+        }
+    )
+
+    assert bridge.handle_message(web_view, value, reply) is True
+    assert authentication.clear_calls == 1
+    assert authentication.token is None
+    assert refreshes == ["refresh"]
+    assert reply.value == "cleared"
+
+
+def test_web_portal_bridge_registration_and_host_clear_stay_fixed_origin():
+    from flatpak_app import app
+
+    bridge = app.WebPortalAuthBridge(FakeBridgeAuthentication())
+    web_view = app._build_locked_web_portal_view(
+        FakeWebKit,
+        auth_bridge=bridge,
+    )
+    manager = web_view.user_content_manager
+    signal = (
+        "script-message-with-reply-received::"
+        f"{app.WEB_PORTAL_AUTH_HANDLER}"
+    )
+
+    assert manager.registrations == [(app.WEB_PORTAL_AUTH_HANDLER, None)]
+    assert signal in manager.signal_handlers
+
+    web_view.current_uri = app.WEB_PORTAL_URL
+    bridge.clear_web_portal_session()
+    assert len(web_view.evaluated_scripts) == 1
+    script_call = web_view.evaluated_scripts[0]
+    assert script_call[0] == bridge._CLEAR_PORTAL_SCRIPT
+    assert script_call[3] == (
+        f"{app.WEB_PORTAL_ORIGIN}/companion-auth-bridge"
+    )
+
+    web_view.current_uri = "https://example.com/"
+    bridge.clear_web_portal_session()
+    assert len(web_view.evaluated_scripts) == 1
+
+
 @pytest.mark.parametrize(
     ("configured_zoom", "expected_zoom"),
     ((-100.0, 1.0), (100.0, 2.0)),
@@ -624,6 +878,12 @@ def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
 
         def start(self):
             return True
+
+        def refresh_async(self):
+            pass
+
+        def refresh_after_auth_change(self):
+            pass
 
         def close_request(self, *_args):
             return self.lifecycle.close_request(*_args)
@@ -956,7 +1216,7 @@ def test_live_smoke_rejects_getpass_echo_fallback(capsys):
     assert secret not in rendered
 
 
-def test_web_portal_shell_has_no_token_injection_or_persistence_path():
+def test_web_portal_shell_keeps_tokens_out_of_urls_and_webview_configuration():
     from flatpak_app import app
 
     source = "\n".join(

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -183,18 +183,22 @@ def test_tray_menu_contains_every_required_action():
     (
         (TrayStatus.RUNNING, "Running", "Active"),
         (TrayStatus.STOPPED, "Stopped", "Active"),
-        (TrayStatus.TRANSITIONING, "Transitioning", "Active"),
+        (
+            TrayStatus.TRANSITIONING,
+            "Transitioning",
+            "NeedsAttention",
+        ),
         (
             TrayStatus.NEEDS_AUTHENTICATION,
             "Needs Authentication",
-            "NeedsAttention",
+            "Active",
         ),
         (
             TrayStatus.DAEMON_UNAVAILABLE,
             "Daemon Unavailable",
-            "NeedsAttention",
+            "Active",
         ),
-        (TrayStatus.ERROR, "Error", "NeedsAttention"),
+        (TrayStatus.ERROR, "Error", "Active"),
     ),
 )
 def test_tray_status_labels_and_icon_variants_reflect_daemon_state(
@@ -210,6 +214,31 @@ def test_tray_status_labels_and_icon_variants_reflect_daemon_state(
     assert f"Current status: {label}" in model.action_labels()
     assert model.icon_name == ICON_NAMES[status]
     assert model.notifier_status == notifier_status
+
+
+def test_needs_authentication_is_static_and_only_transitioning_requests_attention():
+    needs_authentication = build_tray_menu_model(
+        TrayState(
+            status=TrayStatus.NEEDS_AUTHENTICATION,
+            status_label="Needs Authentication",
+        ),
+        window_visible=True,
+    )
+    transitioning = build_tray_menu_model(
+        TrayState(
+            status=TrayStatus.TRANSITIONING,
+            status_label="Transitioning",
+            busy_action="start",
+        ),
+        window_visible=True,
+    )
+
+    assert needs_authentication.icon_name == ICON_NAMES[
+        TrayStatus.NEEDS_AUTHENTICATION
+    ]
+    assert needs_authentication.notifier_status == "Active"
+    assert transitioning.icon_name == ICON_NAMES[TrayStatus.TRANSITIONING]
+    assert transitioning.notifier_status == "NeedsAttention"
 
 
 class FakeWindow:
@@ -404,6 +433,11 @@ def test_authenticated_running_refresh_maps_to_running():
     assert state.status_label == "Running"
     assert state.authenticated is True
     assert state.daemon_available is True
+    menu = build_tray_menu_model(state, window_visible=True)
+    assert _menu_enabled(menu, "start") is False
+    assert _menu_enabled(menu, "stop") is True
+    assert _menu_enabled(menu, "restart") is True
+    assert _menu_enabled(menu, "repair") is True
 
 
 def test_unexpected_client_construction_failure_maps_to_error():
@@ -520,8 +554,48 @@ class FakeBackend:
 class FakeControls:
     state = TrayState()
 
+    def refresh(self):
+        return self.state
+
     def perform(self, *_args, **_kwargs):
         raise AssertionError("Quit must not perform a hotspot action")
+
+
+def test_auth_change_refresh_is_deferred_until_active_worker_finishes():
+    application = FakeApplication()
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=WindowLifecycleController(
+            application=application,
+            window=FakeWindow(),
+        ),
+        controls=FakeControls(),
+        authentication=object(),
+        backend=FakeBackend(),
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=object(),
+        open_diagnostics=lambda: None,
+    )
+    attempts = []
+
+    def fake_run_worker(call, **_kwargs):
+        attempts.append(call)
+        return len(attempts) > 1
+
+    runtime._run_worker = fake_run_worker
+
+    runtime.refresh_after_auth_change()
+
+    assert runtime._auth_refresh_pending is True
+    assert len(attempts) == 1
+
+    runtime._worker_lock.acquire()
+    runtime._finish_worker()
+
+    assert runtime._auth_refresh_pending is False
+    assert len(attempts) == 2
 
 
 def _menu_enabled(model, action):
@@ -594,6 +668,7 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
         open_diagnostics=lambda: None,
     )
     refreshes = []
+    runtime.refresh_after_auth_change = lambda: refreshes.append("refresh")
     runtime.refresh_async = lambda: refreshes.append("refresh")
     entry = Entry()
     save_securely = SaveSecurely()
@@ -618,6 +693,7 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
 
 def test_clearing_authentication_refreshes_needs_authentication_menu():
     noncredential = "clear-refresh-test-placeholder"
+    portal_clears = []
 
     class Entry:
         def __init__(self):
@@ -686,13 +762,14 @@ def test_clearing_authentication_refreshes_needs_authentication_menu():
         Gio=object(),
         GLib=object(),
         open_diagnostics=lambda: None,
+        on_auth_cleared=lambda: portal_clears.append("clear"),
     )
 
     def refresh_now():
         controls.refresh()
         runtime._update_menu()
 
-    runtime.refresh_async = refresh_now
+    runtime.refresh_after_auth_change = refresh_now
     runtime._update_menu()
     assert _menu_enabled(backend.models[-1], "stop") is True
 
@@ -703,6 +780,7 @@ def test_clearing_authentication_refreshes_needs_authentication_menu():
     refreshed_menu = backend.models[-1]
     assert authentication.clear_calls == 1
     assert controls.refresh_calls == 1
+    assert portal_clears == ["clear"]
     assert entry.text == ""
     assert "Current status: Needs Authentication" in refreshed_menu.action_labels()
     assert _menu_enabled(refreshed_menu, "authentication") is True

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -126,7 +126,15 @@ def _controller(client, *, token="explicit-token"):
     )
 
 
-def test_tray_menu_contains_every_required_action():
+def _menu_item(model, action):
+    return next(item for item in model.all_items() if item.action == action)
+
+
+def _submenu(model, label):
+    return next(item for item in model.items if item.label == label)
+
+
+def test_tray_menu_contains_every_required_action_in_grouped_submenus():
     model = build_tray_menu_model(
         TrayState(
             status=TrayStatus.RUNNING,
@@ -141,41 +149,150 @@ def test_tray_menu_contains_every_required_action():
         window_visible=True,
     )
 
+    assert tuple(item.label for item in model.items) == (
+        "Show VR Hotspot",
+        "Hide VR Hotspot",
+        "Current status: Running",
+        "Refresh Status",
+        "Hotspot Commands",
+        "Network",
+        "Advanced",
+        "Quit VR Hotspot",
+    )
     assert model.action_labels() == (
         "Show VR Hotspot",
         "Hide VR Hotspot",
         "Current status: Running",
         "Refresh Status",
+        "Hotspot Commands",
         "Start Hotspot",
         "Stop Hotspot",
         "Restart Service",
         "Repair Network",
+        "Network",
         "Share Internet Connection",
-        "Privacy Mode",
-        "Start Hotspot Automatically",
+        "Advanced",
         "Authentication…",
         "Open Diagnostics",
+        "Privacy Mode",
+        "Start Hotspot Automatically",
         "Quit VR Hotspot",
     )
-    assert all(item.action != "web_portal" for item in model.items)
-    groups = []
-    current = []
-    for item in model.items:
-        if item.separator:
-            groups.append(tuple(current))
-            current = []
-        else:
-            current.append(item.action)
-    groups.append(tuple(current))
-    assert groups == [
-        ("show", "hide"),
-        ("status", "refresh"),
-        ("start", "stop", "restart", "repair"),
-        ("share_internet", "privacy", "hotspot_autostart"),
-        ("authentication",),
-        ("diagnostics",),
-        ("quit",),
-    ]
+    hotspot_commands = _submenu(model, "Hotspot Commands")
+    network = _submenu(model, "Network")
+    advanced = _submenu(model, "Advanced")
+    assert tuple(item.action for item in hotspot_commands.children) == (
+        "start",
+        "stop",
+        "restart",
+        "repair",
+    )
+    assert tuple(item.action for item in network.children) == (
+        "share_internet",
+    )
+    assert tuple(item.action for item in advanced.children) == (
+        "authentication",
+        "diagnostics",
+        "privacy",
+        "hotspot_autostart",
+    )
+    nested_actions = {
+        "start",
+        "stop",
+        "restart",
+        "repair",
+        "share_internet",
+        "authentication",
+        "diagnostics",
+        "privacy",
+        "hotspot_autostart",
+    }
+    assert not nested_actions.intersection(
+        item.action for item in model.items
+    )
+    assert all(not item.separator for item in model.all_items())
+    assert all(item.action != "web_portal" for item in model.all_items())
+    assert not any(
+        item.label.casefold().startswith("launch vr hotspot at log")
+        for item in model.all_items()
+    )
+
+
+def test_dbus_menu_layout_exports_nested_submenus_without_kde():
+    class Variant:
+        def __init__(self, signature, value):
+            self.signature = signature
+            self.value = value
+
+    backend = StatusNotifierBackend(
+        Gio=object(),
+        GLib=type("GLib", (), {"Variant": Variant}),
+        model=build_tray_menu_model(
+            TrayState(
+                status=TrayStatus.RUNNING,
+                status_label="Running",
+                daemon_available=True,
+                authenticated=True,
+                share_internet=True,
+                hotspot_autostart=False,
+            ),
+            window_visible=True,
+        ),
+        on_action=lambda _action: None,
+        on_activate=lambda: None,
+    )
+
+    root_id, root_properties, root_children = backend._layout()
+    exported = {
+        child.value[1]["label"].value: child.value
+        for child in root_children
+    }
+
+    assert root_id == 0
+    assert root_properties["children-display"].value == "submenu"
+    assert tuple(exported) == (
+        "Show VR Hotspot",
+        "Hide VR Hotspot",
+        "Current status: Running",
+        "Refresh Status",
+        "Hotspot Commands",
+        "Network",
+        "Advanced",
+        "Quit VR Hotspot",
+    )
+    assert tuple(
+        child.value[1]["label"].value
+        for child in exported["Hotspot Commands"][2]
+    ) == (
+        "Start Hotspot",
+        "Stop Hotspot",
+        "Restart Service",
+        "Repair Network",
+    )
+    assert tuple(
+        child.value[1]["label"].value
+        for child in exported["Network"][2]
+    ) == ("Share Internet Connection",)
+    assert tuple(
+        child.value[1]["label"].value
+        for child in exported["Advanced"][2]
+    ) == (
+        "Authentication…",
+        "Open Diagnostics",
+        "Privacy Mode",
+        "Start Hotspot Automatically",
+    )
+    for label in ("Hotspot Commands", "Network", "Advanced"):
+        assert exported[label][1]["children-display"].value == "submenu"
+
+    parent_id, _properties, children = backend._layout(23, 1, ("label",))
+    assert parent_id == 23
+    assert tuple(child.value[1]["label"].value for child in children) == (
+        "Authentication…",
+        "Open Diagnostics",
+        "Privacy Mode",
+        "Start Hotspot Automatically",
+    )
 
 
 @pytest.mark.parametrize(
@@ -214,6 +331,7 @@ def test_tray_status_labels_and_icon_variants_reflect_daemon_state(
     assert f"Current status: {label}" in model.action_labels()
     assert model.icon_name == ICON_NAMES[status]
     assert model.notifier_status == notifier_status
+    assert _menu_enabled(model, "authentication") is True
 
 
 def test_needs_authentication_is_static_and_only_transitioning_requests_attention():
@@ -420,6 +538,19 @@ def test_missing_token_disables_mutations_with_fixed_state():
         not _menu_enabled(menu, action)
         for action in ("start", "stop", "restart", "repair")
     )
+    assert _menu_enabled(menu, "share_internet") is False
+    assert _menu_enabled(menu, "hotspot_autostart") is False
+
+
+def test_explicit_token_never_appears_in_menu_labels():
+    secret = "menu-label-secret-must-not-escape"
+    controller = _controller(FakeControlClient(), token=secret)
+
+    state = controller.refresh()
+    menu = build_tray_menu_model(state, window_visible=True)
+
+    assert secret not in "\n".join(menu.action_labels())
+    assert secret not in repr(menu)
 
 
 def test_authenticated_running_refresh_maps_to_running():
@@ -437,6 +568,25 @@ def test_authenticated_running_refresh_maps_to_running():
     assert _menu_enabled(menu, "start") is False
     assert _menu_enabled(menu, "stop") is True
     assert _menu_enabled(menu, "restart") is True
+    assert _menu_enabled(menu, "repair") is True
+    assert _menu_enabled(menu, "share_internet") is True
+    assert _menu_item(menu, "share_internet").checked is True
+    assert _menu_enabled(menu, "hotspot_autostart") is True
+    assert _menu_item(menu, "hotspot_autostart").checked is False
+
+
+def test_authenticated_stopped_state_enables_only_valid_hotspot_commands():
+    controller = _controller(
+        FakeControlClient(phase="stopped", running=False)
+    )
+
+    state = controller.refresh()
+    menu = build_tray_menu_model(state, window_visible=True)
+
+    assert state.status is TrayStatus.STOPPED
+    assert _menu_enabled(menu, "start") is True
+    assert _menu_enabled(menu, "stop") is False
+    assert _menu_enabled(menu, "restart") is False
     assert _menu_enabled(menu, "repair") is True
 
 
@@ -518,7 +668,7 @@ def test_pending_operation_immediately_disables_mutations_in_menu_model():
     assert controller.state.busy_action == "start"
     assert all(
         not item.enabled
-        for item in model.items
+        for item in model.all_items()
         if item.action in {"start", "stop", "restart", "repair"}
     )
 
@@ -532,11 +682,31 @@ def test_hotspot_autostart_and_desktop_login_autostart_are_not_conflated():
     )
 
     assert "Start Hotspot Automatically" in model.action_labels()
-    assert "Launch VR Hotspot at login" not in model.action_labels()
+    assert not any(
+        label.casefold().startswith("launch vr hotspot at log")
+        for label in model.action_labels()
+    )
     assert not any(
         argument.startswith("--filesystem=")
         for argument in manifest["finish-args"]
     )
+
+
+def test_tray_sources_do_not_restore_retired_graphical_symbols():
+    names = (
+        "run_" + "gui",
+        "_populate_" + "native_" + "dashboard_window",
+        "Native" + "DashboardModel",
+        "Dashboard" + "SectionLabels",
+        "build_" + "dashboard_model",
+    )
+    source = "\n".join(
+        Path(path).read_text(encoding="utf-8")
+        for path in ("flatpak_app/app.py", "flatpak_app/tray.py")
+    )
+
+    for name in names:
+        assert name not in source
 
 
 class FakeBackend:
@@ -599,7 +769,7 @@ def test_auth_change_refresh_is_deferred_until_active_worker_finishes():
 
 
 def _menu_enabled(model, action):
-    return next(item.enabled for item in model.items if item.action == action)
+    return _menu_item(model, action).enabled
 
 
 def test_saving_and_testing_authentication_refreshes_status_without_leakage():

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -150,20 +150,14 @@ def test_tray_menu_contains_every_required_action_in_grouped_submenus():
     )
 
     assert tuple(item.label for item in model.items) == (
-        "Show VR Hotspot",
-        "Hide VR Hotspot",
         "Current status: Running",
-        "Refresh Status",
         "Hotspot Commands",
         "Network",
         "Advanced",
         "Quit VR Hotspot",
     )
     assert model.action_labels() == (
-        "Show VR Hotspot",
-        "Hide VR Hotspot",
         "Current status: Running",
-        "Refresh Status",
         "Hotspot Commands",
         "Start Hotspot",
         "Stop Hotspot",
@@ -173,6 +167,7 @@ def test_tray_menu_contains_every_required_action_in_grouped_submenus():
         "Share Internet Connection",
         "Advanced",
         "Authentication…",
+        "Refresh Status",
         "Open Diagnostics",
         "Privacy Mode",
         "Start Hotspot Automatically",
@@ -192,6 +187,7 @@ def test_tray_menu_contains_every_required_action_in_grouped_submenus():
     )
     assert tuple(item.action for item in advanced.children) == (
         "authentication",
+        "refresh",
         "diagnostics",
         "privacy",
         "hotspot_autostart",
@@ -202,6 +198,7 @@ def test_tray_menu_contains_every_required_action_in_grouped_submenus():
         "restart",
         "repair",
         "share_internet",
+        "refresh",
         "authentication",
         "diagnostics",
         "privacy",
@@ -210,6 +207,17 @@ def test_tray_menu_contains_every_required_action_in_grouped_submenus():
     assert not nested_actions.intersection(
         item.action for item in model.items
     )
+    assert all(
+        item.action not in {"show", "hide"}
+        for item in model.all_items()
+    )
+    assert all(
+        item.label not in {"Show VR Hotspot", "Hide VR Hotspot"}
+        for item in model.all_items()
+    )
+    assert _menu_item(model, "refresh") in advanced.children
+    assert all(item.action != "refresh" for item in model.items)
+    assert model.items[0].action == "status"
     assert all(not item.separator for item in model.all_items())
     assert all(item.action != "web_portal" for item in model.all_items())
     assert not any(
@@ -251,10 +259,7 @@ def test_dbus_menu_layout_exports_nested_submenus_without_kde():
     assert root_id == 0
     assert root_properties["children-display"].value == "submenu"
     assert tuple(exported) == (
-        "Show VR Hotspot",
-        "Hide VR Hotspot",
         "Current status: Running",
-        "Refresh Status",
         "Hotspot Commands",
         "Network",
         "Advanced",
@@ -278,6 +283,7 @@ def test_dbus_menu_layout_exports_nested_submenus_without_kde():
         for child in exported["Advanced"][2]
     ) == (
         "Authentication…",
+        "Refresh Status",
         "Open Diagnostics",
         "Privacy Mode",
         "Start Hotspot Automatically",
@@ -289,10 +295,70 @@ def test_dbus_menu_layout_exports_nested_submenus_without_kde():
     assert parent_id == 23
     assert tuple(child.value[1]["label"].value for child in children) == (
         "Authentication…",
+        "Refresh Status",
         "Open Diagnostics",
         "Privacy Mode",
         "Start Hotspot Automatically",
     )
+
+
+def test_dbus_update_exports_refreshed_command_sensitivity_to_kde():
+    class Variant:
+        def __init__(self, signature, value):
+            self.signature = signature
+            self.value = value
+
+    class Connection:
+        def __init__(self):
+            self.signals = []
+
+        def emit_signal(self, *_args):
+            self.signals.append(_args)
+
+    stopped = build_tray_menu_model(
+        TrayState(
+            status=TrayStatus.STOPPED,
+            status_label="Stopped",
+            daemon_available=True,
+            authenticated=True,
+        ),
+        window_visible=True,
+    )
+    running = build_tray_menu_model(
+        TrayState(
+            status=TrayStatus.RUNNING,
+            status_label="Running",
+            running=True,
+            daemon_available=True,
+            authenticated=True,
+        ),
+        window_visible=True,
+    )
+    backend = StatusNotifierBackend(
+        Gio=object(),
+        GLib=type("GLib", (), {"Variant": Variant}),
+        model=stopped,
+        on_action=lambda _action: None,
+        on_activate=lambda: None,
+    )
+    connection = Connection()
+    backend._connection = connection
+
+    backend.update(running)
+
+    update_signal = next(
+        signal
+        for signal in connection.signals
+        if signal[3] == "ItemsPropertiesUpdated"
+    )
+    changes, removed = update_signal[4].value
+    changes_by_id = {item_id: values for item_id, values in changes}
+    assert changes_by_id[7]["enabled"].value is False
+    assert changes_by_id[8]["enabled"].value is True
+    assert removed == []
+    assert _menu_enabled(backend._model, "start") is False
+    assert _menu_enabled(backend._model, "stop") is True
+    assert _menu_enabled(backend._model, "restart") is True
 
 
 @pytest.mark.parametrize(
@@ -586,8 +652,68 @@ def test_authenticated_stopped_state_enables_only_valid_hotspot_commands():
     assert state.status is TrayStatus.STOPPED
     assert _menu_enabled(menu, "start") is True
     assert _menu_enabled(menu, "stop") is False
-    assert _menu_enabled(menu, "restart") is False
+    assert _menu_enabled(menu, "restart") is True
     assert _menu_enabled(menu, "repair") is True
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    (
+        (
+            TrayState(),
+            (False, False, False, False, True),
+        ),
+        (
+            TrayState(
+                status=TrayStatus.DAEMON_UNAVAILABLE,
+                status_label="Daemon Unavailable",
+            ),
+            (False, False, False, False, True),
+        ),
+        (
+            TrayState(
+                status=TrayStatus.STOPPED,
+                status_label="Stopped",
+                daemon_available=True,
+                authenticated=True,
+            ),
+            (True, False, True, True, True),
+        ),
+        (
+            TrayState(
+                status=TrayStatus.RUNNING,
+                status_label="Running",
+                running=True,
+                daemon_available=True,
+                authenticated=True,
+            ),
+            (False, True, True, True, True),
+        ),
+        (
+            TrayState(
+                status=TrayStatus.TRANSITIONING,
+                status_label="Transitioning",
+                daemon_available=True,
+                authenticated=True,
+                busy_action="start",
+            ),
+            (False, False, False, False, True),
+        ),
+    ),
+)
+def test_tray_command_sensitivity_matrix_is_deterministic(state, expected):
+    model = build_tray_menu_model(state, window_visible=True)
+
+    assert tuple(
+        _menu_enabled(model, action)
+        for action in (
+            "start",
+            "stop",
+            "restart",
+            "repair",
+            "authentication",
+        )
+    ) == expected
 
 
 def test_unexpected_client_construction_failure_maps_to_error():
@@ -713,6 +839,13 @@ class FakeBackend:
     def __init__(self):
         self.stop_calls = 0
         self.models = []
+        self.start_calls = 0
+        self.model_at_start = None
+
+    def start(self):
+        self.start_calls += 1
+        self.model_at_start = self.models[-1]
+        return True
 
     def stop(self):
         self.stop_calls += 1
@@ -729,6 +862,86 @@ class FakeControls:
 
     def perform(self, *_args, **_kwargs):
         raise AssertionError("Quit must not perform a hotspot action")
+
+
+@pytest.mark.parametrize(
+    ("status", "label", "start_enabled", "stop_enabled"),
+    (
+        (TrayStatus.RUNNING, "Running", False, True),
+        (TrayStatus.STOPPED, "Stopped", True, False),
+    ),
+)
+def test_startup_refresh_registers_authenticated_daemon_state_as_initial_model(
+    status,
+    label,
+    start_enabled,
+    stop_enabled,
+):
+    class Application(FakeApplication):
+        def __init__(self):
+            super().__init__()
+            self.hold_calls = 0
+
+        def hold(self):
+            self.hold_calls += 1
+
+    class Controls:
+        def __init__(self):
+            self.refresh_calls = 0
+            self.state = TrayState()
+
+        def refresh(self):
+            self.refresh_calls += 1
+            self.state = TrayState(
+                status=status,
+                status_label=label,
+                phase=status.value,
+                running=status is TrayStatus.RUNNING,
+                daemon_available=True,
+                authenticated=True,
+            )
+            return self.state
+
+    class GLib:
+        timers = []
+
+        @classmethod
+        def timeout_add_seconds(cls, seconds, callback):
+            cls.timers.append((seconds, callback))
+            return 1
+
+    application = Application()
+    controls = Controls()
+    backend = FakeBackend()
+    runtime = TrayRuntime(
+        application=application,
+        lifecycle=WindowLifecycleController(
+            application=application,
+            window=FakeWindow(),
+        ),
+        controls=controls,
+        authentication=object(),
+        backend=backend,
+        Gtk=object(),
+        Gdk=object(),
+        Gio=object(),
+        GLib=GLib,
+        open_diagnostics=lambda: None,
+    )
+
+    assert runtime.start() is True
+
+    initial = backend.model_at_start
+    assert controls.refresh_calls == 1
+    assert backend.start_calls == 1
+    assert initial.icon_name == ICON_NAMES[status]
+    assert initial.tooltip == f"VR Hotspot — {label}"
+    assert _menu_enabled(initial, "start") is start_enabled
+    assert _menu_enabled(initial, "stop") is stop_enabled
+    assert _menu_enabled(initial, "restart") is True
+    assert application.hold_calls == 1
+    assert len(GLib.timers) == 1
+    assert GLib.timers[0][0] == 5
 
 
 def test_auth_change_refresh_is_deferred_until_active_worker_finishes():
@@ -962,7 +1175,7 @@ def test_clearing_authentication_refreshes_needs_authentication_menu():
     assert noncredential not in repr(refreshed_menu)
 
 
-def test_close_to_tray_immediately_refreshes_exported_show_hide_state():
+def test_close_to_tray_keeps_redundant_show_hide_commands_absent():
     application = FakeApplication()
     lifecycle = WindowLifecycleController(
         application=application,
@@ -984,21 +1197,18 @@ def test_close_to_tray_immediately_refreshes_exported_show_hide_state():
     )
 
     runtime.show()
-    assert _menu_enabled(backend.models[-1], "show") is False
-    assert _menu_enabled(backend.models[-1], "hide") is True
-
-    runtime.dispatch_action("hide")
-    assert _menu_enabled(backend.models[-1], "show") is True
-    assert _menu_enabled(backend.models[-1], "hide") is False
-
-    runtime.dispatch_action("show")
-    assert _menu_enabled(backend.models[-1], "show") is False
-    assert _menu_enabled(backend.models[-1], "hide") is True
+    assert lifecycle.visible is True
+    assert all(
+        item.action not in {"show", "hide"}
+        for item in backend.models[-1].all_items()
+    )
 
     assert runtime.close_request(lifecycle.window) is True
     assert lifecycle.visible is False
-    assert _menu_enabled(backend.models[-1], "show") is True
-    assert _menu_enabled(backend.models[-1], "hide") is False
+    assert all(
+        item.label not in {"Show VR Hotspot", "Hide VR Hotspot"}
+        for item in backend.models[-1].all_items()
+    )
 
 
 def test_tray_window_close_event_uses_runtime_state_refresh_path():
@@ -1168,7 +1378,7 @@ def test_dbus_menu_get_property_preserves_false_boolean_values():
     class Parameters:
         @staticmethod
         def unpack():
-            return 2, "enabled"
+            return 7, "enabled"
 
     class Invocation:
         returned = None

--- a/tests/test_flatpak_wallet.py
+++ b/tests/test_flatpak_wallet.py
@@ -1,9 +1,11 @@
 import inspect
+import json
 from pathlib import Path
 import sys
 
 
 from flatpak_app import build_smoke_payload, render_smoke_json
+from flatpak_app.app import WebPortalAuthBridge
 from flatpak_client import (
     ApiResponse,
     AuthenticationController,
@@ -73,6 +75,49 @@ def client_factory(*, token):
 
         raise LocalApiClientError("invalid token")
     return AuthClient(token)
+
+
+class FixedOriginView:
+    def get_uri(self):
+        return "http://127.0.0.1:8732/ui"
+
+
+class MessageValue:
+    def __init__(self, message):
+        self.value = json.dumps(message)
+
+    @classmethod
+    def new_string(cls, _context, value):
+        instance = cls.__new__(cls)
+        instance.value = value
+        return instance
+
+    def get_context(self):
+        return object()
+
+    def is_string(self):
+        return True
+
+    def to_string(self):
+        return self.value
+
+
+class MessageReply:
+    def __init__(self):
+        self.value = None
+
+    def return_value(self, value):
+        self.value = value.value
+
+
+def _accepted_portal_message(token):
+    return MessageValue(
+        {
+            "version": 1,
+            "type": "auth_accepted",
+            "token": token,
+        }
+    )
 
 
 def test_manual_token_is_retained_only_in_memory_when_not_saved():
@@ -148,6 +193,54 @@ def test_wallet_unavailable_falls_back_to_memory_only_with_fixed_message():
     assert "memory" in result.message.casefold()
     assert secret not in result.message
     assert controller.token_for_operation() == secret
+
+
+def test_accepted_portal_token_is_saved_to_available_app_wallet():
+    secret = "accepted-portal-wallet-value"
+    wallet = FakeWallet()
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+    bridge = WebPortalAuthBridge(controller)
+    reply = MessageReply()
+
+    assert bridge.handle_message(
+        FixedOriginView(),
+        _accepted_portal_message(secret),
+        reply,
+    ) is True
+
+    assert reply.value == "accepted"
+    assert wallet.stored == [secret]
+    assert controller.token_for_operation() == secret
+    assert controller.securely_saved is True
+    assert secret not in repr(bridge)
+    assert secret not in repr(controller)
+
+
+def test_accepted_portal_token_falls_back_to_current_process_memory():
+    secret = "accepted-portal-memory-value"
+    wallet = FakeWallet(available=False)
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+    bridge = WebPortalAuthBridge(controller)
+    reply = MessageReply()
+
+    assert bridge.handle_message(
+        FixedOriginView(),
+        _accepted_portal_message(secret),
+        reply,
+    ) is True
+
+    assert reply.value == "accepted"
+    assert wallet.stored == []
+    assert controller.token_for_operation() == secret
+    assert controller.securely_saved is False
+    assert secret not in repr(bridge)
+    assert secret not in repr(controller)
 
 
 def test_memory_only_replace_reports_when_old_wallet_entry_cannot_be_removed():

--- a/tests/test_ui_login_splash_contract.py
+++ b/tests/test_ui_login_splash_contract.py
@@ -10,8 +10,35 @@ class TestUiLoginSplashContract(unittest.TestCase):
         self.assertRegex(src, r"function\s+renderLoginSplash\s*\(")
 
         startup_guard = re.compile(
-            r"const\s+tok\s*=\s*migrateLegacyToken\(\)\s*\|\|\s*getStoredToken\(\)\s*;"
+            r"const\s+companionBridge\s*=\s*companionAuthBridgeAvailable\(\)\s*;"
+            r".*?if\s*\(\s*companionBridge\s*\).*?"
+            r"requestCompanionAuthToken\(\).*?"
+            r"else\s*\{\s*tok\s*=\s*migrateLegacyToken\(\)\s*\|\|\s*getStoredToken\(\)\s*;"
             r".*?if\s*\(\s*!tok\s*\)\s*\{\s*renderLoginSplash\(\)\s*;\s*return\s*;",
             re.S,
         )
         self.assertIsNotNone(startup_guard.search(src))
+
+    def test_companion_auth_bridge_uses_fixed_origin_memory_only_contract(self):
+        src = Path("assets/ui.js").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "const COMPANION_AUTH_ORIGIN = 'http://127.0.0.1:8732';",
+            src,
+        )
+        self.assertIn(
+            "const COMPANION_AUTH_HANDLER = 'vrHotspotCompanionAuth';",
+            src,
+        )
+        self.assertIn("path !== '/ui'", src)
+        self.assertIn("!path.startsWith('/assets/')", src)
+        self.assertIn("type: 'token_request'", src)
+        self.assertIn("type: 'auth_accepted'", src)
+        self.assertIn("type: 'auth_cleared'", src)
+        self.assertIn("companionSessionToken = token;", src)
+        self.assertIn(
+            "clearStoredTokenEverywhere({ notifyCompanion: false });",
+            src,
+        )
+        self.assertNotIn("COMPANION_AUTH_ORIGIN + '?'", src)
+        self.assertNotIn("COMPANION_AUTH_ORIGIN + '#'", src)

--- a/tests/test_ui_preflight_contract.py
+++ b/tests/test_ui_preflight_contract.py
@@ -778,8 +778,93 @@ async function scenarioExport() {
   assert.deepStrictEqual(environment.state.revokedUrls, ['blob:test-1']);
 }
 
+async function scenarioCompanionAuth() {
+  const secret = 'companion-auth-secret-value';
+  {
+    const environment = createEnvironment();
+    environment.context.__bridgeMessages = [];
+    environment.context.__bootstraps = 0;
+    environment.run(`
+      window.location.origin = 'http://127.0.0.1:8732';
+      window.location.pathname = '/ui';
+      window.webkit = {
+        messageHandlers: {
+          vrHotspotCompanionAuth: {
+            postMessage: async (raw) => {
+              const message = JSON.parse(raw);
+              __bridgeMessages.push(message);
+              return message.type === 'auth_accepted' ? 'accepted' : '';
+            },
+          },
+        },
+      };
+      bootstrapAuthenticatedUi = () => { __bootstraps += 1; };
+    `);
+    environment.document.getElementById('loginToken').value = secret;
+    environment.state.responses.push(responseBody({ result_code: 'ok', data: { phase: 'stopped' } }));
+
+    await environment.run('submitLoginSplashToken()');
+
+    assert.strictEqual(environment.run('isAuthenticated'), true);
+    assert.strictEqual(environment.run('getToken()'), secret);
+    assert.strictEqual(environment.localStorage.getItem('vr_hotspot_token'), null);
+    assert.strictEqual(environment.context.__bootstraps, 1);
+    assert.deepStrictEqual(
+      Array.from(environment.context.__bridgeMessages, (message) => message.type),
+      ['auth_accepted'],
+    );
+    assert.strictEqual(environment.context.__bridgeMessages[0].version, 1);
+
+    environment.run(`logoutToSplash('Invalid token');`);
+    await settle();
+    assert.strictEqual(environment.run('isAuthenticated'), false);
+    assert.strictEqual(environment.run('getToken()'), '');
+    assert.deepStrictEqual(
+      Array.from(environment.context.__bridgeMessages, (message) => message.type),
+      ['auth_accepted', 'auth_cleared'],
+    );
+  }
+
+  {
+    const environment = createEnvironment();
+    environment.context.__bridgeMessages = [];
+    environment.context.__bootstraps = 0;
+    environment.run(`
+      window.location.origin = 'http://127.0.0.1:8732';
+      window.location.pathname = '/ui';
+      window.webkit = {
+        messageHandlers: {
+          vrHotspotCompanionAuth: {
+            postMessage: async (raw) => {
+              const message = JSON.parse(raw);
+              __bridgeMessages.push(message);
+              return message.type === 'token_request'
+                ? ${JSON.stringify(secret)}
+                : 'rejected';
+            },
+          },
+        },
+      };
+      bootstrapAuthenticatedUi = () => { __bootstraps += 1; };
+    `);
+    environment.state.responses.push(responseBody({ result_code: 'ok', data: { phase: 'running' } }));
+
+    await environment.run('init()');
+
+    assert.strictEqual(environment.run('isAuthenticated'), true);
+    assert.strictEqual(environment.run('getToken()'), secret);
+    assert.strictEqual(environment.localStorage.getItem('vr_hotspot_token'), null);
+    assert.strictEqual(environment.context.__bootstraps, 1);
+    assert.deepStrictEqual(
+      Array.from(environment.context.__bridgeMessages, (message) => message.type),
+      ['token_request'],
+    );
+  }
+}
+
 const scenarios = {
   auth_errors: scenarioAuthErrors,
+  companion_auth: scenarioCompanionAuth,
   export: scenarioExport,
   hostile: scenarioHostileValues,
   on_demand: scenarioOnDemand,
@@ -863,6 +948,9 @@ class TestUiPreflightContract(unittest.TestCase):
 
     def test_unauthorized_responses_follow_logout_behavior(self):
         _run_node_scenario("auth_errors")
+
+    def test_companion_auth_success_wallet_startup_and_logout_sync(self):
+        _run_node_scenario("companion_auth")
 
     def test_network_http_and_malformed_response_errors_are_clear(self):
         _run_node_scenario("request_errors")


### PR DESCRIPTION
# Summary
- Sync Web Portal shell authentication with the Flatpak tray/wallet state.
- Add shared companion authentication state so Portal auth success refreshes tray status immediately or through a queued refresh.
- Sync Portal clear/logout back to tray state.
- Load valid app-specific wallet tokens on startup for tray and Portal companion state.
- Keep wallet-unavailable tokens limited to current-process memory.
- Stop treating missing/rejected auth as tray Error.
- Make Needs Authentication static; reserve pulsing/working state for active transitions.

# Product behavior
- Web Portal shell and tray now behave as one companion app instead of separate auth clients.
- Accepted Portal auth can update tray controls without sudo and without reading daemon secrets from root-owned files.
- Running authenticated daemon state maps to Running.
- Missing/rejected token maps to Needs Authentication.
- Daemon connection failure maps to Daemon Unavailable.
- Unexpected failures remain Error.

# Security boundaries
- No sudo, pkexec, or helper prompt added.
- No `/etc/vr-hotspot/env` reads added.
- No `/var/lib/vr-hotspot` token discovery added.
- No environment-token discovery added.
- No token CLI flags added.
- No token in URLs, argv, files, Web storage, logs, notifications, menus, smoke JSON, exceptions, or reprs.
- Flatpak manifest permissions unchanged.
- WebKit fixed origin, navigation lock, CSP, ephemeral session, and fixed 1.75x zoom preserved.
- Native GTK dashboard remains absent.

# WebKit bridge
- Adds a fixed-origin, bounded, schema-validated bridge between Web Portal shell and companion host.
- Bridge is restricted to `http://127.0.0.1:8732/ui` and same fixed-origin assets.
- Message size is bounded to 8192 bytes.
- Token length is bounded to 4096 characters.
- Malformed or non-fixed-origin bridge messages fail closed.

# Validation
- Focused suite: 206 passed.
- Exact full suite: 876 passed, 4 subtests passed, 6 teardown errors.
- Clean `origin/main` baseline independently reproduced the same six legacy iptables guard teardown errors.
- All 78 test files passed in isolated processes.
- Ruff passed.
- py_compile passed.
- shell syntax, installer matrix, vendor manifest/SBOM, manifest JSON, and git diff --check passed.
- Real Flatpak build/install and token-free smokes passed.
- Limited no-wallet KDE validation passed.
- Authenticated KDE validation remains manual because no token was supplied during review.

# Review
- Final review verdict: approve; no blockers.
- Final review file: `/tmp/vrhotspot-flatpak-tray-portal-auth-sync-final-review.md`
- Final review SHA-256: `c2cdaeabc8e138e234330a503de3ebdf777a7f645fd8f8d7d35ddfaf324d09a4`
