### PR TITLE
Fix Flatpak window app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,17 @@ never discovers one from `/etc/vr-hotspot/env`, `/var/lib/vr-hotspot`, daemon
 configuration, environment variables, or command arguments. Missing or
 rejected credentials are reported as **Needs Authentication**, separately from
 **Daemon Unavailable** and unexpected **Error** states. Needs Authentication is
-a static icon state; working/pulsing indication is reserved for active
-transitions. Every state uses the VR Hotspot icon family instead of a generic
-system Wi-Fi icon: Stopped has a red/off indicator, Running has a green/on
-indicator, Transitioning has an amber/working indicator, and authentication,
-daemon-unavailable, and error states retain the VR mark with a red error-style
-indicator. Start, Stop, Restart, and Repair remain disabled until the shared
-token authenticates successfully and then become available according to the
-real daemon state. The historical flag remains a compatibility alias for the
-same default graphical behavior:
+a static tray icon state; working/pulsing indication is reserved for active
+transitions. Every tray state uses the VR Hotspot icon family instead of a
+generic system Wi-Fi icon: Stopped has a red/off indicator, Running has a
+green/on indicator, Transitioning has an amber/working indicator, and
+authentication, daemon-unavailable, and error states retain the VR mark with a
+red error-style indicator. The WebKit host window and KDE task manager always
+use the stable base `io.github.josethevrtech.VRhotspot` application icon; that
+window/taskbar icon does not follow hotspot or tray state. Start, Stop, Restart,
+and Repair remain disabled until the shared token authenticates successfully
+and then become available according to the real daemon state. The historical
+flag remains a compatibility alias for the same default graphical behavior:
 
 ```bash
 flatpak run io.github.josethevrtech.VRhotspot --web-portal-shell

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -751,11 +751,16 @@ Flatpak never searches `/etc/vr-hotspot/env`, `/var/lib/vr-hotspot`, command
 arguments, URLs, query strings, or plaintext files for a token, and clearing
 removes only the matching VR Hotspot wallet item.
 
-The installed scalable application icon now uses a cyan VR mark on a near-black
-rounded tile. Stopped, running, working, and error variants retain the same VR
-base identity at panel sizes and represent state through a small red/off,
-green/on, amber/working, or red/error-style indicator. Packaging installs all
-variants through deterministic application-ID icon paths.
+The installed scalable base application icon uses a cyan VR mark on a
+near-black rounded tile. The desktop file, Flatpak app ID, GTK application ID,
+GTK default/window icon name, and hicolor base-icon path all use
+`io.github.josethevrtech.VRhotspot`, so Plasma can associate the Wayland window
+with its desktop entry. The WebKit host window and task manager always use that
+stable base icon and never follow hotspot state. Stopped, running, working, and
+error variants are tray-only; they retain the same VR base identity at panel
+sizes and represent state through a small red/off, green/on, amber/working, or
+red/error-style indicator. Packaging installs the base and tray variants
+through deterministic application-ID icon paths.
 
 The only new session-bus grants are:
 

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -27,6 +27,7 @@ from flatpak_client import (
 
 APP_ID = "io.github.josethevrtech.VRhotspot"
 APP_NAME = "VR Hotspot"
+WINDOW_ICON_NAME = APP_ID
 WEB_PORTAL_ORIGIN = "http://127.0.0.1:8732"
 WEB_PORTAL_URL = f"{WEB_PORTAL_ORIGIN}/ui"
 WEBKIT_GI_NAMESPACE = "WebKit"
@@ -819,6 +820,13 @@ def _populate_new_portal_window(Gtk, window, *, auth_bridge=None) -> bool:
     )
 
 
+def _set_window_icon(Gtk, window) -> None:
+    """Keep the window/taskbar identity on the stable base application icon."""
+
+    Gtk.Window.set_default_icon_name(WINDOW_ICON_NAME)
+    window.set_icon_name(WINDOW_ICON_NAME)
+
+
 def run_web_portal_shell() -> int:
     """Run the only Flatpak graphical UI inside a locked WebKit view."""
 
@@ -835,6 +843,7 @@ def run_web_portal_shell() -> int:
             return
 
         window = Gtk.ApplicationWindow(application=app)
+        _set_window_icon(Gtk, window)
         _populate_new_portal_window(
             Gtk,
             window,
@@ -875,6 +884,7 @@ def run_tray() -> int:
             return
 
         window = Gtk.ApplicationWindow(application=app)
+        _set_window_icon(Gtk, window)
         authentication = AuthenticationController()
         auth_bridge = WebPortalAuthBridge(authentication)
         _populate_new_portal_window(

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -211,9 +211,13 @@ class FakeGtkApplicationWindow(FakeGtkWidget):
 
     def __init__(self, **properties):
         super().__init__(**properties)
+        self.icon_names = []
         self.present_calls = 0
         self.hide_calls = 0
         type(self).created.append(self)
+
+    def set_icon_name(self, icon_name):
+        self.icon_names.append(icon_name)
 
     def set_title(self, _title):
         pass
@@ -229,6 +233,14 @@ class FakeGtkApplicationWindow(FakeGtkWidget):
     def hide(self):
         self.visible = False
         self.hide_calls += 1
+
+
+class FakeGtkWindow:
+    default_icon_names = []
+
+    @classmethod
+    def set_default_icon_name(cls, icon_name):
+        cls.default_icon_names.append(icon_name)
 
 
 class FakeGtkLabel(FakeGtkWidget):
@@ -250,6 +262,7 @@ class FakeGtk:
 
     Application = FakeGtkApplication
     ApplicationWindow = FakeGtkApplicationWindow
+    Window = FakeGtkWindow
     Box = FakeGtkWidget
     Label = FakeGtkLabel
     Button = FakeGtkButton
@@ -376,6 +389,7 @@ def _reset_gui_fakes():
     FakeGtkApplication.activations = 1
     FakeGtkApplicationWindow.created = []
     FakeGtkApplicationWindow.last_presented = None
+    FakeGtkWindow.default_icon_names = []
     FakeWebKitWebView.created = []
     FakeWebKitWebView.last_created = None
 
@@ -801,6 +815,7 @@ def test_web_portal_shell_zoom_is_bounded(
 
 def test_default_graphical_launch_uses_one_web_portal_window(monkeypatch):
     from flatpak_app import app
+    from flatpak_app.tray import ICON_NAMES
 
     _reset_gui_fakes()
     monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
@@ -810,6 +825,11 @@ def test_default_graphical_launch_uses_one_web_portal_window(monkeypatch):
     assert len(FakeGtkApplicationWindow.created) == 1
     assert len(FakeWebKitWebView.created) == 1
     assert FakeWebKitWebView.last_created.loaded_uris == [app.WEB_PORTAL_URL]
+    assert FakeGtkApplication.last_created.application_id == APP_ID
+    assert app.WINDOW_ICON_NAME == APP_ID
+    assert FakeGtkWindow.default_icon_names == [APP_ID]
+    assert FakeGtkApplicationWindow.created[0].icon_names == [APP_ID]
+    assert app.WINDOW_ICON_NAME not in ICON_NAMES.values()
 
 
 def test_compatibility_alias_uses_default_web_portal_behavior(monkeypatch):
@@ -901,6 +921,9 @@ def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
     assert len(FakeWebKitWebView.created) == 1
     assert FakeWebKitWebView.last_created.loaded_uris == [app.WEB_PORTAL_URL]
     assert FakeGtkApplicationWindow.created[0].present_calls == 3
+    assert FakeGtkApplication.last_created.application_id == APP_ID
+    assert FakeGtkWindow.default_icon_names == [APP_ID]
+    assert FakeGtkApplicationWindow.created[0].icon_names == [APP_ID]
 
 
 def test_webkit_unavailable_shows_bounded_error_without_alternate_ui(monkeypatch):
@@ -1344,8 +1367,10 @@ def test_manifest_has_only_minimal_display_and_loopback_client_permissions():
 
 
 def test_manifest_packages_only_shell_client_and_static_desktop_assets():
+    manifest = _manifest()
     manifest_text = MANIFEST_PATH.read_text(encoding="utf-8")
-    sources = _manifest()["modules"][0]["sources"]
+    module = manifest["modules"][0]
+    sources = module["sources"]
     paths = {source["path"] for source in sources}
 
     assert all(source["type"] == "file" for source in sources)
@@ -1365,6 +1390,12 @@ def test_manifest_packages_only_shell_client_and_static_desktop_assets():
         "systemd",
     ):
         assert forbidden not in manifest_text
+    base_icon_install = (
+        f"install -Dm644 {APP_ID}.svg "
+        f"/app/share/icons/hicolor/scalable/apps/{APP_ID}.svg"
+    )
+    assert base_icon_install in module["build-commands"]
+    assert f"{APP_ID}.svg" in paths
 
 
 def test_desktop_file_matches_app_id_name_and_launcher():


### PR DESCRIPTION
# Summary
- Fix the Flatpak KDE/Wayland window and taskbar icon.
- Explicitly set the stable base app icon for GTK/WebKit windows.
- Keep tray icons stateful and unchanged.

# Behavior
- Window/taskbar icon uses io.github.josethevrtech.VRhotspot.
- Tray icons continue using stopped/running/working/error state icons.
- App ID, window icon name, desktop identity, and Flatpak identity remain canonical.

# Boundaries
- Flatpak manifest unchanged.
- No permissions added.
- No token/security changes.
- No WebKit security changes.
- Native dashboard remains absent.
- Backend/vendor/installer untouched.

# Validation
- Review approved with no blockers.
- Targeted tests: 131 passed.
- Focused tests: 221 passed.
- Full suite: 891 passed, 4 subtests passed.
- Ruff and git diff --check passed.
- Real Flatpak build/install and smoke passed.
- Manual KDE validation in the handoff passed for Wayland association, base taskbar/titlebar icon, stateful tray icon, close-to-tray, and restoration.
