### PR TITLE
Unify Flatpak window and tray authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,29 @@ autostart. Launching VR Hotspot at desktop login remains deferred and is not
 shown as a tray item. Explicit Quit exits only the desktop companion and does
 not stop an already-running hotspot.
 
-The Web Portal shell and tray are one companion and share authentication state.
-An API token accepted after explicit entry in the Portal is adopted immediately
-by the tray. When Secret Service is available, the accepted token is saved in
-the app-specific wallet; otherwise it remains in memory for the current
-companion process only. A valid saved wallet token authenticates the tray at
-launch and is supplied to the Portal only through a bounded, fixed-origin,
-in-memory WebKit bridge—not through a URL, file, or command argument.
+The Flatpak Web Portal window and tray share saved local authentication through
+one native authentication controller and the app-specific Secret Service wallet.
+Both modes load and validate that wallet entry against the bounded loopback API
+at startup. Saving or replacing authentication in either mode is therefore
+detected by the other; clearing it returns both to needs-authentication state on
+their next prompt refresh. A rejected stale wallet entry is forgotten safely
+instead of being retried indefinitely.
 
-**Authentication…** remains available for explicit token entry, replacement,
+The locked page receives only token-free authentication readiness and
+allowlisted daemon responses through the fixed-origin native broker. The wallet
+token is never returned to JavaScript or placed in page HTML, browser storage,
+URLs, labels, tooltips, notifications, logs, exception representations, or
+smoke JSON. Selecting **Authenticate this device** in the Flatpak page opens the
+native dialog; **Save for this desktop** controls Secret Service persistence.
+If saving is not selected or the wallet is unavailable, the accepted token
+remains local to that Flatpak process and is not shared through new IPC.
+
+A normal local or remote browser is not connected to the Flatpak wallet or
+native broker. Each browser page load requires explicit login, and the
+browser-entered token is kept only in that page's memory—not Local Storage,
+Session Storage, or IndexedDB.
+
+**Authentication…** remains available for native token entry, replacement,
 testing, and clearing. The companion never uses sudo to obtain a token and
 never discovers one from `/etc/vr-hotspot/env`, `/var/lib/vr-hotspot`, daemon
 configuration, environment variables, or command arguments. Missing or

--- a/assets/index.html
+++ b/assets/index.html
@@ -25,6 +25,7 @@
         <input id="loginToken" type="password" maxlength="4096" placeholder="API Token" />
         <button class="btn primary" id="btnLoginSubmit" type="submit">Continue</button>
       </form>
+      <div id="loginHelp" class="small mt-10">Authenticate this browser session with the daemon API token.</div>
       <div id="loginError" class="small mt-10 error-text" role="alert"></div>
     </div>
   </div>

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -3,16 +3,12 @@ const PREFLIGHT_REPORT_PATH = '/v1/diagnostics/preflight';
 const STORE = (function () {
   try { localStorage.setItem('__t', '1'); localStorage.removeItem('__t'); return localStorage; } catch { return sessionStorage; }
 })();
-const TOKEN_KEY = 'vr_hotspot_token';
-const LEGACY_TOKEN_KEY = 'vr_hotspot_api_token';
 const COMPANION_AUTH_ORIGIN = 'http://127.0.0.1:8732';
 const COMPANION_AUTH_HANDLER = 'vrHotspotCompanionAuth';
 const COMPANION_AUTH_PROTOCOL_VERSION = 1;
-const MAX_COMPANION_AUTH_MESSAGE_CHARS = 8192;
-const MAX_COMPANION_AUTH_TOKEN_CHARS = 4096;
-const DEBUG_TOKEN = false;
+const MAX_COMPANION_AUTH_MESSAGE_CHARS = 262144;
+const COMPANION_AUTH_REFRESH_INTERVAL_MS = 2000;
 const LS = {
-  token: TOKEN_KEY,
   privacy: 'vr_hotspot_privacy',
   showTelemetry: 'vr_hotspot_show_telemetry',
   auto: 'vr_hotspot_auto',
@@ -80,7 +76,8 @@ let activeTipTarget = null;
 let floatingTipWired = false;
 let isAuthenticated = false;
 let authFlowLocked = false;
-let companionSessionToken = '';
+let browserSessionToken = '';
+let companionAuthPollTimer = null;
 let uiBootstrapped = false;
 let refreshTimer = null;
 const BASIC_REFRESH_INTERVAL_MS = 2000;
@@ -875,15 +872,11 @@ function wireDirtyTracking() {
 
 function cid() { return 'ui-' + Date.now() + '-' + Math.random().toString(16).slice(2); }
 
-function getLocalStorageSafe() {
-  try { return localStorage; } catch { return null; }
-}
-
 function getCompanionAuthHandler() {
   try {
     if (!window.location || window.location.origin !== COMPANION_AUTH_ORIGIN) return null;
     const path = window.location.pathname || '';
-    if (path !== '/ui' && path !== '/ui/' && !path.startsWith('/assets/')) return null;
+    if (path !== '/ui' && path !== '/ui/') return null;
     const handlers = window.webkit && window.webkit.messageHandlers;
     const handler = handlers && handlers[COMPANION_AUTH_HANDLER];
     return (handler && typeof handler.postMessage === 'function') ? handler : null;
@@ -921,25 +914,31 @@ async function postCompanionAuthMessage(message) {
   }
 }
 
-async function requestCompanionAuthToken() {
+async function requestCompanionAuthStatus() {
   const result = await postCompanionAuthMessage({
     version: COMPANION_AUTH_PROTOCOL_VERSION,
-    type: 'token_request',
+    type: 'auth_status',
   });
-  if (!result.available) return null;
-  const token = result.reply.trim();
-  if (!token || token.length > MAX_COMPANION_AUTH_TOKEN_CHARS) return '';
-  return token;
+  if (!result.available) return { available: false, authenticated: false, code: 'unavailable' };
+  try {
+    const status = JSON.parse(result.reply);
+    return {
+      available: true,
+      authenticated: status && status.authenticated === true,
+      code: (status && typeof status.code === 'string') ? status.code : 'invalid_response',
+    };
+  } catch {
+    return { available: true, authenticated: false, code: 'invalid_response' };
+  }
 }
 
-async function notifyCompanionAuthAccepted(token) {
+async function requestCompanionAuthPrompt() {
   const result = await postCompanionAuthMessage({
     version: COMPANION_AUTH_PROTOCOL_VERSION,
-    type: 'auth_accepted',
-    token,
+    type: 'auth_prompt',
   });
   if (!result.available) return null;
-  return result.reply === 'accepted';
+  return result.reply === 'opened';
 }
 
 function notifyCompanionAuthCleared() {
@@ -949,62 +948,22 @@ function notifyCompanionAuthCleared() {
   });
 }
 
-function getStoredToken() {
-  const ls = getLocalStorageSafe();
-  if (ls) return (ls.getItem(TOKEN_KEY) || '').trim();
-  try { return (STORE.getItem(TOKEN_KEY) || '').trim(); } catch { return ''; }
-}
-
-function setStoredToken(token) {
-  const val = (token || '').trim();
-  const ls = getLocalStorageSafe();
-  try {
-    if (ls) {
-      if (val) ls.setItem(TOKEN_KEY, val);
-      else ls.removeItem(TOKEN_KEY);
-    }
-  } catch { /* ignore */ }
-  if (!ls) {
-    try {
-      if (val) STORE.setItem(TOKEN_KEY, val);
-      else STORE.removeItem(TOKEN_KEY);
-    } catch { /* ignore */ }
+function clearLegacyBrowserTokenStorage() {
+  const storages = [];
+  try { storages.push(globalThis.localStorage); } catch { /* ignore */ }
+  try { storages.push(globalThis.sessionStorage); } catch { /* ignore */ }
+  for (const storage of storages) {
+    try { storage.removeItem('vr_hotspot_token'); } catch { /* ignore */ }
+    try { storage.removeItem('vr_hotspot_api_token'); } catch { /* ignore */ }
   }
-}
-
-function migrateLegacyToken() {
-  const current = getStoredToken();
-  if (current) return current;
-  const ls = getLocalStorageSafe();
-  let legacy = '';
-  if (ls) legacy = (ls.getItem(LEGACY_TOKEN_KEY) || '').trim();
-  if (!legacy) {
-    try { legacy = (STORE.getItem(LEGACY_TOKEN_KEY) || '').trim(); } catch { legacy = ''; }
-  }
-  if (legacy) {
-    setStoredToken(legacy);
-    try { if (ls) ls.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
-    try { STORE.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
-    return legacy;
-  }
-  return '';
-}
-
-function debugTokenLog(injected) {
-  if (!DEBUG_TOKEN) return;
-  const len = getStoredToken().length;
-  try {
-    console.log('[token]', { TOKEN_KEY, tokenLength: len, injected });
-  } catch { /* ignore */ }
 }
 
 function getToken() {
-  return companionSessionToken || getStoredToken();
+  return browserSessionToken;
 }
 
 function setToken(v) {
-  const val = (v || '').trim();
-  setStoredToken(val);
+  browserSessionToken = (v || '').trim();
 }
 
 function setAuthState(state) {
@@ -1017,20 +976,10 @@ function isUnauthorizedStatus(status) {
 }
 
 function clearStoredTokenEverywhere(opts = {}) {
-  companionSessionToken = '';
-  setStoredToken('');
-  const ls = getLocalStorageSafe();
-  try { if (ls) ls.removeItem(TOKEN_KEY); } catch { /* ignore */ }
-  try { if (ls) ls.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
-  try { STORE.removeItem(TOKEN_KEY); } catch { /* ignore */ }
-  try { STORE.removeItem(LEGACY_TOKEN_KEY); } catch { /* ignore */ }
+  browserSessionToken = '';
+  clearLegacyBrowserTokenStorage();
   if (opts.notifyCompanion !== false) notifyCompanionAuthCleared();
 }
-
-window.vrHotspotCompanionAuthCleared = function () {
-  clearStoredTokenEverywhere({ notifyCompanion: false });
-  renderLoginSplash();
-};
 
 function clearLoggedOutRouteState() {
   if (!window.location.hash) return;
@@ -1049,8 +998,10 @@ function setLoginError(text = '') {
 
 function renderLoginSplash(errorText = '', opts = {}) {
   const keepInput = !!opts.keepInput;
+  const companion = companionAuthBridgeAvailable();
   const input = document.getElementById('loginToken');
   const submit = document.getElementById('btnLoginSubmit');
+  const help = document.getElementById('loginHelp');
   const splash = document.getElementById('login-splash');
   if (splash) splash.setAttribute('aria-hidden', 'false');
   setAuthState('unauthenticated');
@@ -1059,11 +1010,20 @@ function renderLoginSplash(errorText = '', opts = {}) {
   stopActivePolling();
   setMsg('');
   setLoginError(errorText);
-  if (submit) submit.disabled = false;
+  if (help) {
+    help.textContent = companion
+      ? 'Use native authentication for this Flatpak desktop app. Saved local authentication is shared with the tray; remote browsers sign in separately.'
+      : 'Authenticate this browser session with the daemon API token.';
+  }
+  if (submit) {
+    submit.disabled = false;
+    submit.textContent = companion ? 'Authenticate this device' : 'Continue';
+  }
   if (input) {
-    input.disabled = false;
+    input.hidden = companion;
+    input.disabled = companion;
     if (!keepInput) input.value = '';
-    input.focus();
+    if (!companion) input.focus();
   }
 }
 
@@ -1082,6 +1042,45 @@ function logoutToSplash(errorText = 'Invalid token') {
   clearStoredTokenEverywhere();
   renderLoginSplash(errorText);
 }
+
+function enterAuthenticatedApp() {
+  showAuthenticatedApp();
+  if (!uiBootstrapped) {
+    bootstrapAuthenticatedUi();
+    return;
+  }
+  try {
+    refresh();
+    applyAutoRefresh();
+  } catch { /* ignore */ }
+}
+
+async function syncCompanionAuthState() {
+  if (!companionAuthBridgeAvailable()) return false;
+  const status = await requestCompanionAuthStatus();
+  if (status.authenticated) {
+    if (!isAuthenticated) enterAuthenticatedApp();
+    return true;
+  }
+  if (isAuthenticated || document.body.getAttribute('data-auth-state') === 'pending') {
+    renderLoginSplash(
+      status.code === 'token_rejected' ? 'Saved authentication was rejected.' : '',
+    );
+  }
+  return false;
+}
+
+function startCompanionAuthRefresh() {
+  if (companionAuthPollTimer !== null) return;
+  companionAuthPollTimer = setInterval(
+    () => { void syncCompanionAuthState(); },
+    COMPANION_AUTH_REFRESH_INTERVAL_MS,
+  );
+}
+
+window.vrHotspotCompanionAuthChanged = function () {
+  void syncCompanionAuthState();
+};
 
 async function validateTokenCandidate(token) {
   const val = (token || '').trim();
@@ -1104,6 +1103,17 @@ async function submitLoginSplashToken() {
   const input = document.getElementById('loginToken');
   const submit = document.getElementById('btnLoginSubmit');
   if (!input || !submit) return;
+  if (companionAuthBridgeAvailable()) {
+    submit.disabled = true;
+    const opened = await requestCompanionAuthPrompt();
+    setLoginError(
+      opened === true
+        ? 'Complete authentication in the native VR Hotspot dialog.'
+        : 'Native authentication is unavailable.',
+    );
+    submit.disabled = false;
+    return;
+  }
   const token = (input.value || '').trim();
   if (!token) {
     setLoginError('Token required');
@@ -1116,25 +1126,9 @@ async function submitLoginSplashToken() {
 
   const result = await validateTokenCandidate(token);
   if (result.ok) {
-    const companionAccepted = await notifyCompanionAuthAccepted(token);
-    if (companionAccepted === true) {
-      companionSessionToken = token;
-      input.value = '';
-      showAuthenticatedApp();
-      bootstrapAuthenticatedUi();
-      return;
-    }
-    if (companionAccepted === false) {
-      clearStoredTokenEverywhere({ notifyCompanion: false });
-      input.value = '';
-      setLoginError('Invalid token');
-      input.disabled = false;
-      submit.disabled = false;
-      input.focus();
-      return;
-    }
     setToken(token);
-    window.location.reload();
+    input.value = '';
+    enterAuthenticatedApp();
     return;
   }
 
@@ -1942,11 +1936,62 @@ function updateCharts(t) {
   rateChartRef.update('none');
 }
 
+async function companionApiRequest(path, opts = {}, responseKind = 'text') {
+  const method = String(opts.method || 'GET').toUpperCase();
+  let body = null;
+  if (opts.body !== undefined && opts.body !== null && opts.body !== '') {
+    try {
+      body = (typeof opts.body === 'string') ? JSON.parse(opts.body) : opts.body;
+    } catch {
+      return { ok: false, status: 400, body: '', headers: {}, body_encoding: 'text' };
+    }
+  }
+  const result = await postCompanionAuthMessage({
+    version: COMPANION_AUTH_PROTOCOL_VERSION,
+    type: 'api_request',
+    path,
+    method,
+    body,
+    response: responseKind,
+  });
+  if (!result.available) {
+    return { ok: false, status: 503, body: '', headers: {}, body_encoding: 'text' };
+  }
+  try {
+    const response = JSON.parse(result.reply);
+    return {
+      ok: response && response.ok === true,
+      status: Number.isInteger(response && response.status) ? response.status : 502,
+      body: (response && typeof response.body === 'string') ? response.body : '',
+      body_encoding: (response && response.body_encoding === 'base64') ? 'base64' : 'text',
+      headers: (response && response.headers && typeof response.headers === 'object')
+        ? response.headers
+        : {},
+    };
+  } catch {
+    return { ok: false, status: 502, body: '', headers: {}, body_encoding: 'text' };
+  }
+}
+
 async function api(path, opts = {}) {
   const tokenOverride = (typeof opts.tokenOverride === 'string') ? opts.tokenOverride.trim() : '';
   const skipAuthHandling = !!opts.skipAuthHandling;
   if (!tokenOverride && !skipAuthHandling && !isAuthenticated) {
     return { ok: false, status: 401, json: null, raw: '' };
+  }
+  if (companionAuthBridgeAvailable()) {
+    const response = await companionApiRequest(path, opts, 'text');
+    let json = null;
+    try { json = JSON.parse(response.body); } catch { /* keep null */ }
+    if (!skipAuthHandling && isUnauthorizedStatus(response.status)) {
+      logoutToSplash('Invalid saved local authentication');
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      json,
+      raw: response.body,
+    };
   }
   const fetchOpts = Object.assign({}, opts);
   delete fetchOpts.tokenOverride;
@@ -1966,10 +2011,8 @@ async function api(path, opts = {}) {
   }, {});
   if (!headerKeys['x-correlation-id']) baseHeaders['X-Correlation-Id'] = cid();
   const tok = tokenOverride || getToken();
-  const injected = !!(tok && !headerKeys['x-api-token']);
-  if (injected) baseHeaders['X-Api-Token'] = tok;
+  if (tok && !headerKeys['x-api-token']) baseHeaders['X-Api-Token'] = tok;
   if (fetchOpts.body && !headerKeys['content-type']) baseHeaders['Content-Type'] = 'application/json';
-  debugTokenLog(injected);
 
   const res = await fetch(BASE + path, Object.assign({}, fetchOpts, { headers: baseHeaders }));
   const text = await res.text();
@@ -1997,9 +2040,7 @@ function getAuthenticatedHeaders(opts = {}) {
   if (!headerKeys['x-correlation-id']) baseHeaders['X-Correlation-Id'] = cid();
   const tokenOverride = (typeof opts.tokenOverride === 'string') ? opts.tokenOverride.trim() : '';
   const tok = tokenOverride || getToken();
-  const injected = !!(tok && !headerKeys['x-api-token']);
-  if (injected) baseHeaders['X-Api-Token'] = tok;
-  debugTokenLog(injected);
+  if (tok && !headerKeys['x-api-token']) baseHeaders['X-Api-Token'] = tok;
   return baseHeaders;
 }
 
@@ -2008,6 +2049,34 @@ async function apiBlob(path, opts = {}) {
   const skipAuthHandling = !!opts.skipAuthHandling;
   if (!tokenOverride && !skipAuthHandling && !isAuthenticated) {
     return { ok: false, status: 401, blob: null, headers: new Headers() };
+  }
+  if (companionAuthBridgeAvailable()) {
+    const response = await companionApiRequest(path, opts, 'blob');
+    if (!skipAuthHandling && isUnauthorizedStatus(response.status)) {
+      logoutToSplash('Your local authentication expired. Sign in again.');
+    }
+    let blob = null;
+    if (response.ok && response.body_encoding === 'base64') {
+      try {
+        const binary = atob(response.body);
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index += 1) {
+          bytes[index] = binary.charCodeAt(index);
+        }
+        blob = new Blob(
+          [bytes],
+          { type: response.headers['content-type'] || 'application/octet-stream' },
+        );
+      } catch {
+        blob = null;
+      }
+    }
+    return {
+      ok: response.ok && blob !== null,
+      status: response.status,
+      blob,
+      headers: new Headers(response.headers),
+    };
   }
   const fetchOpts = Object.assign({}, opts);
   delete fetchOpts.tokenOverride;
@@ -3856,19 +3925,20 @@ function bootstrapAuthenticatedUi() {
 async function init() {
   wireFloatingTips();
   wireLoginSplash();
+  clearLegacyBrowserTokenStorage();
   window.addEventListener('hashchange', () => {
     if (!isAuthenticated) clearLoggedOutRouteState();
   });
 
-  const companionBridge = companionAuthBridgeAvailable();
-  let tok = '';
-  if (companionBridge) {
-    clearStoredTokenEverywhere({ notifyCompanion: false });
-    tok = (await requestCompanionAuthToken()) || '';
-    companionSessionToken = tok;
-  } else {
-    tok = migrateLegacyToken() || getStoredToken();
+  if (companionAuthBridgeAvailable()) {
+    setAuthState('pending');
+    startCompanionAuthRefresh();
+    const authenticated = await syncCompanionAuthState();
+    if (!authenticated) renderLoginSplash();
+    return;
   }
+
+  const tok = getToken();
   if (!tok) {
     renderLoginSplash();
     return;
@@ -3888,10 +3958,8 @@ async function init() {
     return;
   }
 
-  if (companionBridge) companionSessionToken = tok;
-  else setToken(tok);
-  showAuthenticatedApp();
-  bootstrapAuthenticatedUi();
+  setToken(tok);
+  enterAuthenticatedApp();
 }
 
 function wireQr() {

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -1,6 +1,6 @@
 # Flatpak control app architecture plan
 
-Status: PR #93 shared Web Portal/tray companion authentication; PRs #77-#92 retained
+Status: unified native Flatpak authentication broker; PRs #77-#93 retained
 
 Date: 2026-07-24
 
@@ -21,11 +21,12 @@ copy; it never opens another graphical surface. The browser `/ui` route
 continues to use the shared assets at normal browser scale.
 
 PR #83's explicit terminal-only live daemon pairing smoke path and PR #84's
-optional installer prompt remain. PR #93 connects the Portal and tray through a
-bounded, fixed-origin, in-memory WebKit authentication bridge and the existing
-companion wallet/session controller. It adds no direct host command execution,
-host filesystem access, token argument or discovery path, permission, or change
-to the daemon's privileged network ownership.
+optional installer prompt remain. The unified authentication broker corrects
+PR #93's page-token exchange: the native controller now owns loading, validation,
+entry, and Secret Service persistence. The locked page receives only token-free
+readiness and allowlisted local API results. This adds no direct host command
+execution, host filesystem access, token argument or discovery path, permission,
+or change to the daemon's privileged network ownership.
 
 ## Architectural decision
 
@@ -376,10 +377,11 @@ flatpak run io.github.josethevrtech.VRhotspot
 rm -rf .flatpak-test-build .flatpak-builder
 ```
 
-Token persistence and keyring integration remain separately reviewed future
-work. Lifecycle/configuration controls, start/stop actions, support-bundle
-portal export, production UI polish, Flathub polish, Steam Frame, VR Direct
-Link, and adapter-registry work also remain separate future phases.
+At the PR #82 stage, token persistence and keyring integration remained future
+work; PR #91 later added the app-specific Secret Service backend, and the unified
+broker now reuses it across Flatpak processes. Support-bundle portal export,
+production UI polish, Flathub polish, Steam Frame, VR Direct Link, and
+adapter-registry work remain separate future phases.
 
 ## PR #83 live daemon pairing smoke path
 
@@ -600,9 +602,10 @@ namespace version `6.0`. The shell imports it lazily and creates a
 `WebKit.NetworkSession.new_ephemeral()` session. Persistent HTTP credential
 storage, cookies, page cache, offline application cache, DNS prefetching,
 back/forward gestures, automatic JavaScript windows, and file-URL access are
-disabled. The portal's own manual token-entry behavior remains inside the
-daemon-served frontend and any Web Storage it uses is confined to the ephemeral
-WebKit session rather than persisted by the Flatpak shell.
+disabled. In a normal browser, explicit login remains page-local and is never
+inherited from the Flatpak wallet. In the Flatpak shell, the page requests native
+authentication readiness and authenticated API results without receiving the
+wallet token.
 
 The WebView is locked to the exact literal HTTP origin
 `http://127.0.0.1:8732`. Navigation and response policy decisions fail closed
@@ -613,13 +616,14 @@ forms, and API connections only on the pinned daemon origin; external sites and
 remote subresources are not permitted. There is no address bar, arbitrary URL
 option, popup window, or general-browser mode.
 
-The shell does not place an API token in a URL, header, request override,
-JavaScript, WebKit user script, Local Storage, Session Storage, cookie, model,
-exception, representation, or smoke JSON. It does not read a daemon token from
-the environment, daemon configuration, files, keyrings, portals, `/etc`,
-`/var/lib`, or another filesystem location. Token entry, validation, and use
-remain the existing Web Portal's behavior. PR #92 removed the separate GTK
-manual-entry path.
+The shell does not place its wallet token in a URL, page header, JavaScript,
+WebKit user script, page HTML, Local Storage, Session Storage, IndexedDB, cookie,
+model, exception, representation, or smoke JSON. It reads only its app-specific
+Secret Service item through the native authentication controller; it does not
+read daemon configuration, `/etc`, `/var/lib`, or another token file. Selecting
+the Flatpak page's authentication action opens a small native GTK token dialog,
+not the removed GTK dashboard. Normal browser login remains explicit and
+separate.
 
 If the `WebKit` 6.0 namespace or required ephemeral-session API is unavailable,
 or WebKit construction fails during activation, PR #92 populates the host
@@ -801,36 +805,50 @@ Logon remains deferred and no tray item is exported for it. Primary activation
 is the only tray action that opens or restores the already-default graphical
 shell.
 
-## PR #93 shared Portal and tray authentication state
+## Unified local Flatpak authentication broker
 
-PR #93 treats the Web Portal shell and tray as two surfaces of one companion
-process, not as separate authentication clients. Both use the existing
-`AuthenticationController`. An explicitly entered token is still accepted only
-after the Portal's authenticated status request succeeds. The origin-locked
-WebKit page then sends one bounded, versioned message to the host; the host
-adopts the token in memory, stores it in the app-specific Secret Service wallet
-when that provider is available, and requests an immediate tray refresh.
+The Web Portal shell/window and tray are separate Flatpak processes that share
+only explicitly saved local authentication. Both construct the same
+`AuthenticationController`, load the same app-specific Secret Service item at
+startup, and validate it through the bounded loopback pairing call. A valid item
+starts either surface authenticated. A rejected stale item is cleared and
+suppressed in that process so periodic refresh does not repeat the rejected
+validation indefinitely.
 
-The reverse path is equally narrow. On launch, the existing authentication
-controller may retrieve the matching app-specific wallet item. The Portal can
-request that current wallet/session token only through WebKit's in-memory
-script-message reply mechanism. The credential is not placed in a URL, query
-string, command argument, local file, log, notification, menu label, smoke JSON,
-or exception. The bridge accepts only fixed protocol message shapes, enforces
-token and message-size limits, and responds only while the WebView is at the
-exact loopback origin used by `/ui` and its same-origin assets.
+Token entry for the Flatpak is native. Selecting **Authenticate this device** in
+the locked page opens the same GTK authentication dialog used by the tray.
+**Save for this desktop** stores the accepted token in the app-specific wallet.
+A process that saves, replaces, or clears the item notifies its own page and tray
+immediately; the other process detects the wallet change through its existing
+bounded refresh loop. An accepted token that is not saved remains process-local.
+No broad D-Bus API, helper, privilege prompt, or new token-sharing IPC is added.
 
-Portal logout and token clearing clear the companion's session and matching
-wallet item and refresh the tray. Clearing through the tray authentication
-dialog also clears the Portal's in-memory session. If Secret Service is
-unavailable, an accepted Portal token remains usable only in the current
-companion process; it is not persisted elsewhere.
+The fixed-origin WebKit channel is now a token-free native broker. Page messages
+can request authentication readiness, open or clear native authentication, or
+request an exact allowlisted existing `/v1/*` route. The native
+`LocalApiClient` attaches the wallet token and returns only bounded daemon
+response bytes plus allowlisted content metadata. Request paths and methods are
+fixed, redirects and proxies remain disabled, bodies and replies are bounded,
+and a daemon response reflecting the token is discarded. The page cannot ask
+for, receive, save, log, or render the raw wallet token.
+
+The same daemon-served assets still support normal browser access without the
+native handler. Browser sessions must explicitly enter the daemon token and keep
+that browser-entered value only in page memory. They do not read the Flatpak
+wallet and do not persist a token in Local Storage, Session Storage, or IndexedDB.
+Reloading a browser page therefore requires explicit authentication again.
+
+Clear/logout removes the app-specific wallet item and in-process token. Both
+Flatpak surfaces return to needs-authentication state on their immediate or
+periodic refresh. If Secret Service is unavailable, accepted authentication is
+usable only by the process in which it was entered.
 
 The companion never invokes sudo or searches `/etc/vr-hotspot/env`,
 `/var/lib/vr-hotspot`, daemon configuration, environment variables, or command
-arguments for credentials. PR #93 adds no filesystem, host/home, device,
-system-bus, or other Flatpak permission. The exact WebKit origin and navigation
-lock, CSP, ephemeral network session, and 1.75x zoom remain unchanged.
+arguments for credentials. The manifest permissions are unchanged. The exact
+WebKit origin and navigation lock, CSP, ephemeral network session, and 1.75x zoom
+are unchanged. The native dashboard remains absent; GTK is used only for the
+host window, tray, authentication dialog, bounded errors, and small utilities.
 
 Tray status and icon policy is explicit. Missing or rejected credentials map to
 `Needs Authentication`, not `Error`; the authentication action stays enabled
@@ -943,7 +961,8 @@ bounded, cleaned up, and contain only the already-sanitized daemon output.
 | PR #90 | Flatpak Web Portal shell scaling/density polish. Apply fixed bounded 1.75x WebKit zoom to the locked shell. | Tests prove fixed zoom/clamping, no user-controlled scale, normal browser scale, and unchanged origin/session/token boundaries. |
 | PR #91 | Flatpak system-tray control surface and desktop identity. Add StatusNotifierItem/DBusMenu, close-to-tray, typed live state, fixed controls, explicit Secret Service authentication, and cyan/black icons. | Tests prove complete menu/state mapping, serialized mutations, refresh-after-success, companion-only quit, safe wallet behavior, narrow D-Bus grants, and installed icon identity. |
 | PR #92 | Web Portal-only Flatpak graphical UI. Delete the retired GTK content surface and all routes/tests supporting it; make default and tray window behavior use one locked Web Portal shell; classify authentication and daemon availability separately; organize the tray menu. | Tests prove default/alias/tray activation, close-to-tray and single-window behavior, bounded WebKit errors with no alternate surface, retained origin/CSP/session/zoom locks, six status classes, explicit-auth refresh, deterministic menu sections, no credential leakage, unchanged permissions, and zero forbidden active references. |
-| PR #93 | Shared Web Portal/tray companion authentication. Connect accepted Portal entry and logout to the existing wallet/in-memory session controller, supply an existing wallet token only through a bounded fixed-origin WebKit reply, refresh tray state immediately, and reserve working attention for transitions. | Tests prove bidirectional sync, wallet and current-process fallback behavior, strict message/origin bounds, clear synchronization, token secrecy, correct auth/running/unavailable state and menu mapping, static auth-needed indication, retained WebKit locks, unchanged permissions, and no native dashboard. |
+| PR #93 | Historical first shared-auth bridge. It established the fixed-origin hook, wallet controller, and refresh behavior but exchanged the raw token with page JavaScript. | Retained as history; the unified native broker below supersedes its page-token exchange. |
+| Unified native auth broker | Keep token entry, loading, saving, validation, and authenticated loopback calls in the native Flatpak layer. Share saved state only through the app wallet; expose only readiness and allowlisted API results to the locked page; keep browser login separate and memory-only. | Tests prove window/tray startup loading, both save directions, clear/replacement detection, one-shot stale-token rejection, token-free bridge/smoke/UI surfaces, no browser token storage, retained remote explicit login, unchanged permissions/WebKit/icon/menu behavior, and no native dashboard. |
 | Later, separately approved work | Steam Frame and VR Direct Link evidence-based research, followed by any separately approved adapter-intelligence work. | Work begins from lawful public or user-provided evidence and does not claim support before hardware, driver, regulatory, and security validation. |
 
 Each phase is independently reviewable. A later phase is not authorized merely
@@ -1024,7 +1043,7 @@ reporting. Flatpak work must not weaken or bypass those controls.
   be downloaded, bundled, redistributed, or collected as a side effect of
   Flatpak installation or use.
 
-## Explicit non-goals for PR #93
+## Explicit non-goals for the unified native auth broker
 
 - No second graphical shell, alternate failure UI, legacy launch route, or
   development-only route for the removed GTK content surface.
@@ -1048,11 +1067,11 @@ reporting. Flatpak work must not weaken or bypass those controls.
 - No Steam Frame, VR Direct Link, known-adapter registry, or
   HostFactsSnapshot work.
 
-PR #93 authorizes only the fixed-origin WebKit authentication bridge, reuse of
-the existing companion wallet/session state, Portal/tray clear synchronization,
-tray status and attention-icon correction, deterministic tests, and
-documentation above. It does not change the fixed autostart API, session-bus
-grants, desktop identity, WebKit security boundaries, or permissions. A real
-daemon pairing or live lifecycle result is claimed only when exercised with an
-explicitly entered or previously saved credential; no credential is printed or
-exported in validation.
+This change authorizes only native wallet/controller unification, fixed-origin
+token-free WebKit broker requests for existing Portal routes, Portal/tray
+save-clear refresh, removal of browser token persistence, deterministic tests,
+and the documentation above. It does not change the fixed autostart API,
+session-bus grants, desktop identity, WebKit security boundaries, icons, menu
+organization, or permissions. A real daemon pairing or live lifecycle result is
+claimed only when exercised with an explicitly entered or previously saved
+credential; no credential is printed or exported in validation.

--- a/flatpak_app/app.py
+++ b/flatpak_app/app.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import argparse
+import base64
 from dataclasses import asdict
 import getpass
 import json
 import sys
+import threading
 from typing import Any, Sequence
 from urllib.parse import urlsplit
 import warnings
 
 from flatpak_client import (
     AuthenticationController,
+    AuthenticationError,
+    ConnectionFailure,
     DiagnosticsControlUiController,
     DiagnosticsControlUiModel,
     FirstRunResult,
@@ -37,8 +41,8 @@ MAX_SMOKE_JSON_BYTES = 8_192
 MAX_LIVE_SMOKE_JSON_BYTES = 65_536
 WEB_PORTAL_AUTH_HANDLER = "vrHotspotCompanionAuth"
 WEB_PORTAL_AUTH_PROTOCOL_VERSION = 1
-MAX_WEB_PORTAL_AUTH_MESSAGE_BYTES = 8_192
-MAX_WEB_PORTAL_AUTH_TOKEN_CHARS = 4_096
+MAX_WEB_PORTAL_AUTH_MESSAGE_BYTES = 262_144
+MAX_WEB_PORTAL_AUTH_REPLY_BYTES = 1_500_000
 _WEB_PORTAL_SHELL_ZOOM_MIN = 1.0
 _WEB_PORTAL_SHELL_ZOOM_MAX = 2.0
 _WEB_PORTAL_CSP = (
@@ -69,17 +73,25 @@ class WebKitUnavailableError(RuntimeError):
 
 
 class WebPortalAuthBridge:
-    """Share companion authentication with only the locked local Portal."""
+    """Broker auth state and exact local API calls without disclosing the token."""
 
-    _CLEAR_PORTAL_SCRIPT = (
-        "if (typeof window.vrHotspotCompanionAuthCleared === 'function') {"
-        "window.vrHotspotCompanionAuthCleared();"
+    _AUTH_CHANGED_SCRIPT = (
+        "if (typeof window.vrHotspotCompanionAuthChanged === 'function') {"
+        "window.vrHotspotCompanionAuthChanged();"
         "}"
     )
 
-    def __init__(self, authentication: AuthenticationController):
+    def __init__(
+        self,
+        authentication: AuthenticationController,
+        *,
+        auth_prompt=None,
+        reply_runner=None,
+    ):
         self._authentication = authentication
         self._auth_changed = None
+        self._auth_prompt = auth_prompt if callable(auth_prompt) else None
+        self._reply_runner = reply_runner if callable(reply_runner) else None
         self._web_view = None
 
     def __repr__(self) -> str:
@@ -90,6 +102,9 @@ class WebPortalAuthBridge:
 
     def set_auth_changed_callback(self, callback) -> None:
         self._auth_changed = callback if callable(callback) else None
+
+    def set_auth_prompt_callback(self, callback) -> None:
+        self._auth_prompt = callback if callable(callback) else None
 
     def attach_web_view(self, web_view) -> None:
         self._web_view = web_view
@@ -145,30 +160,136 @@ class WebPortalAuthBridge:
         if not isinstance(message_type, str):
             return None
         expected_keys = {
-            "token_request": {"version", "type"},
-            "auth_accepted": {"version", "type", "token"},
+            "auth_status": {"version", "type"},
+            "auth_prompt": {"version", "type"},
             "auth_cleared": {"version", "type"},
+            "api_request": {
+                "version",
+                "type",
+                "path",
+                "method",
+                "body",
+                "response",
+            },
         }.get(message_type)
         if expected_keys is None or set(payload) != expected_keys:
             return None
-        if message_type == "auth_accepted":
-            token = payload.get("token")
+        if message_type == "api_request":
+            path = payload.get("path")
+            method = payload.get("method")
+            body = payload.get("body")
+            response_kind = payload.get("response")
             if (
-                not isinstance(token, str)
-                or not token
-                or len(token) > MAX_WEB_PORTAL_AUTH_TOKEN_CHARS
+                not isinstance(path, str)
+                or not path.startswith("/v1/")
+                or len(path) > 256
+                or method not in {"GET", "POST"}
+                or (body is not None and not isinstance(body, dict))
+                or response_kind not in {"text", "blob"}
             ):
                 return None
         return payload
 
+    @staticmethod
+    def _render_reply(payload: dict[str, Any]) -> str:
+        try:
+            rendered = json.dumps(
+                payload,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        except (TypeError, ValueError):
+            rendered = '{"code":"invalid_response","ok":false,"status":502}'
+        if len(rendered.encode("utf-8")) > MAX_WEB_PORTAL_AUTH_REPLY_BYTES:
+            return '{"code":"response_too_large","ok":false,"status":502}'
+        return rendered
+
+    def _auth_status_reply(self) -> str:
+        try:
+            result = self._authentication.refresh_saved_auth()
+            authenticated = result.state is FirstRunState.TOKEN_ACCEPTED
+            code = result.state.value
+        except Exception:
+            authenticated = False
+            code = FirstRunState.INVALID_RESPONSE.value
+        return self._render_reply(
+            {
+                "authenticated": authenticated,
+                "code": code,
+            }
+        )
+
+    def _api_reply(self, payload: dict[str, Any]) -> str:
+        try:
+            response = self._authentication.request_local_api(
+                payload["path"],
+                method=payload["method"],
+                body=payload["body"],
+            )
+        except AuthenticationError:
+            return self._render_reply(
+                {"body": "", "code": "authentication_required", "ok": False, "status": 401}
+            )
+        except ConnectionFailure:
+            return self._render_reply(
+                {"body": "", "code": "daemon_unavailable", "ok": False, "status": 503}
+            )
+        except Exception:
+            return self._render_reply(
+                {"body": "", "code": "request_failed", "ok": False, "status": 502}
+            )
+
+        headers = {}
+        for key, value in response.headers.items():
+            normalized = str(key).casefold()
+            if normalized in {"content-disposition", "content-type"}:
+                headers[normalized] = str(value)[:512]
+        if payload["response"] == "blob":
+            body = base64.b64encode(response.body).decode("ascii")
+            body_encoding = "base64"
+        else:
+            body = response.body.decode("utf-8", "replace")
+            body_encoding = "text"
+        return self._render_reply(
+            {
+                "body": body,
+                "body_encoding": body_encoding,
+                "headers": headers,
+                "ok": 200 <= response.status < 300,
+                "status": response.status,
+            }
+        )
+
+    def _run_reply(self, operation, message_value, reply) -> None:
+        runner = self._reply_runner
+        if runner is None:
+            try:
+                response = operation()
+            except Exception:
+                response = '{"code":"request_failed","ok":false,"status":502}'
+            self._reply_string(message_value, reply, response)
+            return
+
+        def complete(response) -> bool:
+            if not isinstance(response, str):
+                response = '{"code":"request_failed","ok":false,"status":502}'
+            self._reply_string(message_value, reply, response)
+            return False
+
+        try:
+            runner(operation, complete)
+        except Exception:
+            complete('{"code":"request_failed","ok":false,"status":502}')
+
     def _emit_auth_changed(self) -> None:
         callback = self._auth_changed
-        if callback is None:
-            return
-        try:
-            callback()
-        except Exception:
-            pass
+        if callback is not None:
+            try:
+                callback()
+            except Exception:
+                pass
+        self.notify_web_portal_auth_changed()
 
     def handle_message(self, web_view, message_value, reply) -> bool:
         """Handle one bounded message and always return only a fixed reply."""
@@ -185,20 +306,33 @@ class WebPortalAuthBridge:
             return False
 
         message_type = payload["type"]
-        if message_type == "token_request":
-            token = ""
+        if message_type == "auth_status":
+            self._run_reply(
+                self._auth_status_reply,
+                message_value,
+                reply,
+            )
+            return True
+
+        if message_type == "api_request":
+            self._run_reply(
+                lambda: self._api_reply(payload),
+                message_value,
+                reply,
+            )
+            return True
+
+        if message_type == "auth_prompt":
+            callback = self._auth_prompt
+            if callback is None:
+                self._reply_string(message_value, reply, "unavailable")
+                return False
             try:
-                candidate = self._authentication.token_for_operation()
-                if (
-                    isinstance(candidate, str)
-                    and 0 < len(candidate) <= MAX_WEB_PORTAL_AUTH_TOKEN_CHARS
-                ):
-                    token = candidate
+                callback()
             except Exception:
-                token = ""
-            self._reply_string(message_value, reply, token)
-            token = ""
-            candidate = None
+                self._reply_string(message_value, reply, "unavailable")
+                return False
+            self._reply_string(message_value, reply, "opened")
             return True
 
         if message_type == "auth_cleared":
@@ -211,33 +345,11 @@ class WebPortalAuthBridge:
             self._reply_string(message_value, reply, "cleared")
             return True
 
-        token = payload["token"]
-        accepted = False
-        try:
-            result = self._authentication.save_or_replace(
-                token,
-                save_securely=True,
-            )
-            accepted = (
-                result.code in {"saved_securely", "wallet_unavailable"}
-                and result.token_available is True
-            )
-        except Exception:
-            accepted = False
-        finally:
-            payload = None
-            token = ""
-        if accepted:
-            self._emit_auth_changed()
-        self._reply_string(
-            message_value,
-            reply,
-            "accepted" if accepted else "rejected",
-        )
-        return accepted
+        self._reply_string(message_value, reply, "rejected")
+        return False
 
-    def clear_web_portal_session(self) -> None:
-        """Clear only the attached fixed-origin page's in-memory auth state."""
+    def notify_web_portal_auth_changed(self) -> None:
+        """Prompt only the attached fixed-origin page to re-check native state."""
 
         web_view = self._web_view
         if web_view is None:
@@ -246,7 +358,7 @@ class WebPortalAuthBridge:
             return
         try:
             web_view.evaluate_javascript(
-                self._CLEAR_PORTAL_SCRIPT,
+                self._AUTH_CHANGED_SCRIPT,
                 -1,
                 None,
                 f"{WEB_PORTAL_ORIGIN}/companion-auth-bridge",
@@ -256,6 +368,11 @@ class WebPortalAuthBridge:
             )
         except Exception:
             pass
+
+    def clear_web_portal_session(self) -> None:
+        """Compatibility callback for tray-driven auth clear notification."""
+
+        self.notify_web_portal_auth_changed()
 
 
 def build_initial_model() -> DiagnosticsControlUiModel:
@@ -554,7 +671,7 @@ def is_approved_web_portal_uri(uri: object) -> bool:
 
 
 def is_approved_web_portal_bridge_uri(uri: object) -> bool:
-    """Restrict companion auth to the Portal document and its asset namespace."""
+    """Restrict the native broker to the exact Portal document."""
 
     if not is_approved_web_portal_uri(uri):
         return False
@@ -562,7 +679,7 @@ def is_approved_web_portal_bridge_uri(uri: object) -> bool:
         path = urlsplit(uri).path
     except (TypeError, ValueError):
         return False
-    return path in {"/ui", "/ui/"} or path.startswith("/assets/")
+    return path in {"/ui", "/ui/"}
 
 
 def _policy_decision_uri(decision, decision_type, WebKit) -> str:
@@ -827,14 +944,52 @@ def _set_window_icon(Gtk, window) -> None:
     window.set_icon_name(WINDOW_ICON_NAME)
 
 
+def _background_reply_runner(GLib):
+    """Keep bounded daemon and wallet calls off the GTK/WebKit main thread."""
+
+    def run(operation, complete) -> None:
+        def worker() -> None:
+            try:
+                response = operation()
+            except Exception:
+                response = '{"code":"request_failed","ok":false,"status":502}'
+            try:
+                GLib.idle_add(complete, response)
+            except Exception:
+                pass
+
+        threading.Thread(
+            target=worker,
+            name="vrhotspot-native-auth-broker",
+            daemon=True,
+        ).start()
+
+    return run
+
+
 def run_web_portal_shell() -> int:
     """Run the only Flatpak graphical UI inside a locked WebKit view."""
 
     Gtk = _load_gtk()
+    try:
+        import gi
+
+        gi.require_version("Gdk", "4.0")
+        from gi.repository import Gdk, GLib
+    except (ImportError, ValueError):
+        Gdk = None
+        GLib = None
     application = Gtk.Application(application_id=APP_ID)
     window_holder: dict[str, Any] = {}
     authentication = AuthenticationController()
-    auth_bridge = WebPortalAuthBridge(authentication)
+    auth_bridge = WebPortalAuthBridge(
+        authentication,
+        reply_runner=_background_reply_runner(GLib) if GLib is not None else None,
+    )
+    try:
+        authentication.refresh_saved_auth()
+    except Exception:
+        pass
 
     def on_activate(app) -> None:
         existing = window_holder.get("window")
@@ -844,6 +999,17 @@ def run_web_portal_shell() -> int:
 
         window = Gtk.ApplicationWindow(application=app)
         _set_window_icon(Gtk, window)
+        from .tray import NativeAuthenticationDialog
+
+        authentication_dialog = NativeAuthenticationDialog(
+            application=app,
+            parent_window=window,
+            authentication=authentication,
+            Gtk=Gtk,
+            Gdk=Gdk,
+            on_auth_changed=auth_bridge.notify_web_portal_auth_changed,
+        )
+        auth_bridge.set_auth_prompt_callback(authentication_dialog.open)
         _populate_new_portal_window(
             Gtk,
             window,
@@ -856,6 +1022,7 @@ def run_web_portal_shell() -> int:
 
         window.connect("close-request", clear_window)
         window_holder["window"] = window
+        window_holder["authentication_dialog"] = authentication_dialog
         window.present()
 
     application.connect("activate", on_activate)
@@ -886,7 +1053,14 @@ def run_tray() -> int:
         window = Gtk.ApplicationWindow(application=app)
         _set_window_icon(Gtk, window)
         authentication = AuthenticationController()
-        auth_bridge = WebPortalAuthBridge(authentication)
+        try:
+            authentication.refresh_saved_auth()
+        except Exception:
+            pass
+        auth_bridge = WebPortalAuthBridge(
+            authentication,
+            reply_runner=_background_reply_runner(GLib),
+        )
         _populate_new_portal_window(
             Gtk,
             window,
@@ -925,9 +1099,12 @@ def run_tray() -> int:
             Gio=Gio,
             GLib=GLib,
             open_diagnostics=open_diagnostics,
-            on_auth_cleared=auth_bridge.clear_web_portal_session,
+            on_auth_changed=auth_bridge.notify_web_portal_auth_changed,
         )
         auth_bridge.set_auth_changed_callback(runtime.refresh_after_auth_change)
+        auth_bridge.set_auth_prompt_callback(
+            getattr(runtime, "open_authentication", None)
+        )
         runtime_holder["runtime"] = runtime
         window.connect("close-request", runtime.close_request)
         lifecycle.show()

--- a/flatpak_app/tray.py
+++ b/flatpak_app/tray.py
@@ -779,6 +779,195 @@ class StatusNotifierBackend:
         )
 
 
+class NativeAuthenticationDialog:
+    """Native token entry shared by tray and locked Web Portal window modes."""
+
+    def __init__(
+        self,
+        *,
+        application,
+        parent_window,
+        authentication: AuthenticationController,
+        Gtk,
+        Gdk,
+        on_auth_changed: Callable[[], None],
+        on_auth_cleared: Callable[[], None] | None = None,
+    ):
+        self._application = application
+        self._parent_window = parent_window
+        self._authentication = authentication
+        self._Gtk = Gtk
+        self._Gdk = Gdk
+        self._on_auth_changed = on_auth_changed
+        self._on_auth_cleared = (
+            on_auth_cleared if callable(on_auth_cleared) else lambda: None
+        )
+        self._window = None
+
+    def __repr__(self) -> str:
+        return f"NativeAuthenticationDialog(open={self._window is not None!r})"
+
+    def open(self) -> None:
+        if self._window is not None:
+            self._window.present()
+            return
+
+        Gtk = self._Gtk
+        window = Gtk.Window(application=self._application)
+        window.set_title("VR Hotspot Authentication")
+        window.set_default_size(560, 330)
+        window.set_transient_for(self._parent_window)
+        window.set_modal(True)
+        set_icon_name = getattr(window, "set_icon_name", None)
+        if callable(set_icon_name):
+            set_icon_name(APP_ID)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        content.set_margin_top(20)
+        content.set_margin_bottom(20)
+        content.set_margin_start(20)
+        content.set_margin_end(20)
+
+        heading = Gtk.Label(label="Authenticate this device")
+        heading.set_xalign(0.0)
+        heading.add_css_class("title-2")
+        content.append(heading)
+        description = Gtk.Label(
+            label=(
+                "Enter the existing daemon API token. Save for this desktop to "
+                "share authentication between this Flatpak's tray and Web Portal "
+                "window. Remote browsers still sign in separately."
+            )
+        )
+        description.set_wrap(True)
+        description.set_xalign(0.0)
+        content.append(description)
+
+        entry = Gtk.PasswordEntry()
+        entry.set_show_peek_icon(True)
+        entry.set_hexpand(True)
+        content.append(entry)
+
+        save_securely = Gtk.CheckButton(label="Save for this desktop")
+        save_securely.set_active(self._authentication.securely_saved)
+        content.append(save_securely)
+
+        status = Gtk.Label(label="")
+        status.set_wrap(True)
+        status.set_xalign(0.0)
+        content.append(status)
+
+        buttons = Gtk.FlowBox()
+        buttons.set_selection_mode(Gtk.SelectionMode.NONE)
+        for label, handler in (
+            (
+                "Authenticate this device",
+                lambda *_args: self.save(entry, save_securely, status),
+            ),
+            ("Test authentication", lambda *_args: self.test(entry, status)),
+            ("Copy saved token", lambda *_args: self.copy(status)),
+            ("Reveal saved token", lambda *_args: self.reveal(entry, status)),
+            (
+                "Clear saved authentication",
+                lambda *_args: self.clear(entry, status),
+            ),
+            ("Close", lambda *_args: window.close()),
+        ):
+            button = Gtk.Button(label=label)
+            button.connect("clicked", handler)
+            buttons.insert(button, -1)
+        content.append(buttons)
+        window.set_child(content)
+
+        def closed(*_args):
+            entry.set_text("")
+            self._window = None
+            return False
+
+        window.connect("close-request", closed)
+        self._window = window
+        window.present()
+
+    def save(self, entry, save_securely, status) -> None:
+        token = entry.get_text()
+        entry.set_text("")
+        try:
+            result = self._authentication.authenticate_and_save(
+                token,
+                save_securely=save_securely.get_active() is True,
+            )
+        except Exception:
+            status.set_text("Authentication could not be saved safely.")
+            return
+        finally:
+            token = ""
+        status.set_text(result.message)
+        save_securely.set_active(result.securely_saved)
+        self._on_auth_changed()
+
+    def test(self, entry, status) -> None:
+        token = entry.get_text()
+        entry.set_text("")
+        try:
+            result = self._authentication.test_authentication(
+                explicit_token=token or None
+            )
+        except Exception:
+            status.set_text("Authentication could not be tested safely.")
+            return
+        finally:
+            token = ""
+        messages = {
+            FirstRunState.TOKEN_ACCEPTED: "Authentication succeeded.",
+            FirstRunState.TOKEN_REJECTED: "Authentication was rejected.",
+            FirstRunState.DAEMON_UNREACHABLE: "The local daemon is unavailable.",
+            FirstRunState.DAEMON_TOKEN_MISSING: (
+                "The daemon has no configured API token."
+            ),
+            FirstRunState.DAEMON_REACHABLE_UNPAIRED: "Enter an API token first.",
+            FirstRunState.INVALID_RESPONSE: (
+                "The daemon returned an unsupported response."
+            ),
+        }
+        status.set_text(messages[result.state])
+        self._on_auth_changed()
+
+    def copy(self, status) -> None:
+        token = self._authentication.copy_token()
+        if not token:
+            status.set_text("No saved API token is available.")
+            return
+        try:
+            display = self._Gdk.Display.get_default()
+            if display is None:
+                raise RuntimeError
+            display.get_clipboard().set(token)
+            status.set_text("API token copied to the clipboard.")
+        except Exception:
+            status.set_text("The API token could not be copied.")
+        finally:
+            token = ""
+
+    def reveal(self, entry, status) -> None:
+        token = self._authentication.reveal_token()
+        if not token:
+            status.set_text("No saved API token is available.")
+            return
+        entry.set_text(token)
+        status.set_text("API token revealed by explicit request.")
+        token = ""
+
+    def clear(self, entry, status) -> None:
+        entry.set_text("")
+        result = self._authentication.clear()
+        status.set_text(result.message)
+        try:
+            self._on_auth_cleared()
+        except Exception:
+            pass
+        self._on_auth_changed()
+
+
 class TrayRuntime:
     """Connect the testable model/controller to GTK and StatusNotifierItem."""
 
@@ -795,6 +984,7 @@ class TrayRuntime:
         Gio,
         GLib,
         open_diagnostics: Callable[[], None],
+        on_auth_changed: Callable[[], None] | None = None,
         on_auth_cleared: Callable[[], None] | None = None,
     ):
         self._application = application
@@ -807,6 +997,9 @@ class TrayRuntime:
         self._Gio = Gio
         self._GLib = GLib
         self._open_diagnostics = open_diagnostics
+        self._on_auth_changed = (
+            on_auth_changed if callable(on_auth_changed) else lambda: None
+        )
         self._on_auth_cleared = (
             on_auth_cleared
             if callable(on_auth_cleared)
@@ -816,7 +1009,15 @@ class TrayRuntime:
         self._auth_refresh_pending = False
         self._notification_counter = 0
         self._last_detail_code = ""
-        self._auth_window = None
+        self._authentication_dialog = NativeAuthenticationDialog(
+            application=application,
+            parent_window=lifecycle.window,
+            authentication=authentication,
+            Gtk=Gtk,
+            Gdk=Gdk,
+            on_auth_changed=self._handle_auth_changed,
+            on_auth_cleared=self._on_auth_cleared,
+        )
 
     def __repr__(self) -> str:
         return (
@@ -970,176 +1171,35 @@ class TrayRuntime:
         else:
             self._auth_refresh_pending = True
 
-    def _open_authentication(self) -> None:
-        if self._auth_window is not None:
-            self._auth_window.present()
-            return
-
-        Gtk = self._Gtk
-        window = Gtk.Window(application=self._application)
-        window.set_title("VR Hotspot Authentication")
-        window.set_default_size(560, 330)
-        window.set_transient_for(self._lifecycle.window)
-        window.set_modal(True)
-
-        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
-        content.set_margin_top(20)
-        content.set_margin_bottom(20)
-        content.set_margin_start(20)
-        content.set_margin_end(20)
-
-        heading = Gtk.Label(label="Authentication")
-        heading.set_xalign(0.0)
-        heading.add_css_class("title-2")
-        content.append(heading)
-        description = Gtk.Label(
-            label=(
-                "Enter the existing daemon API token. It remains in memory "
-                "unless secure wallet storage is explicitly selected."
-            )
-        )
-        description.set_wrap(True)
-        description.set_xalign(0.0)
-        content.append(description)
-
-        entry = Gtk.PasswordEntry()
-        entry.set_show_peek_icon(True)
-        entry.set_hexpand(True)
-        content.append(entry)
-
-        save_securely = Gtk.CheckButton(
-            label="Save API token securely in system wallet"
-        )
-        save_securely.set_active(self._authentication.securely_saved)
-        content.append(save_securely)
-
-        status = Gtk.Label(label="")
-        status.set_wrap(True)
-        status.set_xalign(0.0)
-        content.append(status)
-
-        buttons = Gtk.FlowBox()
-        buttons.set_selection_mode(Gtk.SelectionMode.NONE)
-        for label, handler in (
-            (
-                "Save or replace token",
-                lambda *_args: self._auth_save(
-                    entry,
-                    save_securely,
-                    status,
-                ),
-            ),
-            (
-                "Test authentication",
-                lambda *_args: self._auth_test(entry, status),
-            ),
-            (
-                "Copy saved token",
-                lambda *_args: self._auth_copy(status),
-            ),
-            (
-                "Reveal saved token",
-                lambda *_args: self._auth_reveal(entry, status),
-            ),
-            (
-                "Clear saved token",
-                lambda *_args: self._auth_clear(entry, status),
-            ),
-            ("Close", lambda *_args: window.close()),
-        ):
-            button = Gtk.Button(label=label)
-            button.connect("clicked", handler)
-            buttons.insert(button, -1)
-        content.append(buttons)
-        window.set_child(content)
-
-        def closed(*_args):
-            entry.set_text("")
-            self._auth_window = None
-            return False
-
-        window.connect("close-request", closed)
-        self._auth_window = window
-        window.present()
-
-    def _auth_save(self, entry, save_securely, status) -> None:
-        token = entry.get_text()
-        entry.set_text("")
-        try:
-            result = self._authentication.save_or_replace(
-                token,
-                save_securely=save_securely.get_active() is True,
-            )
-        except Exception:
-            status.set_text("The API token could not be saved.")
-            return
-        finally:
-            token = ""
-        status.set_text(result.message)
-        save_securely.set_active(result.securely_saved)
+    def _handle_auth_changed(self) -> None:
         self.refresh_after_auth_change()
-
-    def _auth_test(self, entry, status) -> None:
-        token = entry.get_text()
-        entry.set_text("")
         try:
-            result = self._authentication.test_authentication(
-                explicit_token=token or None
-            )
-        except Exception:
-            status.set_text("Authentication could not be tested safely.")
-            return
-        finally:
-            token = ""
-        messages = {
-            FirstRunState.TOKEN_ACCEPTED: "Authentication succeeded.",
-            FirstRunState.TOKEN_REJECTED: "Authentication was rejected.",
-            FirstRunState.DAEMON_UNREACHABLE: "The local daemon is unavailable.",
-            FirstRunState.DAEMON_TOKEN_MISSING: (
-                "The daemon has no configured API token."
-            ),
-            FirstRunState.DAEMON_REACHABLE_UNPAIRED: "Enter an API token first.",
-            FirstRunState.INVALID_RESPONSE: (
-                "The daemon returned an unsupported response."
-            ),
-        }
-        status.set_text(messages[result.state])
-        self.refresh_async()
-
-    def _auth_copy(self, status) -> None:
-        token = self._authentication.copy_token()
-        if not token:
-            status.set_text("No saved API token is available.")
-            return
-        try:
-            display = self._Gdk.Display.get_default()
-            if display is None:
-                raise RuntimeError
-            display.get_clipboard().set(token)
-            status.set_text("API token copied to the clipboard.")
-        except Exception:
-            status.set_text("The API token could not be copied.")
-        finally:
-            token = ""
-
-    def _auth_reveal(self, entry, status) -> None:
-        token = self._authentication.reveal_token()
-        if not token:
-            status.set_text("No saved API token is available.")
-            return
-        entry.set_text(token)
-        status.set_text("API token revealed by explicit request.")
-        token = ""
-
-    def _auth_clear(self, entry, status) -> None:
-        entry.set_text("")
-        result = self._authentication.clear()
-        status.set_text(result.message)
-        try:
-            self._on_auth_cleared()
+            self._on_auth_changed()
         except Exception:
             pass
-        self.refresh_after_auth_change()
+
+    def _open_authentication(self) -> None:
+        self._authentication_dialog.open()
+
+    def open_authentication(self) -> None:
+        """Open the shared native authentication dialog."""
+
+        self._open_authentication()
+
+    def _auth_save(self, entry, save_securely, status) -> None:
+        self._authentication_dialog.save(entry, save_securely, status)
+
+    def _auth_test(self, entry, status) -> None:
+        self._authentication_dialog.test(entry, status)
+
+    def _auth_copy(self, status) -> None:
+        self._authentication_dialog.copy(status)
+
+    def _auth_reveal(self, entry, status) -> None:
+        self._authentication_dialog.reveal(entry, status)
+
+    def _auth_clear(self, entry, status) -> None:
+        self._authentication_dialog.clear(entry, status)
 
     def dispatch_action(self, action: str) -> None:
         state = self._controls.state

--- a/flatpak_client/client.py
+++ b/flatpak_client/client.py
@@ -33,11 +33,27 @@ _RESTART_PATH = "/v1/restart"
 _REPAIR_PATH = "/v1/repair"
 _AUTOSTART_PATH = "/v1/autostart"
 _DEFAULT_TIMEOUT_SECONDS = 10.0
+_MAX_REQUEST_BODY_BYTES = 262_144
 _MAX_RESPONSE_BYTES = 1_000_000
 _MAX_ERROR_BODY_BYTES = 4_096
 _MAX_ERROR_SNIPPET_CHARS = 256
 _REDACTED = "[redacted]"
 _AUTH_HEADER_NAMES = frozenset({"authorization", "x-api-token"})
+_PORTAL_REQUEST_METHODS = {
+    "/v1/adapters": frozenset({"GET"}),
+    "/v1/adapters/readiness": frozenset({"GET"}),
+    "/v1/config": frozenset({"GET", "POST"}),
+    "/v1/config/reveal_passphrase": frozenset({"POST"}),
+    "/v1/diagnostics/preflight": frozenset({"GET"}),
+    "/v1/diagnostics/support_bundle": frozenset({"GET"}),
+    "/v1/info": frozenset({"GET"}),
+    "/v1/repair": frozenset({"POST"}),
+    "/v1/restart": frozenset({"POST"}),
+    "/v1/start": frozenset({"POST"}),
+    "/v1/status": frozenset({"GET"}),
+    "/v1/status?include_logs=1": frozenset({"GET"}),
+    "/v1/stop": frozenset({"POST"}),
+}
 
 
 class LocalApiClientError(RuntimeError):
@@ -478,6 +494,50 @@ class LocalApiClient:
             },
         )
 
+    def portal_request(
+        self,
+        path: str,
+        *,
+        method: str,
+        body: Mapping[str, Any] | None = None,
+    ) -> HttpResponse:
+        """Run one exact Web Portal route without exposing the token to WebKit."""
+
+        if not isinstance(path, str) or path not in _PORTAL_REQUEST_METHODS:
+            raise LocalApiClientError("The local Web Portal route is not allowed.")
+        if not isinstance(method, str):
+            raise LocalApiClientError("The local Web Portal method is not allowed.")
+        normalized_method = method.upper()
+        if normalized_method not in _PORTAL_REQUEST_METHODS[path]:
+            raise LocalApiClientError("The local Web Portal method is not allowed.")
+        if normalized_method == "GET" and body is not None:
+            raise LocalApiClientError("GET requests cannot include a request body.")
+        if body is not None and not isinstance(body, Mapping):
+            raise LocalApiClientError("The local Web Portal request body is invalid.")
+
+        response = self._request(
+            path,
+            method=normalized_method,
+            authenticated=True,
+            body=body,
+        )
+        if 300 <= response.status < 400:
+            raise RedirectRejectedError(response.status)
+        if response.body_truncated:
+            raise ResponseTooLargeError(
+                "The local daemon API response exceeded the client size limit."
+            )
+        token_bytes = self._token.encode("ascii") if self._token else b""
+        if self._token and (
+            token_bytes in response.body
+            or _contains_secret(response.headers, self._token)
+        ):
+            raise InvalidResponseError(
+                "The local daemon API reflected the authentication token; "
+                "the response was discarded."
+            )
+        return response
+
     def _get_api_response(self, path: str) -> ApiResponse:
         return self._request_api_response(path, method="GET")
 
@@ -530,6 +590,10 @@ class LocalApiClient:
                 separators=(",", ":"),
                 sort_keys=True,
             ).encode("utf-8")
+            if len(request_body) > _MAX_REQUEST_BODY_BYTES:
+                raise LocalApiClientError(
+                    "The local daemon API request exceeded the client size limit."
+                )
             headers["Content-Type"] = "application/json"
         request = HttpRequest(
             url=self._base_url + path,

--- a/flatpak_client/control.py
+++ b/flatpak_client/control.py
@@ -59,6 +59,9 @@ class TokenProvider(Protocol):
     def token_for_operation(self) -> str | None:
         """Return an explicitly entered or previously saved token."""
 
+    def discard_rejected_auth(self) -> None:
+        """Forget a credential rejected by the daemon."""
+
 
 class TrayControlController:
     """Serialize tray actions and project daemon responses into safe state."""
@@ -126,6 +129,15 @@ class TrayControlController:
             return None
         return self._client_factory(token=token)
 
+    def _discard_rejected_auth(self) -> None:
+        discard = getattr(self._token_provider, "discard_rejected_auth", None)
+        if not callable(discard):
+            return
+        try:
+            discard()
+        except Exception:
+            pass
+
     def _state_from_responses(
         self,
         status_response: ApiResponse,
@@ -189,6 +201,7 @@ class TrayControlController:
                 raise TypeError
             return self._state_from_responses(status_response, config_response)
         except AuthenticationError:
+            self._discard_rejected_auth()
             return self._classified_failure_state(
                 status=TrayStatus.NEEDS_AUTHENTICATION,
                 message="Authentication was rejected.",
@@ -370,6 +383,7 @@ class TrayControlController:
                         raise LocalApiClientError("Unsupported tray action.")
                     response = call()
             except AuthenticationError:
+                self._discard_rejected_auth()
                 state = self._set_state(
                     self._classified_failure_state(
                         status=TrayStatus.NEEDS_AUTHENTICATION,

--- a/flatpak_client/wallet.py
+++ b/flatpak_client/wallet.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+import hashlib
+import threading
+from typing import Any, Mapping, Protocol
 
-from .client import LocalApiClient, LocalApiClientError
+from .client import AuthenticationError, HttpResponse, LocalApiClient, LocalApiClientError
 from .pairing import FirstRunResult, FirstRunState, TokenPairingController
 
 
@@ -149,6 +151,9 @@ class AuthenticationController:
         self._client_factory = client_factory
         self._memory_token = ""
         self._securely_saved = False
+        self._validation_state: FirstRunState | None = None
+        self._rejected_wallet_digest = ""
+        self._state_lock = threading.RLock()
 
     def __repr__(self) -> str:
         return (
@@ -159,7 +164,8 @@ class AuthenticationController:
 
     @property
     def securely_saved(self) -> bool:
-        return self._securely_saved
+        with self._state_lock:
+            return self._securely_saved
 
     def wallet_available(self) -> bool:
         try:
@@ -197,82 +203,200 @@ class AuthenticationController:
                 securely_saved=self._securely_saved,
             )
 
-        self._memory_token = token
-        if not save_securely:
+        with self._state_lock:
+            self._memory_token = token
+            self._validation_state = None
+            self._rejected_wallet_digest = ""
+            if not save_securely:
+                try:
+                    self._wallet.clear()
+                except Exception:
+                    self._securely_saved = False
+                    return AuthenticationResult(
+                        code="saved_in_memory_wallet_unavailable",
+                        message=(
+                            "The API token is retained in memory for this session. "
+                            "Secure wallet storage was unavailable, so an older "
+                            "VR Hotspot wallet entry could not be checked or removed."
+                        ),
+                        token_available=True,
+                        securely_saved=False,
+                    )
+                self._securely_saved = False
+                return AuthenticationResult(
+                    code="saved_in_memory",
+                    message="API token retained in memory for this session only.",
+                    token_available=True,
+                    securely_saved=False,
+                )
+
             try:
-                self._wallet.clear()
+                self._wallet.store(token)
             except Exception:
                 self._securely_saved = False
                 return AuthenticationResult(
-                    code="saved_in_memory_wallet_unavailable",
+                    code="wallet_unavailable",
                     message=(
-                        "The API token is retained in memory for this session. "
-                        "Secure wallet storage was unavailable, so an older "
-                        "VR Hotspot wallet entry could not be checked or removed."
+                        "Secure wallet persistence is unavailable; the API token "
+                        "is retained in memory for this session only."
                     ),
                     token_available=True,
                     securely_saved=False,
                 )
-            self._securely_saved = False
+
+            self._securely_saved = True
             return AuthenticationResult(
-                code="saved_in_memory",
-                message="API token retained in memory for this session only.",
+                code="saved_securely",
+                message="Authentication saved for this Flatpak desktop app.",
                 token_available=True,
-                securely_saved=False,
+                securely_saved=True,
             )
 
-        try:
-            self._wallet.store(token)
-        except Exception:
-            self._securely_saved = False
-            return AuthenticationResult(
-                code="wallet_unavailable",
-                message=(
-                    "Secure wallet persistence is unavailable; the API token "
-                    "is retained in memory for this session only."
-                ),
-                token_available=True,
-                securely_saved=False,
-            )
+    @staticmethod
+    def _token_digest(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
-        self._securely_saved = True
-        return AuthenticationResult(
-            code="saved_securely",
-            message="API token saved securely in the system wallet.",
-            token_available=True,
-            securely_saved=True,
-        )
-
-    def token_for_operation(self) -> str | None:
-        if self._memory_token:
+    def _token_for_operation_locked(self) -> str | None:
+        if self._memory_token and not self._securely_saved:
             return self._memory_token
+
         try:
             token = self._wallet.load()
         except Exception:
-            self._securely_saved = False
+            if self._securely_saved:
+                self._memory_token = ""
+                self._securely_saved = False
+                self._validation_state = None
             return None
         if not token:
+            if self._securely_saved:
+                self._memory_token = ""
+                self._securely_saved = False
+                self._validation_state = None
+            self._rejected_wallet_digest = ""
+            return None
+
+        digest = self._token_digest(token)
+        if digest == self._rejected_wallet_digest:
+            self._memory_token = ""
             self._securely_saved = False
             return None
-        try:
-            self._client_factory(token=token)
-        except Exception:
-            return None
-        self._memory_token = token
-        self._securely_saved = True
-        return token
+        if token != self._memory_token or not self._securely_saved:
+            self._memory_token = token
+            self._securely_saved = True
+            self._validation_state = None
+        return self._memory_token
+
+    def token_for_operation(self) -> str | None:
+        with self._state_lock:
+            token = self._token_for_operation_locked()
+            if not token:
+                return None
+            try:
+                self._client_factory(token=token)
+            except Exception:
+                self.discard_rejected_auth()
+                return None
+            return token
+
+    def discard_rejected_auth(self) -> None:
+        """Forget one rejected token and suppress repeat validation if clear fails."""
+
+        with self._state_lock:
+            token = self._memory_token
+            was_securely_saved = self._securely_saved
+            self._memory_token = ""
+            self._securely_saved = False
+            self._validation_state = FirstRunState.TOKEN_REJECTED
+            self._rejected_wallet_digest = (
+                self._token_digest(token) if token and was_securely_saved else ""
+            )
+            if was_securely_saved:
+                try:
+                    self._wallet.clear()
+                except Exception:
+                    pass
+            token = ""
+
+    def refresh_saved_auth(self) -> FirstRunResult:
+        """Reload and validate app-wallet auth without disclosing the credential."""
+
+        with self._state_lock:
+            token = self._token_for_operation_locked()
+            if not token:
+                return FirstRunResult(FirstRunState.DAEMON_REACHABLE_UNPAIRED)
+            if self._validation_state is FirstRunState.TOKEN_ACCEPTED:
+                return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+
+        result = TokenPairingController(self._client_factory).evaluate(token=token)
+        with self._state_lock:
+            if token != self._memory_token:
+                return FirstRunResult(FirstRunState.DAEMON_REACHABLE_UNPAIRED)
+            if result.state is FirstRunState.TOKEN_REJECTED:
+                self.discard_rejected_auth()
+            elif result.state is FirstRunState.TOKEN_ACCEPTED:
+                self._validation_state = FirstRunState.TOKEN_ACCEPTED
+            token = ""
+            return result
+
+    def authenticate_and_save(
+        self,
+        token: str,
+        *,
+        save_securely: bool,
+    ) -> AuthenticationResult:
+        """Validate explicit native input before retaining or persisting it."""
+
+        result = TokenPairingController(self._client_factory).evaluate(token=token)
+        if result.state is not FirstRunState.TOKEN_ACCEPTED:
+            messages = {
+                FirstRunState.DAEMON_UNREACHABLE: (
+                    "The local daemon is unavailable. Authentication was not saved."
+                ),
+                FirstRunState.TOKEN_REJECTED: (
+                    "Authentication was rejected. Nothing was saved."
+                ),
+                FirstRunState.DAEMON_TOKEN_MISSING: (
+                    "The daemon has no configured API token. Nothing was saved."
+                ),
+                FirstRunState.INVALID_RESPONSE: (
+                    "Authentication could not be verified safely. Nothing was saved."
+                ),
+                FirstRunState.DAEMON_REACHABLE_UNPAIRED: (
+                    "Enter the daemon API token."
+                ),
+            }
+            return AuthenticationResult(
+                code=result.state.value,
+                message=messages.get(
+                    result.state,
+                    "Authentication could not be verified safely. Nothing was saved.",
+                ),
+                token_available=bool(self._memory_token),
+                securely_saved=self._securely_saved,
+            )
+
+        saved = self.save_or_replace(token, save_securely=save_securely)
+        with self._state_lock:
+            if saved.code in {
+                "saved_in_memory",
+                "saved_in_memory_wallet_unavailable",
+                "saved_securely",
+                "wallet_unavailable",
+            }:
+                self._validation_state = FirstRunState.TOKEN_ACCEPTED
+        return saved
 
     def test_authentication(
         self,
         *,
         explicit_token: str | None = None,
     ) -> FirstRunResult:
-        token = (
-            explicit_token
-            if isinstance(explicit_token, str) and explicit_token
-            else self.token_for_operation()
-        )
-        return TokenPairingController(self._client_factory).evaluate(token=token)
+        if isinstance(explicit_token, str) and explicit_token:
+            return TokenPairingController(self._client_factory).evaluate(
+                token=explicit_token
+            )
+        return self.refresh_saved_auth()
 
     def reveal_token(self) -> str | None:
         """Return the current token only for an explicit reveal action."""
@@ -285,32 +409,56 @@ class AuthenticationController:
         return self.token_for_operation()
 
     def clear(self) -> AuthenticationResult:
-        self._memory_token = ""
-        removed = False
-        try:
-            removed = self._wallet.clear()
-        except Exception:
+        with self._state_lock:
+            self._memory_token = ""
+            self._validation_state = None
+            self._rejected_wallet_digest = ""
+            removed = False
+            try:
+                removed = self._wallet.clear()
+            except Exception:
+                self._securely_saved = False
+                return AuthenticationResult(
+                    code="cleared_memory_wallet_unavailable",
+                    message=(
+                        "The in-memory authentication was cleared. Secure wallet "
+                        "storage was unavailable."
+                    ),
+                    token_available=False,
+                    securely_saved=False,
+                )
             self._securely_saved = False
             return AuthenticationResult(
-                code="cleared_memory_wallet_unavailable",
+                code="cleared",
                 message=(
-                    "The in-memory token was cleared. Secure wallet storage "
-                    "was unavailable."
+                    "Saved authentication for this desktop was cleared."
+                    if removed
+                    else "No saved authentication for this desktop was present."
                 ),
                 token_available=False,
                 securely_saved=False,
             )
-        self._securely_saved = False
-        return AuthenticationResult(
-            code="cleared",
-            message=(
-                "VR Hotspot's saved API token was cleared."
-                if removed
-                else "No saved VR Hotspot API token was present."
-            ),
-            token_available=False,
-            securely_saved=False,
-        )
+
+    def request_local_api(
+        self,
+        path: str,
+        *,
+        method: str,
+        body: Mapping[str, Any] | None = None,
+    ) -> HttpResponse:
+        """Broker one allowlisted daemon request without returning the token."""
+
+        token = self.token_for_operation()
+        if not token:
+            raise AuthenticationError(401)
+        try:
+            client = self._client_factory(token=token)
+            response = client.portal_request(path, method=method, body=body)
+        finally:
+            token = ""
+        if response.status in {401, 403}:
+            self.discard_rejected_auth()
+        return response
 
     def authentication_state(self) -> FirstRunState:
-        return self.test_authentication().state
+        return self.refresh_saved_auth().state

--- a/tests/test_flatpak_app_shell.py
+++ b/tests/test_flatpak_app_shell.py
@@ -14,6 +14,9 @@ from flatpak_client import (
     AuthenticationError,
     ConnectionFailure,
     DaemonTokenMissingError,
+    FirstRunResult,
+    FirstRunState,
+    HttpResponse,
 )
 
 
@@ -595,28 +598,32 @@ class FakeScriptReply:
 
 
 class FakeBridgeAuthentication:
-    def __init__(self, *, token=None):
-        self.token = token
-        self.saved = []
+    def __init__(
+        self,
+        *,
+        state=FirstRunState.DAEMON_REACHABLE_UNPAIRED,
+        response=None,
+    ):
+        self.state = state
+        self.response = response or HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"result_code":"ok","data":{"phase":"stopped"}}',
+        )
+        self.refresh_calls = 0
+        self.requests = []
         self.clear_calls = 0
 
-    def token_for_operation(self):
-        return self.token
+    def refresh_saved_auth(self):
+        self.refresh_calls += 1
+        return FirstRunResult(self.state)
 
-    def save_or_replace(self, token, *, save_securely):
-        self.saved.append((bool(token), save_securely))
-        self.token = token
-        return type(
-            "Result",
-            (),
-            {
-                "code": "saved_securely",
-                "token_available": True,
-            },
-        )()
+    def request_local_api(self, path, *, method, body):
+        self.requests.append((path, method, body))
+        return self.response
 
     def clear(self):
-        self.token = None
+        self.state = FirstRunState.DAEMON_REACHABLE_UNPAIRED
         self.clear_calls += 1
 
 
@@ -624,58 +631,80 @@ def _bridge_message(message):
     return FakeJavascriptValue(json.dumps(message)), FakeScriptReply()
 
 
-def test_web_portal_auth_success_updates_shared_state_and_refreshes_tray():
+def test_web_portal_saved_auth_status_is_token_free_and_needs_no_second_prompt():
     from flatpak_app import app
 
-    secret = "accepted-portal-value"
-    authentication = FakeBridgeAuthentication()
+    secret = "wallet-value-must-never-enter-web-content"
+    authentication = FakeBridgeAuthentication(state=FirstRunState.TOKEN_ACCEPTED)
     bridge = app.WebPortalAuthBridge(authentication)
-    refreshes = []
-    bridge.set_auth_changed_callback(lambda: refreshes.append("refresh"))
+    prompts = []
+    bridge.set_auth_prompt_callback(lambda: prompts.append("prompt"))
     web_view = FakeWebKitWebView()
     web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/ui"
     value, reply = _bridge_message(
         {
             "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
-            "type": "auth_accepted",
-            "token": secret,
+            "type": "auth_status",
         }
     )
 
     assert bridge.handle_message(web_view, value, reply) is True
 
-    assert authentication.saved == [(True, True)]
-    assert refreshes == ["refresh"]
-    assert reply.value == "accepted"
+    assert json.loads(reply.value) == {
+        "authenticated": True,
+        "code": "token_accepted",
+    }
+    assert authentication.refresh_calls == 1
+    assert prompts == []
+    assert secret not in reply.value
     assert secret not in repr(bridge)
-    assert secret not in repr(authentication.saved)
 
 
-def test_wallet_token_reply_is_fixed_origin_only_and_never_enters_bridge_repr():
+def test_web_portal_native_api_broker_returns_only_daemon_response():
     from flatpak_app import app
 
-    secret = "wallet-value-for-fixed-origin"
-    authentication = FakeBridgeAuthentication(token=secret)
+    secret = "native-wallet-token-must-not-cross-bridge"
+    authentication = FakeBridgeAuthentication(state=FirstRunState.TOKEN_ACCEPTED)
     bridge = app.WebPortalAuthBridge(authentication)
     value, reply = _bridge_message(
         {
             "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
-            "type": "token_request",
+            "type": "api_request",
+            "path": "/v1/status",
+            "method": "GET",
+            "body": None,
+            "response": "text",
         }
     )
     web_view = FakeWebKitWebView()
-    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/assets/ui.js"
+    web_view.current_uri = app.WEB_PORTAL_URL
 
     assert bridge.handle_message(web_view, value, reply) is True
-    assert reply.value == secret
+    payload = json.loads(reply.value)
+    assert payload["ok"] is True
+    assert payload["status"] == 200
+    assert json.loads(payload["body"])["data"]["phase"] == "stopped"
+    assert authentication.requests == [("/v1/status", "GET", None)]
+    assert secret not in reply.value
     assert secret not in repr(bridge)
 
+
+def test_web_portal_native_auth_prompt_is_fixed_origin_only():
+    from flatpak_app import app
+
+    authentication = FakeBridgeAuthentication()
+    prompts = []
+    bridge = app.WebPortalAuthBridge(
+        authentication,
+        auth_prompt=lambda: prompts.append("opened"),
+    )
     rejected_value, rejected_reply = _bridge_message(
         {
             "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
-            "type": "token_request",
+            "type": "auth_prompt",
         }
     )
+    web_view = FakeWebKitWebView()
     web_view.current_uri = "https://example.com/ui"
     assert bridge.handle_message(
         web_view,
@@ -687,16 +716,47 @@ def test_wallet_token_reply_is_fixed_origin_only_and_never_enters_bridge_repr():
     same_origin_value, same_origin_reply = _bridge_message(
         {
             "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
-            "type": "token_request",
+            "type": "auth_prompt",
         }
     )
-    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/v1/status"
+    web_view.current_uri = app.WEB_PORTAL_URL
     assert bridge.handle_message(
         web_view,
         same_origin_value,
         same_origin_reply,
-    ) is False
-    assert same_origin_reply.value == "rejected"
+    ) is True
+    assert same_origin_reply.value == "opened"
+    assert prompts == ["opened"]
+
+    asset_value, asset_reply = _bridge_message(
+        {
+            "version": app.WEB_PORTAL_AUTH_PROTOCOL_VERSION,
+            "type": "auth_prompt",
+        }
+    )
+    web_view.current_uri = f"{app.WEB_PORTAL_ORIGIN}/assets/ui.js"
+    assert bridge.handle_message(web_view, asset_value, asset_reply) is False
+    assert asset_reply.value == "rejected"
+    assert prompts == ["opened"]
+
+
+def test_web_portal_bridge_has_no_raw_token_message_or_reply_path():
+    from flatpak_app import app
+
+    source = inspect.getsource(app.WebPortalAuthBridge)
+
+    for forbidden in (
+        "token_for_operation",
+        "save_or_replace",
+        '"auth_accepted"',
+        '"token_request"',
+        '"token":',
+        "X-Api-Token",
+        "Authorization",
+        "localStorage",
+        "sessionStorage",
+    ):
+        assert forbidden not in source
 
 
 @pytest.mark.parametrize(
@@ -704,12 +764,27 @@ def test_wallet_token_reply_is_fixed_origin_only_and_never_enters_bridge_repr():
     (
         None,
         [],
-        {"version": True, "type": "token_request"},
-        {"version": 2, "type": "token_request"},
+        {"version": True, "type": "auth_status"},
+        {"version": 2, "type": "auth_status"},
         {"version": 1, "type": "unknown"},
-        {"version": 1, "type": "token_request", "extra": True},
-        {"version": 1, "type": "auth_accepted"},
-        {"version": 1, "type": "auth_accepted", "token": ""},
+        {"version": 1, "type": "auth_status", "extra": True},
+        {"version": 1, "type": "api_request"},
+        {
+            "version": 1,
+            "type": "api_request",
+            "path": "https://example.com/",
+            "method": "GET",
+            "body": None,
+            "response": "text",
+        },
+        {
+            "version": 1,
+            "type": "api_request",
+            "path": "/v1/status",
+            "method": "GET",
+            "body": {"x-api-token": "forbidden"},
+            "response": "unknown",
+        },
     ),
 )
 def test_web_portal_auth_bridge_rejects_invalid_message_schema(message):
@@ -724,7 +799,7 @@ def test_web_portal_auth_bridge_rejects_invalid_message_schema(message):
 
     assert bridge.handle_message(web_view, value, reply) is False
     assert reply.value == "rejected"
-    assert authentication.saved == []
+    assert authentication.requests == []
 
 
 def test_web_portal_auth_bridge_bounds_message_bytes_before_parsing():
@@ -745,7 +820,7 @@ def test_web_portal_auth_bridge_bounds_message_bytes_before_parsing():
 def test_web_portal_clear_syncs_shared_auth_and_refreshes_tray():
     from flatpak_app import app
 
-    authentication = FakeBridgeAuthentication(token="present")
+    authentication = FakeBridgeAuthentication(state=FirstRunState.TOKEN_ACCEPTED)
     bridge = app.WebPortalAuthBridge(authentication)
     refreshes = []
     bridge.set_auth_changed_callback(lambda: refreshes.append("refresh"))
@@ -760,7 +835,7 @@ def test_web_portal_clear_syncs_shared_auth_and_refreshes_tray():
 
     assert bridge.handle_message(web_view, value, reply) is True
     assert authentication.clear_calls == 1
-    assert authentication.token is None
+    assert authentication.state is FirstRunState.DAEMON_REACHABLE_UNPAIRED
     assert refreshes == ["refresh"]
     assert reply.value == "cleared"
 
@@ -786,7 +861,7 @@ def test_web_portal_bridge_registration_and_host_clear_stay_fixed_origin():
     bridge.clear_web_portal_session()
     assert len(web_view.evaluated_scripts) == 1
     script_call = web_view.evaluated_scripts[0]
-    assert script_call[0] == bridge._CLEAR_PORTAL_SCRIPT
+    assert script_call[0] == bridge._AUTH_CHANGED_SCRIPT
     assert script_call[3] == (
         f"{app.WEB_PORTAL_ORIGIN}/companion-auth-bridge"
     )
@@ -817,9 +892,19 @@ def test_default_graphical_launch_uses_one_web_portal_window(monkeypatch):
     from flatpak_app import app
     from flatpak_app.tray import ICON_NAMES
 
+    class Authentication:
+        def __init__(self):
+            self.refresh_calls = 0
+
+        def refresh_saved_auth(self):
+            self.refresh_calls += 1
+            return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+
+    authentication = Authentication()
     _reset_gui_fakes()
     monkeypatch.setattr(app, "_load_gtk", lambda: FakeGtk)
     monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
+    monkeypatch.setattr(app, "AuthenticationController", lambda: authentication)
 
     assert app.main([]) == 0
     assert len(FakeGtkApplicationWindow.created) == 1
@@ -830,6 +915,7 @@ def test_default_graphical_launch_uses_one_web_portal_window(monkeypatch):
     assert FakeGtkWindow.default_icon_names == [APP_ID]
     assert FakeGtkApplicationWindow.created[0].icon_names == [APP_ID]
     assert app.WINDOW_ICON_NAME not in ICON_NAMES.values()
+    assert authentication.refresh_calls == 1
 
 
 def test_compatibility_alias_uses_default_web_portal_behavior(monkeypatch):
@@ -876,7 +962,17 @@ def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
         lambda: (object(), object(), object()),
     )
     monkeypatch.setattr(app, "_load_webkit", lambda: FakeWebKit)
-    monkeypatch.setattr(app, "AuthenticationController", lambda: object())
+
+    class Authentication:
+        def __init__(self):
+            self.refresh_calls = 0
+
+        def refresh_saved_auth(self):
+            self.refresh_calls += 1
+            return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
+
+    authentication = Authentication()
+    monkeypatch.setattr(app, "AuthenticationController", lambda: authentication)
     monkeypatch.setattr(
         app,
         "TrayControlController",
@@ -905,6 +1001,9 @@ def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
         def refresh_after_auth_change(self):
             pass
 
+        def open_authentication(self):
+            pass
+
         def close_request(self, *_args):
             return self.lifecycle.close_request(*_args)
 
@@ -924,6 +1023,7 @@ def test_tray_primary_activation_restores_single_web_portal_window(monkeypatch):
     assert FakeGtkApplication.last_created.application_id == APP_ID
     assert FakeGtkWindow.default_icon_names == [APP_ID]
     assert FakeGtkApplicationWindow.created[0].icon_names == [APP_ID]
+    assert authentication.refresh_calls == 1
 
 
 def test_webkit_unavailable_shows_bounded_error_without_alternate_ui(monkeypatch):

--- a/tests/test_flatpak_local_api_client.py
+++ b/tests/test_flatpak_local_api_client.py
@@ -14,6 +14,7 @@ from flatpak_client import (
     InvalidJsonError,
     InvalidResponseError,
     LocalApiClient,
+    LocalApiClientError,
     RedirectRejectedError,
 )
 
@@ -281,6 +282,7 @@ def test_client_exposes_only_reviewed_routes_and_no_generic_public_request_metho
         "adapter_readiness",
         "config",
         "health",
+        "portal_request",
         "preflight_report",
         "repair_network",
         "restart_service",
@@ -306,6 +308,83 @@ def test_client_exposes_only_reviewed_routes_and_no_generic_public_request_metho
             "update_config",
         }
     )
+
+
+def test_portal_request_is_exact_route_bounded_and_keeps_token_native():
+    secret = "native-broker-only-token"
+    transport = FakeTransport(
+        HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=_envelope({"saved": True}, result_code="config_saved"),
+        )
+    )
+    client = LocalApiClient(token=secret, transport=transport)
+
+    response = client.portal_request(
+        "/v1/config",
+        method="POST",
+        body={"config": {"enable_internet": True}},
+    )
+
+    request = transport.requests[0]
+    assert response.status == 200
+    assert request.url == "http://127.0.0.1:8732/v1/config"
+    assert request.method == "POST"
+    assert json.loads(request.body) == {"config": {"enable_internet": True}}
+    assert request.headers["X-Api-Token"] == secret
+    assert secret not in repr(request)
+    assert secret not in repr(response)
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "body"),
+    (
+        ("https://example.com/v1/status", "GET", None),
+        ("/v1/unknown", "GET", None),
+        ("/v1/status", "POST", {}),
+        ("/v1/status", "GET", {}),
+        ("/v1/config", "DELETE", None),
+    ),
+)
+def test_portal_request_rejects_unreviewed_routes_and_shapes(path, method, body):
+    client = LocalApiClient(
+        token="native-broker-token",
+        transport=FakeTransport([]),
+    )
+
+    with pytest.raises(LocalApiClientError):
+        client.portal_request(path, method=method, body=body)
+
+
+@pytest.mark.parametrize(
+    "response",
+    (
+        HttpResponse(
+            status=200,
+            body=b'{"value":"native-reflection-guard-token"}',
+        ),
+        HttpResponse(
+            status=200,
+            headers={
+                "Content-Disposition": (
+                    'attachment; filename="native-reflection-guard-token.zip"'
+                )
+            },
+        ),
+    ),
+)
+def test_portal_request_discards_any_daemon_token_reflection(response):
+    secret = "native-reflection-guard-token"
+    client = LocalApiClient(
+        token=secret,
+        transport=FakeTransport(response),
+    )
+
+    with pytest.raises(InvalidResponseError) as exc_info:
+        client.portal_request("/v1/status", method="GET")
+
+    assert secret not in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flatpak_token_pairing.py
+++ b/tests/test_flatpak_token_pairing.py
@@ -257,6 +257,7 @@ def test_pairing_flow_wires_only_health_and_adapter_readiness():
         "adapter_readiness",
         "config",
         "health",
+        "portal_request",
         "preflight_report",
         "repair_network",
         "restart_service",

--- a/tests/test_flatpak_tray_control.py
+++ b/tests/test_flatpak_tray_control.py
@@ -1126,8 +1126,8 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
         def __init__(self):
             self.supplied = []
 
-        def save_or_replace(self, token, *, save_securely):
-            self.supplied.append(("save", bool(token), save_securely))
+        def authenticate_and_save(self, token, *, save_securely):
+            self.supplied.append(("authenticate", bool(token), save_securely))
             return type(
                 "Result",
                 (),
@@ -1142,6 +1142,7 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
             return FirstRunResult(FirstRunState.TOKEN_ACCEPTED)
 
     authentication = Authentication()
+    portal_refreshes = []
     runtime = TrayRuntime(
         application=FakeApplication(),
         lifecycle=WindowLifecycleController(
@@ -1156,6 +1157,7 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
         Gio=object(),
         GLib=object(),
         open_diagnostics=lambda: None,
+        on_auth_changed=lambda: portal_refreshes.append("refresh"),
     )
     refreshes = []
     runtime.refresh_after_auth_change = lambda: refreshes.append("refresh")
@@ -1167,15 +1169,17 @@ def test_saving_and_testing_authentication_refreshes_status_without_leakage():
     runtime._auth_save(entry, save_securely, status)
     assert entry.text == ""
     assert refreshes == ["refresh"]
+    assert portal_refreshes == ["refresh"]
     assert secret not in status.text
 
     entry.text = secret
     runtime._auth_test(entry, status)
     assert entry.text == ""
     assert refreshes == ["refresh", "refresh"]
+    assert portal_refreshes == ["refresh", "refresh"]
     assert status.text == "Authentication succeeded."
     assert authentication.supplied == [
-        ("save", True, True),
+        ("authenticate", True, True),
         ("test", True),
     ]
     assert secret not in repr(authentication.supplied)

--- a/tests/test_flatpak_wallet.py
+++ b/tests/test_flatpak_wallet.py
@@ -1,13 +1,12 @@
 import inspect
-import json
 from pathlib import Path
 import sys
 
 
 from flatpak_app import build_smoke_payload, render_smoke_json
-from flatpak_app.app import WebPortalAuthBridge
 from flatpak_client import (
     ApiResponse,
+    AuthenticationError,
     AuthenticationController,
     FirstRunState,
     SECRET_ATTRIBUTES,
@@ -75,49 +74,6 @@ def client_factory(*, token):
 
         raise LocalApiClientError("invalid token")
     return AuthClient(token)
-
-
-class FixedOriginView:
-    def get_uri(self):
-        return "http://127.0.0.1:8732/ui"
-
-
-class MessageValue:
-    def __init__(self, message):
-        self.value = json.dumps(message)
-
-    @classmethod
-    def new_string(cls, _context, value):
-        instance = cls.__new__(cls)
-        instance.value = value
-        return instance
-
-    def get_context(self):
-        return object()
-
-    def is_string(self):
-        return True
-
-    def to_string(self):
-        return self.value
-
-
-class MessageReply:
-    def __init__(self):
-        self.value = None
-
-    def return_value(self, value):
-        self.value = value.value
-
-
-def _accepted_portal_message(token):
-    return MessageValue(
-        {
-            "version": 1,
-            "type": "auth_accepted",
-            "token": token,
-        }
-    )
 
 
 def test_manual_token_is_retained_only_in_memory_when_not_saved():
@@ -195,52 +151,117 @@ def test_wallet_unavailable_falls_back_to_memory_only_with_fixed_message():
     assert controller.token_for_operation() == secret
 
 
-def test_accepted_portal_token_is_saved_to_available_app_wallet():
-    secret = "accepted-portal-wallet-value"
+def test_window_auth_save_is_loaded_and_validated_by_tray_controller():
+    secret = "window-saved-wallet-value"
     wallet = FakeWallet()
-    controller = AuthenticationController(
+    window = AuthenticationController(
         wallet=wallet,
         client_factory=client_factory,
     )
-    bridge = WebPortalAuthBridge(controller)
-    reply = MessageReply()
+    tray = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
 
-    assert bridge.handle_message(
-        FixedOriginView(),
-        _accepted_portal_message(secret),
-        reply,
-    ) is True
+    saved = window.authenticate_and_save(secret, save_securely=True)
+    tray_state = tray.refresh_saved_auth()
 
-    assert reply.value == "accepted"
+    assert saved.code == "saved_securely"
     assert wallet.stored == [secret]
-    assert controller.token_for_operation() == secret
-    assert controller.securely_saved is True
-    assert secret not in repr(bridge)
-    assert secret not in repr(controller)
+    assert tray_state.state is FirstRunState.TOKEN_ACCEPTED
+    assert tray.securely_saved is True
+    assert secret not in repr(saved)
+    assert secret not in repr(tray_state)
 
 
-def test_accepted_portal_token_falls_back_to_current_process_memory():
-    secret = "accepted-portal-memory-value"
-    wallet = FakeWallet(available=False)
-    controller = AuthenticationController(
+def test_tray_auth_save_is_loaded_and_validated_by_window_controller():
+    secret = "tray-saved-wallet-value"
+    wallet = FakeWallet()
+    tray = AuthenticationController(
         wallet=wallet,
         client_factory=client_factory,
     )
-    bridge = WebPortalAuthBridge(controller)
-    reply = MessageReply()
+    window = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
 
-    assert bridge.handle_message(
-        FixedOriginView(),
-        _accepted_portal_message(secret),
-        reply,
-    ) is True
+    saved = tray.authenticate_and_save(secret, save_securely=True)
+    window_state = window.refresh_saved_auth()
 
-    assert reply.value == "accepted"
-    assert wallet.stored == []
-    assert controller.token_for_operation() == secret
-    assert controller.securely_saved is False
-    assert secret not in repr(bridge)
+    assert saved.code == "saved_securely"
+    assert wallet.stored == [secret]
+    assert window_state.state is FirstRunState.TOKEN_ACCEPTED
+    assert window.securely_saved is True
+    assert secret not in repr(saved)
+    assert secret not in repr(window_state)
+
+
+def test_cross_process_clear_and_replace_are_detected_from_same_wallet():
+    wallet = FakeWallet(token="first-shared-value")
+    window = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+    tray = AuthenticationController(
+        wallet=wallet,
+        client_factory=client_factory,
+    )
+
+    assert window.refresh_saved_auth().state is FirstRunState.TOKEN_ACCEPTED
+    assert tray.clear().code == "cleared"
+    assert (
+        window.refresh_saved_auth().state
+        is FirstRunState.DAEMON_REACHABLE_UNPAIRED
+    )
+
+    saved = tray.authenticate_and_save(
+        "replacement-shared-value",
+        save_securely=True,
+    )
+
+    assert saved.code == "saved_securely"
+    assert window.refresh_saved_auth().state is FirstRunState.TOKEN_ACCEPTED
+
+
+def test_invalid_saved_token_is_cleared_once_and_validation_does_not_loop():
+    secret = "stale-wallet-value"
+    wallet = FakeWallet(token=secret)
+
+    class RejectingFactory:
+        def __init__(self):
+            self.adapter_calls = 0
+
+        def __call__(self, *, token):
+            factory = self
+
+            class Client:
+                def health(self):
+                    return True
+
+                def adapter_readiness(self):
+                    factory.adapter_calls += 1
+                    raise AuthenticationError(401)
+
+            return Client()
+
+    factory = RejectingFactory()
+    controller = AuthenticationController(
+        wallet=wallet,
+        client_factory=factory,
+    )
+
+    first = controller.refresh_saved_auth()
+    second = controller.refresh_saved_auth()
+
+    assert first.state is FirstRunState.TOKEN_REJECTED
+    assert second.state is FirstRunState.DAEMON_REACHABLE_UNPAIRED
+    assert factory.adapter_calls == 1
+    assert wallet.clear_calls == 1
+    assert wallet.token is None
+    assert controller.token_for_operation() is None
     assert secret not in repr(controller)
+    assert secret not in repr(first)
 
 
 def test_memory_only_replace_reports_when_old_wallet_entry_cannot_be_removed():
@@ -373,9 +394,14 @@ def test_authentication_controller_has_no_implicit_print_or_export_method():
     }
 
     assert {
+        "authenticate_and_save",
+        "authentication_state",
         "clear",
         "copy_token",
+        "discard_rejected_auth",
+        "refresh_saved_auth",
         "reveal_token",
+        "request_local_api",
         "save_or_replace",
         "test_authentication",
         "token_for_operation",

--- a/tests/test_ui_login_splash_contract.py
+++ b/tests/test_ui_login_splash_contract.py
@@ -10,16 +10,17 @@ class TestUiLoginSplashContract(unittest.TestCase):
         self.assertRegex(src, r"function\s+renderLoginSplash\s*\(")
 
         startup_guard = re.compile(
-            r"const\s+companionBridge\s*=\s*companionAuthBridgeAvailable\(\)\s*;"
-            r".*?if\s*\(\s*companionBridge\s*\).*?"
-            r"requestCompanionAuthToken\(\).*?"
-            r"else\s*\{\s*tok\s*=\s*migrateLegacyToken\(\)\s*\|\|\s*getStoredToken\(\)\s*;"
+            r"if\s*\(\s*companionAuthBridgeAvailable\(\)\s*\)\s*\{"
+            r".*?startCompanionAuthRefresh\(\)\s*;"
+            r".*?syncCompanionAuthState\(\)\s*;"
+            r".*?return\s*;"
+            r".*?const\s+tok\s*=\s*getToken\(\)\s*;"
             r".*?if\s*\(\s*!tok\s*\)\s*\{\s*renderLoginSplash\(\)\s*;\s*return\s*;",
             re.S,
         )
         self.assertIsNotNone(startup_guard.search(src))
 
-    def test_companion_auth_bridge_uses_fixed_origin_memory_only_contract(self):
+    def test_companion_auth_bridge_uses_fixed_origin_native_broker_contract(self):
         src = Path("assets/ui.js").read_text(encoding="utf-8")
 
         self.assertIn(
@@ -31,14 +32,30 @@ class TestUiLoginSplashContract(unittest.TestCase):
             src,
         )
         self.assertIn("path !== '/ui'", src)
-        self.assertIn("!path.startsWith('/assets/')", src)
-        self.assertIn("type: 'token_request'", src)
-        self.assertIn("type: 'auth_accepted'", src)
+        self.assertIn("path !== '/ui/'", src)
+        self.assertNotIn("path.startsWith('/assets/')", src)
+        self.assertIn("type: 'auth_status'", src)
+        self.assertIn("type: 'auth_prompt'", src)
+        self.assertIn("type: 'api_request'", src)
         self.assertIn("type: 'auth_cleared'", src)
-        self.assertIn("companionSessionToken = token;", src)
-        self.assertIn(
-            "clearStoredTokenEverywhere({ notifyCompanion: false });",
-            src,
-        )
+        self.assertNotIn("type: 'token_request'", src)
+        self.assertNotIn("type: 'auth_accepted'", src)
+        self.assertNotIn("companionSessionToken", src)
         self.assertNotIn("COMPANION_AUTH_ORIGIN + '?'", src)
         self.assertNotIn("COMPANION_AUTH_ORIGIN + '#'", src)
+
+    def test_tokens_are_never_persisted_in_browser_storage(self):
+        src = Path("assets/ui.js").read_text(encoding="utf-8")
+
+        self.assertNotRegex(
+            src,
+            r"(?:localStorage|sessionStorage|STORE)\.setItem\([^)]*(?:token|TOKEN)",
+        )
+        self.assertNotRegex(
+            src,
+            r"(?:localStorage|sessionStorage|STORE)\.getItem\([^)]*(?:token|TOKEN)",
+        )
+        self.assertNotIn("indexedDB", src)
+        self.assertNotIn("IndexedDB", src)
+        self.assertIn("let browserSessionToken = '';", src)
+        self.assertIn("browserSessionToken = (v || '').trim();", src)

--- a/tests/test_ui_preflight_contract.py
+++ b/tests/test_ui_preflight_contract.py
@@ -784,6 +784,7 @@ async function scenarioCompanionAuth() {
     const environment = createEnvironment();
     environment.context.__bridgeMessages = [];
     environment.context.__bootstraps = 0;
+    environment.context.__nativeAuthenticated = false;
     environment.run(`
       window.location.origin = 'http://127.0.0.1:8732';
       window.location.pathname = '/ui';
@@ -793,7 +794,27 @@ async function scenarioCompanionAuth() {
             postMessage: async (raw) => {
               const message = JSON.parse(raw);
               __bridgeMessages.push(message);
-              return message.type === 'auth_accepted' ? 'accepted' : '';
+              if (message.type === 'auth_status') {
+                return JSON.stringify({
+                  authenticated: __nativeAuthenticated,
+                  code: __nativeAuthenticated ? 'token_accepted' : 'daemon_reachable_unpaired',
+                });
+              }
+              if (message.type === 'auth_prompt') return 'opened';
+              if (message.type === 'auth_cleared') {
+                __nativeAuthenticated = false;
+                return 'cleared';
+              }
+              if (message.type === 'api_request') {
+                return JSON.stringify({
+                  ok: true,
+                  status: 200,
+                  body: JSON.stringify({ result_code: 'ok', data: { phase: 'stopped' } }),
+                  body_encoding: 'text',
+                  headers: { 'content-type': 'application/json' },
+                });
+              }
+              return 'rejected';
             },
           },
         },
@@ -801,27 +822,38 @@ async function scenarioCompanionAuth() {
       bootstrapAuthenticatedUi = () => { __bootstraps += 1; };
     `);
     environment.document.getElementById('loginToken').value = secret;
-    environment.state.responses.push(responseBody({ result_code: 'ok', data: { phase: 'stopped' } }));
 
     await environment.run('submitLoginSplashToken()');
 
-    assert.strictEqual(environment.run('isAuthenticated'), true);
-    assert.strictEqual(environment.run('getToken()'), secret);
+    assert.strictEqual(environment.run('isAuthenticated'), false);
+    assert.strictEqual(environment.run('getToken()'), '');
     assert.strictEqual(environment.localStorage.getItem('vr_hotspot_token'), null);
-    assert.strictEqual(environment.context.__bootstraps, 1);
     assert.deepStrictEqual(
       Array.from(environment.context.__bridgeMessages, (message) => message.type),
-      ['auth_accepted'],
+      ['auth_prompt'],
     );
-    assert.strictEqual(environment.context.__bridgeMessages[0].version, 1);
+    assert(!JSON.stringify(environment.context.__bridgeMessages).includes(secret));
+
+    environment.context.__nativeAuthenticated = true;
+    await environment.run('syncCompanionAuthState()');
+    assert.strictEqual(environment.run('isAuthenticated'), true);
+    assert.strictEqual(environment.context.__bootstraps, 1);
+    assert.strictEqual(environment.run('getToken()'), '');
+    const apiResult = await environment.run(`api('/v1/status')`);
+    assert.strictEqual(apiResult.ok, true);
+    assert.strictEqual(apiResult.json.data.phase, 'stopped');
+    const apiMessage = environment.context.__bridgeMessages.find((message) => message.type === 'api_request');
+    assert.strictEqual(apiMessage.path, '/v1/status');
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(apiMessage, 'token'), false);
+    assert(!JSON.stringify(apiMessage).includes(secret));
 
     environment.run(`logoutToSplash('Invalid token');`);
     await settle();
     assert.strictEqual(environment.run('isAuthenticated'), false);
     assert.strictEqual(environment.run('getToken()'), '');
-    assert.deepStrictEqual(
-      Array.from(environment.context.__bridgeMessages, (message) => message.type),
-      ['auth_accepted', 'auth_cleared'],
+    assert.strictEqual(
+      environment.context.__bridgeMessages.at(-1).type,
+      'auth_cleared',
     );
   }
 
@@ -838,8 +870,8 @@ async function scenarioCompanionAuth() {
             postMessage: async (raw) => {
               const message = JSON.parse(raw);
               __bridgeMessages.push(message);
-              return message.type === 'token_request'
-                ? ${JSON.stringify(secret)}
+              return message.type === 'auth_status'
+                ? JSON.stringify({ authenticated: true, code: 'token_accepted' })
                 : 'rejected';
             },
           },
@@ -847,18 +879,19 @@ async function scenarioCompanionAuth() {
       };
       bootstrapAuthenticatedUi = () => { __bootstraps += 1; };
     `);
-    environment.state.responses.push(responseBody({ result_code: 'ok', data: { phase: 'running' } }));
 
     await environment.run('init()');
 
     assert.strictEqual(environment.run('isAuthenticated'), true);
-    assert.strictEqual(environment.run('getToken()'), secret);
+    assert.strictEqual(environment.run('getToken()'), '');
     assert.strictEqual(environment.localStorage.getItem('vr_hotspot_token'), null);
+    assert.strictEqual(environment.context.sessionStorage.getItem('vr_hotspot_token'), null);
     assert.strictEqual(environment.context.__bootstraps, 1);
     assert.deepStrictEqual(
       Array.from(environment.context.__bridgeMessages, (message) => message.type),
-      ['token_request'],
+      ['auth_status'],
     );
+    assert(!JSON.stringify(environment.context.__bridgeMessages).includes(secret));
   }
 }
 


### PR DESCRIPTION
# Summary
- Unify local Flatpak authentication between the Web Portal window and tray companion.
- Make the native wallet/controller the saved-auth authority.
- Replace Web-exposed token exchange with token-free native authenticated API brokering.
- Keep remote browser sessions on explicit memory-only authentication.

# Behavior
- Saved tray authentication is picked up by the Flatpak Web Portal window.
- Saved window authentication is picked up by the tray companion.
- Invalid saved tokens fail closed and are cleared or suppressed safely.
- Unsaved tokens remain process-local.
- Clearing auth returns both local Flatpak surfaces to needs-auth after refresh.

# Security boundaries
- Raw tokens are not readable by JavaScript.
- No token persistence in localStorage, sessionStorage, or IndexedDB.
- Tokens are not placed in HTML, URLs, smoke JSON, labels, tooltips, D-Bus menu labels, notifications, reprs, logs, or exceptions.
- Remote browsers cannot access the Flatpak native wallet broker.
- Reflected token bodies/headers are rejected.
- No /etc/vr-hotspot/env, /var/lib token discovery, sudo, pkexec, or helper prompt path added.
- Flatpak permissions unchanged.

# Preservation
- WebKit origin/navigation/CSP/ephemeral session/permission denial/1.75x zoom preserved.
- Stable window icon and stateful tray icon contracts preserved.
- Tray menu organization and sensitivity matrix preserved.
- Native dashboard remains absent.
- Backend/vendor/installer behavior untouched.

# Validation
- Review approved with no blockers.
- Targeted tests: 199 passed.
- Focused tests: 235 passed.
- Full suite: 905 passed, 4 subtests passed.
- Ruff passed.
- node --check assets/ui.js passed.
- git diff --check passed.
- Real release-style Flatpak build, bundle, clean reinstall, and smoke JSON passed.

# Remaining manual release check
- KDE real-credential save/pickup/clear round-trip should be performed before tagging a release.
