### PR TITLE
Add read-only ADB Dev Bridge foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Fedora, and Pop!_OS users.
 
 ### Completed v1.1.0 work in this branch
 
+- Add the read-only ADB Dev Bridge foundation for standalone VR headset
+  development: authenticated `GET /v1/devbridge/status`, `/devices`, `/adb`,
+  and `/readiness` endpoints, `vr-hotspot devbridge
+  status|scan|adb-command|logcat-command` CLI commands, an optional TCP
+  reachability probe of ADB port 5555, copyable-only `adb connect`, Wireless
+  Debugging pairing, and logcat helper commands (never executed by the
+  daemon), Unity Build & Run readiness checks with copyable next steps, and a
+  safe `vr-hotspot/devbridge.json` support-bundle section.
+
 - Add authenticated `GET /v1/adapters/readiness` endpoint for Adapter
   Intelligence v2 summaries, reason codes, Basic Mode recommendation data, and
   no-adapter responses.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ Enter the **API token** shown during installation to access the interface.
 - `POST /v1/diagnostics/ping_under_load` - Performance under load
 - `GET /v1/diagnostics/support_bundle` - Download a sanitized support bundle
 
+**ADB Dev Bridge (read-only, for standalone headset development):**
+- `GET /v1/devbridge/status` - Hotspot/subnet state, host adb presence, and
+  detected device counts
+- `GET /v1/devbridge/devices` - Devices on the hotspot with an optional ADB
+  TCP (port 5555) reachability check (`?probe=0` to skip)
+- `GET /v1/devbridge/adb` - Copyable `adb connect`/pairing/logcat commands
+  (`?ip=`, `?kind=connect|logcat|all`); the daemon never executes adb
+- `GET /v1/devbridge/readiness` - Unity Build & Run readiness checks; every
+  failed check includes a copyable next step
+- `vr-hotspot devbridge status|scan|adb-command|logcat-command` - The same
+  data through the authenticated CLI; see `docs/dev-bridge.md`
+
 ### 🔥 Firewalld Integration (SteamOS-Friendly)
 
 When `firewalld` is running, the daemon uses `firewall-cmd` (not raw nftables/iptables):

--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -36,6 +36,15 @@ from vr_hotspotd.lifecycle import (
 )
 from vr_hotspotd.engine.supervisor import get_tails
 from vr_hotspotd.diagnostics.clients import get_clients_snapshot
+from vr_hotspotd.diagnostics.devbridge import (
+    COMMAND_KIND_ALL,
+    COMMAND_KINDS,
+    collect_adb_command_report,
+    collect_devbridge_devices,
+    collect_devbridge_readiness,
+    collect_devbridge_status,
+    is_valid_ipv4,
+)
 from vr_hotspotd.diagnostics.ping import run_ping, ping_available
 from vr_hotspotd.diagnostics.load import LoadGenerator, validate_curl_url, validate_network_host
 from vr_hotspotd.diagnostics.udp_latency import run_udp_latency_test
@@ -1079,6 +1088,26 @@ class APIHandler(BaseHTTPRequestHandler):
         try:
             files.append(
                 self._support_bundle_json_file(
+                    "vr-hotspot/devbridge.json",
+                    "vr hotspot dev bridge",
+                    collect_devbridge_status(),
+                )
+            )
+        except Exception as exc:
+            warnings.append("devbridge_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/devbridge.json",
+                    "vr hotspot dev bridge",
+                    {},
+                    status=CollectorStatus.FAILED,
+                    error_summary=f"dev bridge status unavailable: {exc}",
+                )
+            )
+
+        try:
+            files.append(
+                self._support_bundle_json_file(
                     "vr-hotspot/vendor_provenance.json",
                     "vendor provenance",
                     collect_vendor_provenance(generated_at=generated_at),
@@ -1328,6 +1357,63 @@ class APIHandler(BaseHTTPRequestHandler):
         if path == "/v1/diagnostics/preflight":
             report = collect_preflight_report(config=load_config_snapshot())
             self._respond(200, self._envelope(correlation_id=cid, data=report))
+            return
+
+        if path == "/v1/devbridge/status":
+            self._respond(
+                200,
+                self._envelope(correlation_id=cid, data=collect_devbridge_status()),
+            )
+            return
+
+        if path == "/v1/devbridge/devices":
+            probe = self._qbool(qs, "probe", True)
+            self._respond(
+                200,
+                self._envelope(
+                    correlation_id=cid,
+                    data=collect_devbridge_devices(probe_adb=probe),
+                ),
+            )
+            return
+
+        if path == "/v1/devbridge/adb":
+            ip_param = (qs.get("ip") or "").strip()
+            kind = (qs.get("kind") or COMMAND_KIND_ALL).strip().lower()
+            if kind not in COMMAND_KINDS:
+                self._respond(
+                    400,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code="invalid_request",
+                        warnings=["invalid_kind_parameter"],
+                        data={"allowed_kinds": list(COMMAND_KINDS)},
+                    ),
+                )
+                return
+            if ip_param and not is_valid_ipv4(ip_param):
+                self._respond(
+                    400,
+                    self._envelope(
+                        correlation_id=cid,
+                        result_code="invalid_request",
+                        warnings=["invalid_ip_parameter"],
+                    ),
+                )
+                return
+            report = collect_adb_command_report(ip=ip_param or None, kind=kind)
+            self._respond(200, self._envelope(correlation_id=cid, data=report))
+            return
+
+        if path == "/v1/devbridge/readiness":
+            probe = self._qbool(qs, "probe", True)
+            self._respond(
+                200,
+                self._envelope(
+                    correlation_id=cid,
+                    data=collect_devbridge_readiness(probe_adb=probe),
+                ),
+            )
             return
 
         if path == "/v1/diagnostics/support_bundle":

--- a/backend/vr_hotspotd/cli.py
+++ b/backend/vr_hotspotd/cli.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import argparse
 import errno
 import getpass
+import ipaddress
 import json
 import os
 from pathlib import Path
 import sys
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit
+from urllib.parse import urlencode, urlsplit
 from urllib.request import build_opener, HTTPRedirectHandler, Request
 import uuid
 
@@ -19,6 +20,10 @@ import uuid
 DEFAULT_API_URL = "http://127.0.0.1:8732"
 DEFAULT_ENV_FILE = "/etc/vr-hotspot/env"
 PREFLIGHT_PATH = "/v1/diagnostics/preflight"
+DEVBRIDGE_STATUS_PATH = "/v1/devbridge/status"
+DEVBRIDGE_DEVICES_PATH = "/v1/devbridge/devices"
+DEVBRIDGE_ADB_PATH = "/v1/devbridge/adb"
+DEVBRIDGE_READINESS_PATH = "/v1/devbridge/readiness"
 
 _ENV_KEYS = {
     "VR_HOTSPOTD_API_TOKEN",
@@ -35,7 +40,7 @@ class CLIError(RuntimeError):
 def _redirect_error(status: int) -> CLIError:
     return CLIError(
         f"API request was redirected (HTTP {status}); redirects are not allowed for "
-        "vr-hotspot preflight."
+        "the vr-hotspot CLI."
     )
 
 
@@ -232,20 +237,23 @@ def _transport_cli_error(
     )
 
 
-def fetch_preflight_report(
+def _fetch_api_data(
     api_url: str,
+    path: str,
     *,
     token: str = "",
     timeout: float = 15.0,
+    correlation_prefix: str = "cli",
+    payload_description: str = "a response payload",
 ) -> Dict[str, Any]:
-    """Fetch and return only the canonical report from the API envelope."""
+    """Fetch one GET endpoint and return only the data from the API envelope."""
 
-    endpoint = _validated_api_url(api_url) + PREFLIGHT_PATH
+    endpoint = _validated_api_url(api_url) + path
     token = _validated_token(token)
     headers = {
         "Accept": "application/json",
         "User-Agent": "vr-hotspot-cli",
-        "X-Correlation-Id": f"cli-preflight-{uuid.uuid4()}",
+        "X-Correlation-Id": f"{correlation_prefix}-{uuid.uuid4()}",
     }
     if token:
         headers["X-Api-Token"] = token
@@ -288,13 +296,33 @@ def fetch_preflight_report(
         raise CLIError(f"The VR Hotspot API returned {safe_result_code}.")
     report = payload.get("data")
     if not isinstance(report, Mapping):
-        raise CLIError("The VR Hotspot API response did not contain a preflight report.")
+        raise CLIError(
+            f"The VR Hotspot API response did not contain {payload_description}."
+        )
     if _contains_secret(report, token):
         raise CLIError(
             "The VR Hotspot API returned a report containing the authentication token; "
             "refusing to print or export it."
         )
     return dict(report)
+
+
+def fetch_preflight_report(
+    api_url: str,
+    *,
+    token: str = "",
+    timeout: float = 15.0,
+) -> Dict[str, Any]:
+    """Fetch and return only the canonical preflight report from the API envelope."""
+
+    return _fetch_api_data(
+        api_url,
+        PREFLIGHT_PATH,
+        token=token,
+        timeout=timeout,
+        correlation_prefix="cli-preflight",
+        payload_description="a preflight report",
+    )
 
 
 def _positive_timeout(value: str) -> float:
@@ -307,21 +335,12 @@ def _positive_timeout(value: str) -> float:
     return timeout
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="vr-hotspot",
-        description="Read-only client for the VR Hotspot daemon API.",
-    )
-    commands = parser.add_subparsers(dest="command", required=True)
-    preflight_parser = commands.add_parser(
-        "preflight",
-        help="Print or export the daemon's canonical preflight diagnostics report.",
-    )
-    preflight_parser.add_argument(
+def _add_client_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
         "--api-url",
         help=f"Daemon API base URL (default: {DEFAULT_API_URL}).",
     )
-    token_group = preflight_parser.add_mutually_exclusive_group()
+    token_group = parser.add_mutually_exclusive_group()
     token_group.add_argument(
         "--token",
         metavar="TOKEN",
@@ -335,27 +354,110 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Read the API token from stdin without echoing it on an interactive terminal.",
     )
-    preflight_parser.add_argument(
+    parser.add_argument(
         "--env-file",
         default=os.environ.get("VR_HOTSPOTD_ENV_FILE", DEFAULT_ENV_FILE),
         help=f"Daemon environment file (default: {DEFAULT_ENV_FILE}).",
     )
-    preflight_parser.add_argument(
+    parser.add_argument(
         "--output",
         default="-",
         metavar="PATH",
         help=(
-            "Write canonical report JSON to a new mode-0600 PATH; existing paths and "
+            "Write the JSON result to a new mode-0600 PATH; existing paths and "
             "symlinks are refused. Use - for stdout."
         ),
     )
-    preflight_parser.add_argument(
+    parser.add_argument(
         "--timeout",
         type=_positive_timeout,
         default=15.0,
         metavar="SECONDS",
         help="HTTP request timeout (default: 15).",
     )
+
+
+def _validated_ipv4_argument(value: str) -> str:
+    try:
+        ipaddress.IPv4Address(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "must be an IPv4 address, for example 192.168.68.23"
+        ) from exc
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vr-hotspot",
+        description="Read-only client for the VR Hotspot daemon API.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    preflight_parser = commands.add_parser(
+        "preflight",
+        help="Print or export the daemon's canonical preflight diagnostics report.",
+    )
+    _add_client_arguments(preflight_parser)
+
+    devbridge_parser = commands.add_parser(
+        "devbridge",
+        help=(
+            "Read-only ADB Dev Bridge helpers for standalone VR headset development. "
+            "Never executes adb; only prints copyable commands."
+        ),
+    )
+    devbridge_commands = devbridge_parser.add_subparsers(
+        dest="devbridge_command",
+        required=True,
+    )
+
+    devbridge_status_parser = devbridge_commands.add_parser(
+        "status",
+        help="Print the Dev Bridge status: hotspot state, subnet, and detected devices.",
+    )
+    _add_client_arguments(devbridge_status_parser)
+
+    devbridge_scan_parser = devbridge_commands.add_parser(
+        "scan",
+        help=(
+            "Discover devices on the hotspot network and check ADB TCP reachability "
+            "on port 5555."
+        ),
+    )
+    _add_client_arguments(devbridge_scan_parser)
+    devbridge_scan_parser.add_argument(
+        "--no-probe",
+        action="store_true",
+        help="Skip the TCP reachability check on the ADB port.",
+    )
+
+    devbridge_adb_parser = devbridge_commands.add_parser(
+        "adb-command",
+        help=(
+            "Print copyable adb connect and Wireless Debugging pairing commands; "
+            "nothing is executed."
+        ),
+    )
+    _add_client_arguments(devbridge_adb_parser)
+    devbridge_adb_parser.add_argument(
+        "--ip",
+        type=_validated_ipv4_argument,
+        metavar="IPV4",
+        help="Target headset IPv4 address to generate commands for.",
+    )
+
+    devbridge_logcat_parser = devbridge_commands.add_parser(
+        "logcat-command",
+        help="Print copyable logcat helper commands; logcat is never collected for you.",
+    )
+    _add_client_arguments(devbridge_logcat_parser)
+    devbridge_logcat_parser.add_argument(
+        "--ip",
+        type=_validated_ipv4_argument,
+        metavar="IPV4",
+        help="Target headset IPv4 address to generate commands for.",
+    )
+
     return parser
 
 
@@ -413,7 +515,7 @@ def _write_new_private_file(path: Path, rendered: str, *, token: str) -> None:
         raise write_error
 
 
-def _run_preflight(args: argparse.Namespace) -> int:
+def _resolve_client_settings(args: argparse.Namespace) -> Tuple[str, str]:
     settings = _load_client_settings(Path(args.env_file))
     api_url = _validated_api_url(args.api_url) if args.api_url else _api_url_from_settings(settings)
     if args.token_stdin:
@@ -422,7 +524,16 @@ def _run_preflight(args: argparse.Namespace) -> int:
         token = args.token
     else:
         token = settings.get("VR_HOTSPOTD_API_TOKEN", "")
-    report = fetch_preflight_report(api_url, token=token, timeout=args.timeout)
+    return api_url, token
+
+
+def _emit_json_result(
+    args: argparse.Namespace,
+    report: Mapping[str, Any],
+    *,
+    token: str,
+    description: str,
+) -> int:
     rendered = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
 
     if args.output == "-":
@@ -432,8 +543,57 @@ def _run_preflight(args: argparse.Namespace) -> int:
     output_path = Path(args.output)
     _write_new_private_file(output_path, rendered, token=token)
     safe_output_path = _redacted_error_text(output_path, token)
-    sys.stderr.write(f"Wrote canonical preflight report to {safe_output_path}\n")
+    sys.stderr.write(f"Wrote {description} to {safe_output_path}\n")
     return 0
+
+
+def _run_preflight(args: argparse.Namespace) -> int:
+    api_url, token = _resolve_client_settings(args)
+    report = fetch_preflight_report(api_url, token=token, timeout=args.timeout)
+    return _emit_json_result(
+        args,
+        report,
+        token=token,
+        description="canonical preflight report",
+    )
+
+
+def _devbridge_request(args: argparse.Namespace) -> Tuple[str, str, str]:
+    """Return (path, correlation prefix, payload description) for a devbridge command."""
+
+    subcommand = args.devbridge_command
+    if subcommand == "status":
+        return DEVBRIDGE_STATUS_PATH, "cli-devbridge-status", "a Dev Bridge status report"
+    if subcommand == "scan":
+        path = DEVBRIDGE_DEVICES_PATH
+        if args.no_probe:
+            path += "?" + urlencode({"probe": "0"})
+        return path, "cli-devbridge-scan", "a Dev Bridge device scan"
+    if subcommand in ("adb-command", "logcat-command"):
+        kind = "connect" if subcommand == "adb-command" else "logcat"
+        query = {"kind": kind}
+        if args.ip:
+            query["ip"] = args.ip
+        return (
+            DEVBRIDGE_ADB_PATH + "?" + urlencode(query),
+            f"cli-devbridge-{kind}",
+            "Dev Bridge copyable commands",
+        )
+    raise CLIError(f"unknown devbridge command: {subcommand}")
+
+
+def _run_devbridge(args: argparse.Namespace) -> int:
+    api_url, token = _resolve_client_settings(args)
+    path, correlation_prefix, description = _devbridge_request(args)
+    report = _fetch_api_data(
+        api_url,
+        path,
+        token=token,
+        timeout=args.timeout,
+        correlation_prefix=correlation_prefix,
+        payload_description=description,
+    )
+    return _emit_json_result(args, report, token=token, description=description)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -442,6 +602,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         if args.command == "preflight":
             return _run_preflight(args)
+        if args.command == "devbridge":
+            return _run_devbridge(args)
     except CLIError as exc:
         parser.exit(1, f"vr-hotspot: error: {exc}\n")
     parser.error(f"unknown command: {args.command}")

--- a/backend/vr_hotspotd/diagnostics/devbridge.py
+++ b/backend/vr_hotspotd/diagnostics/devbridge.py
@@ -1,0 +1,849 @@
+"""Read-only ADB Dev Bridge discovery, command generation, and readiness.
+
+This module never executes adb and never mutates headset or host state. The
+only network interaction is an optional TCP connect() probe against the ADB
+TCP port so reachability can be reported. Every adb/logcat command string is
+generated for the user to copy and run themselves.
+
+Pure build_* functions consume already-collected inputs so CLI, HTTP,
+support-bundle, and future UI callers share one contract. Impure collect_*
+helpers gather those inputs from existing read-only sources (runtime state,
+config, and the connected-clients snapshot) and never raise.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import shutil
+import socket
+import time
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+from vr_hotspotd.config import load_config_snapshot, validate_network_config
+from vr_hotspotd.diagnostics.clients import get_clients_snapshot
+from vr_hotspotd.state import load_state
+
+
+DEVBRIDGE_SCHEMA_VERSION = 1
+ADB_TCP_PORT = 5555
+ADB_PROBE_TIMEOUT_S = 0.5
+
+HEADSET_IP_PLACEHOLDER = "<HEADSET_IP>"
+PAIRING_PORT_PLACEHOLDER = "<PAIRING_PORT>"
+PAIRING_CODE_PLACEHOLDER = "<PAIRING_CODE>"
+
+COMMAND_KIND_ALL = "all"
+COMMAND_KIND_CONNECT = "connect"
+COMMAND_KIND_LOGCAT = "logcat"
+COMMAND_KINDS = (COMMAND_KIND_ALL, COMMAND_KIND_CONNECT, COMMAND_KIND_LOGCAT)
+
+READINESS_READY = "ready"
+READINESS_PARTIAL = "partial"
+READINESS_NOT_READY = "not_ready"
+
+CHECK_PASS = "pass"
+CHECK_WARNING = "warning"
+CHECK_FAIL = "fail"
+CHECK_SKIPPED = "skipped"
+CHECK_UNKNOWN = "unknown"
+
+LIKELIHOOD_LIKELY = "likely_headset"
+LIKELIHOOD_UNKNOWN = "unknown"
+
+_HOSTNAME_VENDOR_HINTS = (
+    ("quest", "Meta Quest"),
+    ("oculus", "Meta Quest"),
+    ("eureka", "Meta Quest"),
+    ("pico", "Pico"),
+    ("vive", "HTC Vive"),
+    ("focus", "HTC Vive Focus"),
+    ("pimax", "Pimax"),
+    ("lynx", "Lynx"),
+)
+
+_READ_ONLY_NOTES = (
+    "Dev Bridge is read-only: VR Hotspot never executes adb and never changes "
+    "headset or host developer settings.",
+    "Copy the generated commands into your own terminal to act on them.",
+)
+
+_START_HOTSPOT_COMMAND = (
+    'curl -sS -X POST -H "X-Api-Token: $VR_HOTSPOTD_API_TOKEN" '
+    "http://127.0.0.1:8732/v1/start"
+)
+
+_ADB_INSTALL_HINT = (
+    "Install the Android platform tools: package android-tools on Arch/SteamOS, "
+    "adb on Debian/Ubuntu, android-tools on Fedora."
+)
+
+
+def classify_headset_hostname(hostname: Optional[str]) -> Dict[str, Optional[str]]:
+    """Best-effort, hostname-only classification. Never authoritative."""
+
+    text = (hostname or "").lower()
+    for hint, vendor in _HOSTNAME_VENDOR_HINTS:
+        if hint in text:
+            return {"likelihood": LIKELIHOOD_LIKELY, "vendor_guess": vendor}
+    return {"likelihood": LIKELIHOOD_UNKNOWN, "vendor_guess": None}
+
+
+def subnet_cidr_from_gateway(gateway_ip: Optional[str]) -> Optional[str]:
+    if not gateway_ip:
+        return None
+    try:
+        return str(ipaddress.IPv4Network(f"{gateway_ip}/24", strict=False))
+    except ValueError:
+        return None
+
+
+def is_valid_ipv4(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        ipaddress.IPv4Address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def build_adb_connect_commands(
+    ip: Optional[str] = None,
+    *,
+    port: int = ADB_TCP_PORT,
+) -> Dict[str, str]:
+    """Copyable adb connection commands. Nothing here is ever executed."""
+
+    target = f"{ip or HEADSET_IP_PLACEHOLDER}:{port}"
+    return {
+        "connect": f"adb connect {target}",
+        "disconnect": f"adb disconnect {target}",
+        "list_devices": "adb devices -l",
+        "enable_tcpip_over_usb": f"adb tcpip {port}",
+    }
+
+
+def build_logcat_commands(
+    ip: Optional[str] = None,
+    *,
+    port: int = ADB_TCP_PORT,
+) -> Dict[str, str]:
+    """Copyable logcat helper commands. Logcat is never collected automatically."""
+
+    target = f"{ip or HEADSET_IP_PLACEHOLDER}:{port}"
+    return {
+        "follow": f"adb -s {target} logcat",
+        "unity_only": f"adb -s {target} logcat -s Unity",
+        "crash_buffer": f"adb -s {target} logcat -b crash",
+        "clear": f"adb -s {target} logcat -c",
+        "save_snapshot": f"adb -s {target} logcat -d > headset-logcat.txt",
+    }
+
+
+def build_pairing_guidance(
+    ip: Optional[str] = None,
+    *,
+    port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Wireless Debugging pairing guidance with explicit placeholders."""
+
+    pair_host = ip or HEADSET_IP_PLACEHOLDER
+    return {
+        "steps": [
+            (
+                "On the headset, enable Developer Mode (usually via the vendor's "
+                "companion app) and turn on debugging in the headset settings."
+            ),
+            (
+                "For Android 11+ Wireless Debugging: open the headset's developer "
+                "settings, enable Wireless Debugging, choose 'Pair device with "
+                "pairing code', and note the pairing port and 6-digit code shown."
+            ),
+            "Run the pair command below with the pairing port and code from the headset.",
+            (
+                f"After pairing once, use the connect command on port {port} (or the "
+                "port shown under Wireless Debugging)."
+            ),
+            (
+                "Alternative without pairing: connect the headset over USB once, "
+                f"accept the debugging prompt, run 'adb tcpip {port}', unplug USB, "
+                "then use the connect command."
+            ),
+        ],
+        "commands": {
+            "pair": (
+                f"adb pair {pair_host}:{PAIRING_PORT_PLACEHOLDER} "
+                f"{PAIRING_CODE_PLACEHOLDER}"
+            ),
+            "connect_after_pairing": f"adb connect {pair_host}:{port}",
+        },
+        "notes": [
+            "The pairing code is shown only on the headset and is never stored "
+            "or inferred by VR Hotspot.",
+        ],
+    }
+
+
+def probe_adb_tcp(
+    ip: str,
+    *,
+    port: int = ADB_TCP_PORT,
+    timeout_s: float = ADB_PROBE_TIMEOUT_S,
+) -> Dict[str, Any]:
+    """TCP connect() reachability probe. No ADB protocol bytes are exchanged."""
+
+    result: Dict[str, Any] = {
+        "tcp_port": port,
+        "checked": True,
+        "reachable": None,
+        "error": None,
+        "latency_ms": None,
+    }
+    started = time.monotonic()
+    try:
+        with socket.create_connection((ip, port), timeout=timeout_s):
+            pass
+    except socket.timeout:
+        result["reachable"] = False
+        result["error"] = "timeout"
+        return result
+    except ConnectionRefusedError:
+        result["reachable"] = False
+        result["error"] = "connection_refused"
+        return result
+    except OSError:
+        result["reachable"] = False
+        result["error"] = "unreachable"
+        return result
+    result["reachable"] = True
+    result["latency_ms"] = round((time.monotonic() - started) * 1000.0, 1)
+    return result
+
+
+def _unchecked_probe(port: int) -> Dict[str, Any]:
+    return {
+        "tcp_port": port,
+        "checked": False,
+        "reachable": None,
+        "error": None,
+        "latency_ms": None,
+    }
+
+
+def build_device_entry(
+    client: Mapping[str, Any],
+    *,
+    adb_probe: Optional[Mapping[str, Any]] = None,
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Project one connected-clients entry into the Dev Bridge device model."""
+
+    ip = client.get("ip")
+    hostname = client.get("hostname")
+    classification = classify_headset_hostname(hostname)
+
+    adb = _unchecked_probe(adb_port)
+    if isinstance(adb_probe, Mapping):
+        adb.update({key: adb_probe.get(key, adb[key]) for key in adb})
+
+    commands: Optional[Dict[str, Any]] = None
+    if is_valid_ipv4(ip):
+        commands = {
+            "connect": build_adb_connect_commands(ip, port=adb_port),
+            "logcat": build_logcat_commands(ip, port=adb_port),
+        }
+
+    return {
+        "mac": client.get("mac"),
+        "ip": ip,
+        "hostname": hostname,
+        "headset_likelihood": classification["likelihood"],
+        "headset_vendor_guess": classification["vendor_guess"],
+        "wifi": {
+            "source": client.get("source"),
+            "associated": client.get("associated"),
+            "authorized": client.get("authorized"),
+            "signal_dbm": client.get("signal_dbm"),
+            "tx_bitrate_mbps": client.get("tx_bitrate_mbps"),
+            "rx_bitrate_mbps": client.get("rx_bitrate_mbps"),
+            "connected_time_s": client.get("connected_time_s"),
+        },
+        "adb": adb,
+        "commands": commands,
+    }
+
+
+def build_devbridge_devices_report(
+    *,
+    clients_snapshot: Mapping[str, Any],
+    adb_probes: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    probe_requested: bool = True,
+    gateway_ip: Optional[str] = None,
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Pure device-scan model built from a connected-clients snapshot."""
+
+    probes = adb_probes or {}
+    clients = clients_snapshot.get("clients") or []
+    devices = [
+        build_device_entry(
+            client,
+            adb_probe=probes.get(client.get("ip")) if client.get("ip") else None,
+            adb_port=adb_port,
+        )
+        for client in clients
+        if isinstance(client, Mapping)
+    ]
+
+    return {
+        "schema_version": DEVBRIDGE_SCHEMA_VERSION,
+        "adb_tcp_port": adb_port,
+        "probe_requested": bool(probe_requested),
+        "ap_interface": clients_snapshot.get("ap_interface"),
+        "subnet_cidr": subnet_cidr_from_gateway(gateway_ip),
+        "devices": devices,
+        "summary": {
+            "devices_detected": len(devices),
+            "likely_headsets": sum(
+                1 for d in devices if d["headset_likelihood"] == LIKELIHOOD_LIKELY
+            ),
+            "adb_tcp_reachable": sum(
+                1 for d in devices if d["adb"]["reachable"] is True
+            ),
+        },
+        "warnings": list(clients_snapshot.get("warnings") or []),
+        "sources": dict(clients_snapshot.get("sources") or {}),
+        "notes": list(_READ_ONLY_NOTES),
+    }
+
+
+def build_devbridge_status(
+    *,
+    state: Mapping[str, Any],
+    config: Mapping[str, Any],
+    clients_snapshot: Mapping[str, Any],
+    host_adb_path: Optional[str],
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Pure status model; probe-free so it stays cheap."""
+
+    clients = clients_snapshot.get("clients") or []
+    likely_headsets = sum(
+        1
+        for client in clients
+        if isinstance(client, Mapping)
+        and classify_headset_hostname(client.get("hostname"))["likelihood"]
+        == LIKELIHOOD_LIKELY
+    )
+    gateway_ip = config.get("lan_gateway_ip")
+
+    return {
+        "schema_version": DEVBRIDGE_SCHEMA_VERSION,
+        "mode": "read_only",
+        "adb_tcp_port": adb_port,
+        "hotspot": {
+            "running": bool(state.get("running")),
+            "phase": state.get("phase"),
+            "adapter": state.get("adapter"),
+            "ap_interface": clients_snapshot.get("ap_interface")
+            or state.get("ap_interface"),
+            "ssid": config.get("ssid"),
+        },
+        "network": {
+            "gateway_ip": gateway_ip,
+            "subnet_cidr": subnet_cidr_from_gateway(gateway_ip),
+            "dhcp_start_ip": config.get("dhcp_start_ip"),
+            "dhcp_end_ip": config.get("dhcp_end_ip"),
+        },
+        "host_adb": {
+            "present": bool(host_adb_path),
+            "path": host_adb_path,
+        },
+        "summary": {
+            "devices_detected": len(clients),
+            "likely_headsets": likely_headsets,
+        },
+        "warnings": list(clients_snapshot.get("warnings") or []),
+        "notes": list(_READ_ONLY_NOTES),
+    }
+
+
+def build_adb_command_report(
+    *,
+    clients: Iterable[Mapping[str, Any]] = (),
+    ip: Optional[str] = None,
+    kind: str = COMMAND_KIND_ALL,
+    host_adb_path: Optional[str] = None,
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Pure copyable-command model. Never executes anything."""
+
+    if kind not in COMMAND_KINDS:
+        kind = COMMAND_KIND_ALL
+    include_connect = kind in (COMMAND_KIND_ALL, COMMAND_KIND_CONNECT)
+    include_logcat = kind in (COMMAND_KIND_ALL, COMMAND_KIND_LOGCAT)
+    warnings: List[str] = []
+
+    def _commands_for(target_ip: Optional[str]) -> Dict[str, Any]:
+        commands: Dict[str, Any] = {}
+        if include_connect:
+            commands["connect"] = build_adb_connect_commands(target_ip, port=adb_port)
+        if include_logcat:
+            commands["logcat"] = build_logcat_commands(target_ip, port=adb_port)
+        return commands
+
+    devices: List[Dict[str, Any]] = []
+    matched_requested_ip = False
+    for client in clients:
+        if not isinstance(client, Mapping):
+            continue
+        client_ip = client.get("ip")
+        if not is_valid_ipv4(client_ip):
+            continue
+        if ip and client_ip != ip:
+            continue
+        matched_requested_ip = matched_requested_ip or client_ip == ip
+        devices.append(
+            {
+                "ip": client_ip,
+                "hostname": client.get("hostname"),
+                "commands": _commands_for(client_ip),
+            }
+        )
+
+    if ip and not matched_requested_ip:
+        warnings.append("requested_ip_not_in_client_list")
+        devices.append({"ip": ip, "hostname": None, "commands": _commands_for(ip)})
+
+    report: Dict[str, Any] = {
+        "schema_version": DEVBRIDGE_SCHEMA_VERSION,
+        "kind": kind,
+        "adb_tcp_port": adb_port,
+        "host_adb": {
+            "present": bool(host_adb_path),
+            "path": host_adb_path,
+            "install_hint": None if host_adb_path else _ADB_INSTALL_HINT,
+        },
+        "devices": devices,
+        "generic": _commands_for(None),
+        "warnings": warnings,
+        "notes": list(_READ_ONLY_NOTES),
+    }
+    if include_connect:
+        report["pairing"] = build_pairing_guidance(ip, port=adb_port)
+    return report
+
+
+def _check(
+    code: str,
+    title: str,
+    status: str,
+    *,
+    detail: str,
+    next_step: Optional[str] = None,
+    next_step_command: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "code": code,
+        "title": title,
+        "status": status,
+        "detail": detail,
+        "next_step": next_step,
+        "next_step_command": next_step_command,
+    }
+
+
+def build_devbridge_readiness_report(
+    *,
+    state: Mapping[str, Any],
+    network_config_errors: Iterable[str] = (),
+    clients: Iterable[Mapping[str, Any]] = (),
+    adb_probes: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    host_adb_path: Optional[str] = None,
+    probe_requested: bool = True,
+    ssid: Optional[str] = None,
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Any]:
+    """Pure readiness model. Every failed check carries a copyable next step."""
+
+    client_list = [c for c in clients if isinstance(c, Mapping)]
+    probes = adb_probes or {}
+    config_errors = [str(e) for e in network_config_errors if str(e)]
+    running = bool(state.get("running"))
+    phase = state.get("phase")
+    ap_interface = state.get("ap_interface")
+    reachable_ips = [
+        ip
+        for ip, probe in probes.items()
+        if isinstance(probe, Mapping) and probe.get("reachable") is True
+    ]
+    checks: List[Dict[str, Any]] = []
+
+    if running:
+        checks.append(
+            _check(
+                "hotspot_running",
+                "VR Hotspot is running",
+                CHECK_PASS,
+                detail=f"The hotspot is running (phase: {phase}).",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "hotspot_running",
+                "VR Hotspot is running",
+                CHECK_FAIL,
+                detail=f"The hotspot is not running (phase: {phase}).",
+                next_step="Start the hotspot from the UI, or with the explicit API call below.",
+                next_step_command=_START_HOTSPOT_COMMAND,
+            )
+        )
+
+    if not running:
+        checks.append(
+            _check(
+                "ap_interface_present",
+                "AP interface is up",
+                CHECK_SKIPPED,
+                detail="Skipped because the hotspot is not running.",
+                next_step="Start the hotspot first.",
+                next_step_command=_START_HOTSPOT_COMMAND,
+            )
+        )
+    elif ap_interface:
+        checks.append(
+            _check(
+                "ap_interface_present",
+                "AP interface is up",
+                CHECK_PASS,
+                detail=f"Access point interface: {ap_interface}.",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "ap_interface_present",
+                "AP interface is up",
+                CHECK_FAIL,
+                detail="The hotspot reports running but no AP interface is recorded.",
+                next_step="Run the host preflight report to diagnose the access point.",
+                next_step_command="vr-hotspot preflight",
+            )
+        )
+
+    if config_errors:
+        checks.append(
+            _check(
+                "network_config_valid",
+                "Hotspot network configuration is valid",
+                CHECK_FAIL,
+                detail="Network configuration errors: " + ", ".join(config_errors) + ".",
+                next_step="Fix the LAN/DHCP settings, then re-check with the preflight report.",
+                next_step_command="vr-hotspot preflight",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "network_config_valid",
+                "Hotspot network configuration is valid",
+                CHECK_PASS,
+                detail="The fixed /24 LAN and DHCP range validate cleanly.",
+            )
+        )
+
+    if host_adb_path:
+        checks.append(
+            _check(
+                "host_adb_present",
+                "adb is installed on this computer",
+                CHECK_PASS,
+                detail=f"Found adb at {host_adb_path}.",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "host_adb_present",
+                "adb is installed on this computer",
+                CHECK_WARNING,
+                detail="adb was not found on PATH. " + _ADB_INSTALL_HINT,
+                next_step="Install the Android platform tools, then verify with the command below.",
+                next_step_command="adb version",
+            )
+        )
+
+    if not running:
+        checks.append(
+            _check(
+                "devices_detected",
+                "A headset is connected to the hotspot",
+                CHECK_SKIPPED,
+                detail="Skipped because the hotspot is not running.",
+                next_step="Start the hotspot first.",
+                next_step_command=_START_HOTSPOT_COMMAND,
+            )
+        )
+    elif client_list:
+        checks.append(
+            _check(
+                "devices_detected",
+                "A headset is connected to the hotspot",
+                CHECK_PASS,
+                detail=f"{len(client_list)} device(s) detected on the hotspot network.",
+            )
+        )
+    else:
+        ssid_text = f" '{ssid}'" if ssid else ""
+        checks.append(
+            _check(
+                "devices_detected",
+                "A headset is connected to the hotspot",
+                CHECK_WARNING,
+                detail="No devices are connected to the hotspot network yet.",
+                next_step=(
+                    f"Connect the headset to the{ssid_text} Wi-Fi network, then rescan."
+                ),
+                next_step_command="vr-hotspot devbridge scan",
+            )
+        )
+
+    if not running or not client_list:
+        checks.append(
+            _check(
+                "adb_tcp_reachable",
+                f"ADB TCP port {adb_port} is reachable on a headset",
+                CHECK_SKIPPED,
+                detail="Skipped because no connected devices were detected.",
+                next_step="Connect the headset to the hotspot, then rescan.",
+                next_step_command="vr-hotspot devbridge scan",
+            )
+        )
+    elif not probe_requested:
+        checks.append(
+            _check(
+                "adb_tcp_reachable",
+                f"ADB TCP port {adb_port} is reachable on a headset",
+                CHECK_UNKNOWN,
+                detail="The TCP reachability probe was disabled for this request.",
+                next_step="Rescan with probing enabled.",
+                next_step_command="vr-hotspot devbridge scan",
+            )
+        )
+    elif reachable_ips:
+        checks.append(
+            _check(
+                "adb_tcp_reachable",
+                f"ADB TCP port {adb_port} is reachable on a headset",
+                CHECK_PASS,
+                detail=(
+                    f"ADB TCP port {adb_port} is open on: "
+                    + ", ".join(sorted(reachable_ips))
+                    + "."
+                ),
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "adb_tcp_reachable",
+                f"ADB TCP port {adb_port} is reachable on a headset",
+                CHECK_WARNING,
+                detail=(
+                    f"No detected device is listening on TCP port {adb_port}. "
+                    "Wireless debugging is probably off, or ADB over TCP is not enabled."
+                ),
+                next_step=(
+                    "Enable Wireless Debugging on the headset, or connect it over USB "
+                    "once and enable ADB over TCP with the command below."
+                ),
+                next_step_command=f"adb tcpip {adb_port}",
+            )
+        )
+
+    unity_ready = bool(host_adb_path) and bool(reachable_ips)
+    if unity_ready:
+        first_ip = sorted(reachable_ips)[0]
+        checks.append(
+            _check(
+                "unity_build_and_run",
+                "Unity Build & Run can target the headset",
+                CHECK_PASS,
+                detail=(
+                    "Unity deploys to devices listed by 'adb devices'. Connect first, "
+                    "then confirm the headset shows as 'device' (not 'unauthorized')."
+                ),
+                next_step="Connect adb to the headset, then use Build & Run in Unity.",
+                next_step_command=f"adb connect {first_ip}:{adb_port}",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "unity_build_and_run",
+                "Unity Build & Run can target the headset",
+                CHECK_SKIPPED,
+                detail=(
+                    "Requires adb on this computer and a headset reachable on "
+                    f"TCP port {adb_port}; see the earlier checks."
+                ),
+                next_step="Resolve the failed checks above first.",
+                next_step_command=f"adb connect {HEADSET_IP_PLACEHOLDER}:{adb_port}",
+            )
+        )
+
+    statuses = [check["status"] for check in checks]
+    if CHECK_FAIL in statuses:
+        overall = READINESS_NOT_READY
+    elif CHECK_WARNING in statuses or CHECK_SKIPPED in statuses or CHECK_UNKNOWN in statuses:
+        overall = READINESS_PARTIAL
+    else:
+        overall = READINESS_READY
+
+    return {
+        "schema_version": DEVBRIDGE_SCHEMA_VERSION,
+        "overall": overall,
+        "adb_tcp_port": adb_port,
+        "probe_requested": bool(probe_requested),
+        "checks": checks,
+        "summary": {
+            status: statuses.count(status)
+            for status in (CHECK_PASS, CHECK_WARNING, CHECK_FAIL, CHECK_SKIPPED, CHECK_UNKNOWN)
+        },
+        "notes": list(_READ_ONLY_NOTES),
+    }
+
+
+def _host_adb_path() -> Optional[str]:
+    try:
+        return shutil.which("adb")
+    except Exception:
+        return None
+
+
+def _clients_snapshot(state: Mapping[str, Any]) -> Dict[str, Any]:
+    adapter = state.get("adapter")
+    try:
+        return get_clients_snapshot(
+            adapter if adapter else None,
+            ap_interface_hint=state.get("ap_interface"),
+        )
+    except Exception:
+        return {
+            "conf_dir": None,
+            "ap_interface": None,
+            "clients": [],
+            "warnings": ["clients_snapshot_failed"],
+            "sources": {"primary": None, "enrichment": []},
+        }
+
+
+def _probe_clients(
+    clients: Iterable[Mapping[str, Any]],
+    *,
+    probe: Optional[Callable[..., Dict[str, Any]]] = None,
+    adb_port: int = ADB_TCP_PORT,
+) -> Dict[str, Dict[str, Any]]:
+    probe_fn = probe or probe_adb_tcp
+    results: Dict[str, Dict[str, Any]] = {}
+    for client in clients:
+        if not isinstance(client, Mapping):
+            continue
+        ip = client.get("ip")
+        if not is_valid_ipv4(ip) or ip in results:
+            continue
+        try:
+            results[ip] = probe_fn(ip, port=adb_port)
+        except Exception:
+            results[ip] = {
+                "tcp_port": adb_port,
+                "checked": True,
+                "reachable": None,
+                "error": "probe_failed",
+                "latency_ms": None,
+            }
+    return results
+
+
+def _network_config_errors(config: Mapping[str, Any]) -> List[str]:
+    try:
+        return list(validate_network_config(config))
+    except Exception:
+        return ["network_config_validation_failed"]
+
+
+def collect_devbridge_status() -> Dict[str, Any]:
+    """Gather the probe-free Dev Bridge status. Never raises."""
+
+    state = load_state()
+    config = load_config_snapshot()
+    return build_devbridge_status(
+        state=state,
+        config=config,
+        clients_snapshot=_clients_snapshot(state),
+        host_adb_path=_host_adb_path(),
+    )
+
+
+def collect_devbridge_devices(
+    *,
+    probe_adb: bool = True,
+    probe: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Gather the device scan, optionally TCP-probing port 5555. Never raises."""
+
+    state = load_state()
+    config = load_config_snapshot()
+    snapshot = _clients_snapshot(state)
+    probes = (
+        _probe_clients(snapshot.get("clients") or [], probe=probe)
+        if probe_adb
+        else {}
+    )
+    return build_devbridge_devices_report(
+        clients_snapshot=snapshot,
+        adb_probes=probes,
+        probe_requested=probe_adb,
+        gateway_ip=config.get("lan_gateway_ip"),
+    )
+
+
+def collect_adb_command_report(
+    *,
+    ip: Optional[str] = None,
+    kind: str = COMMAND_KIND_ALL,
+) -> Dict[str, Any]:
+    """Gather copyable command sets for known devices. Never raises, never probes."""
+
+    state = load_state()
+    snapshot = _clients_snapshot(state)
+    return build_adb_command_report(
+        clients=snapshot.get("clients") or [],
+        ip=ip,
+        kind=kind,
+        host_adb_path=_host_adb_path(),
+    )
+
+
+def collect_devbridge_readiness(
+    *,
+    probe_adb: bool = True,
+    probe: Optional[Callable[..., Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Gather the readiness report, optionally TCP-probing port 5555. Never raises."""
+
+    state = load_state()
+    config = load_config_snapshot()
+    snapshot = _clients_snapshot(state)
+    clients = snapshot.get("clients") or []
+    probes = _probe_clients(clients, probe=probe) if probe_adb else {}
+    return build_devbridge_readiness_report(
+        state=state,
+        network_config_errors=_network_config_errors(config),
+        clients=clients,
+        adb_probes=probes,
+        host_adb_path=_host_adb_path(),
+        probe_requested=probe_adb,
+        ssid=config.get("ssid"),
+    )

--- a/backend/vr_hotspotd/diagnostics/support_bundle.py
+++ b/backend/vr_hotspotd/diagnostics/support_bundle.py
@@ -203,6 +203,7 @@ SUPPORT_BUNDLE_ARCHIVE_LAYOUT = (
     ArchiveFileMetadata("vr-hotspot/status.json", "vr hotspot status", "application/json"),
     ArchiveFileMetadata("vr-hotspot/adapters.json", "vr hotspot adapters", "application/json"),
     ArchiveFileMetadata("vr-hotspot/readiness.json", "vr hotspot readiness", "application/json"),
+    ArchiveFileMetadata("vr-hotspot/devbridge.json", "vr hotspot dev bridge", "application/json"),
     ArchiveFileMetadata(
         "vr-hotspot/vendor_provenance.json",
         "vendor provenance",

--- a/docs/dev-bridge.md
+++ b/docs/dev-bridge.md
@@ -1,0 +1,74 @@
+# ADB Dev Bridge (read-only foundation)
+
+The ADB Dev Bridge helps standalone VR headset developers (Unity Build & Run,
+`adb`, logcat) work over the dedicated VRhotspot network. This document covers
+the read-only foundation shipped first: discovery, reachability, copyable
+commands, and readiness checks. Web Portal and Flatpak UI surfaces build on
+these same contracts later.
+
+## Principles
+
+- **Read-only.** The daemon never executes `adb`, never mutates headset or
+  host developer settings, and never collects logcat.
+- **Copyable commands only.** Every actionable step is emitted as an explicit
+  command string for the user to run in their own terminal.
+- **No secrets.** Pairing codes are placeholders (`<PAIRING_CODE>`); they are
+  shown only on the headset and are never printed, stored, or inferred.
+- **One optional network interaction.** A plain TCP `connect()` probe against
+  ADB port 5555 reports reachability. No ADB protocol bytes are exchanged, and
+  the probe can be disabled with `?probe=0` (API) or `--no-probe` (CLI).
+
+## API surfaces
+
+All endpoints require the same API token as other `/v1` routes.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v1/devbridge/status` | Hotspot/subnet state, host `adb` presence, detected device counts. Probe-free. |
+| `GET /v1/devbridge/devices` | Devices on the hotspot network with hostname-based headset classification and optional port-5555 reachability (`?probe=0` to skip). |
+| `GET /v1/devbridge/adb` | Copyable `adb connect`, Wireless Debugging pairing, and logcat commands. Filters: `?ip=<IPv4>`, `?kind=connect\|logcat\|all`. Never probes, never executes. |
+| `GET /v1/devbridge/readiness` | Ordered readiness checks for Unity Build & Run; every non-passing check carries `next_step` text and a copyable `next_step_command`. |
+
+All payloads carry `schema_version` and are built by pure model builders in
+`backend/vr_hotspotd/diagnostics/devbridge.py`, so the CLI, HTTP API, support
+bundle, and future UI callers share one contract.
+
+## CLI surfaces
+
+The `vr-hotspot` CLI stays a read-only HTTP client of the daemon API and
+prints the endpoint's JSON data:
+
+```sh
+vr-hotspot devbridge status            # GET /v1/devbridge/status
+vr-hotspot devbridge scan              # GET /v1/devbridge/devices
+vr-hotspot devbridge scan --no-probe   # skip the port-5555 TCP check
+vr-hotspot devbridge adb-command --ip 192.168.68.23     # connect/pairing commands
+vr-hotspot devbridge logcat-command --ip 192.168.68.23  # logcat helper commands
+```
+
+The shared connection flags from `vr-hotspot preflight` apply
+(`--api-url`, `--token`/`--token-stdin`, `--env-file`, `--output`,
+`--timeout`).
+
+## Readiness checks
+
+`GET /v1/devbridge/readiness` evaluates, in order: `hotspot_running`,
+`ap_interface_present`, `network_config_valid`, `host_adb_present`,
+`devices_detected`, `adb_tcp_reachable`, and `unity_build_and_run`. Statuses
+are `pass`, `warning`, `fail`, `skipped`, or `unknown`; `overall` is `ready`,
+`partial`, or `not_ready`. Checks that depend on the hotspot being up are
+`skipped` (not failed) while it is down, and each carries a copyable next
+step.
+
+## Support bundle
+
+`vr-hotspot/devbridge.json` in the support bundle contains the probe-free Dev
+Bridge status. It passes through the standard support-bundle redaction (MAC
+addresses and public IPs are redacted) and never contains logcat output or
+pairing data.
+
+## Non-goals
+
+Dev Bridge does not replace Quest Link, SteamVR, ALVR, Virtual Desktop, or any
+PCVR streaming stack, and it is not a VR runtime. Mutating operations, if ever
+added, must be explicit and user-triggered.

--- a/docs/support-bundle.md
+++ b/docs/support-bundle.md
@@ -35,7 +35,9 @@ The implemented web support bundle is intentionally limited but useful:
   and a timestamped `vr-hotspot-support-bundle-YYYYMMDD-HHMMSS.zip` filename.
 - Current archive content includes `manifest.json`, `README.txt`,
   `vr-hotspot/version.json`, `vr-hotspot/status.json`,
-  `vr-hotspot/adapters.json`, and `vr-hotspot/readiness.json`.
+  `vr-hotspot/adapters.json`, `vr-hotspot/readiness.json`, and
+  `vr-hotspot/devbridge.json` (read-only ADB Dev Bridge status; no logcat
+  content, no pairing codes).
 - API tokens, passphrases, private keys, PSKs, emails, usernames, public IPs,
   and MAC addresses are redacted before files enter the archive.
 - The Pro web UI includes a "Download support bundle" action.
@@ -191,6 +193,7 @@ vr-hotspot/
   status.json
   adapters.json
   readiness.json
+  devbridge.json
   config.redacted.json
 wireless/
   iw-dev.txt

--- a/flatpak_client/client.py
+++ b/flatpak_client/client.py
@@ -27,6 +27,10 @@ _STATUS_WITH_LOGS_PATH = "/v1/status?include_logs=1"
 _CONFIG_PATH = "/v1/config"
 _PREFLIGHT_PATH = "/v1/diagnostics/preflight"
 _ADAPTER_READINESS_PATH = "/v1/adapters/readiness"
+_DEVBRIDGE_STATUS_PATH = "/v1/devbridge/status"
+_DEVBRIDGE_DEVICES_PATH = "/v1/devbridge/devices"
+_DEVBRIDGE_ADB_PATH = "/v1/devbridge/adb"
+_DEVBRIDGE_READINESS_PATH = "/v1/devbridge/readiness"
 _START_PATH = "/v1/start"
 _STOP_PATH = "/v1/stop"
 _RESTART_PATH = "/v1/restart"
@@ -44,6 +48,10 @@ _PORTAL_REQUEST_METHODS = {
     "/v1/adapters/readiness": frozenset({"GET"}),
     "/v1/config": frozenset({"GET", "POST"}),
     "/v1/config/reveal_passphrase": frozenset({"POST"}),
+    "/v1/devbridge/adb": frozenset({"GET"}),
+    "/v1/devbridge/devices": frozenset({"GET"}),
+    "/v1/devbridge/readiness": frozenset({"GET"}),
+    "/v1/devbridge/status": frozenset({"GET"}),
     "/v1/diagnostics/preflight": frozenset({"GET"}),
     "/v1/diagnostics/support_bundle": frozenset({"GET"}),
     "/v1/info": frozenset({"GET"}),
@@ -404,6 +412,26 @@ class LocalApiClient:
         """Fetch the daemon-owned adapter readiness model."""
 
         return self._get_api_response(_ADAPTER_READINESS_PATH)
+
+    def devbridge_status(self) -> ApiResponse:
+        """Fetch the read-only ADB Dev Bridge status."""
+
+        return self._get_api_response(_DEVBRIDGE_STATUS_PATH)
+
+    def devbridge_devices(self) -> ApiResponse:
+        """Fetch the read-only ADB Dev Bridge device scan."""
+
+        return self._get_api_response(_DEVBRIDGE_DEVICES_PATH)
+
+    def devbridge_adb_commands(self) -> ApiResponse:
+        """Fetch copyable adb/logcat commands; the daemon never executes them."""
+
+        return self._get_api_response(_DEVBRIDGE_ADB_PATH)
+
+    def devbridge_readiness(self) -> ApiResponse:
+        """Fetch the read-only ADB Dev Bridge readiness checks."""
+
+        return self._get_api_response(_DEVBRIDGE_READINESS_PATH)
 
     def status(self, *, include_logs: bool = False) -> ApiResponse:
         """Fetch current daemon-owned hotspot state with an explicit log choice."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ if str(BACKEND) not in sys.path:
 _ALLOW_REAL_SYSTEM_COMMANDS = "VR_HOTSPOT_TEST_ALLOW_REAL_SYSTEM_COMMANDS"
 _BLOCKED_SYSTEM_COMMANDS = frozenset(
     {
+        "adb",
         "nmcli",
         "iw",
         "iwctl",

--- a/tests/test_api_devbridge.py
+++ b/tests/test_api_devbridge.py
@@ -1,0 +1,196 @@
+import io
+import json
+from email.message import Message
+
+import vr_hotspotd.api as api
+from vr_hotspotd.api import APIHandler
+
+
+def _make_handler(path: str):
+    handler = APIHandler.__new__(APIHandler)
+    handler.rfile = io.BytesIO()
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.command = "GET"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"GET {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _authed_get(monkeypatch, path):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    handler = _make_handler(path)
+    handler.headers["X-Api-Token"] = "secret"
+    handler.do_GET()
+    return handler
+
+
+def test_devbridge_status_endpoint(monkeypatch):
+    sentinel = {"schema_version": 1, "mode": "read_only"}
+    monkeypatch.setattr(api, "collect_devbridge_status", lambda: sentinel)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/status")
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert set(payload) == {"correlation_id", "result_code", "warnings", "data"}
+    assert payload["result_code"] == "ok"
+    assert payload["data"] == sentinel
+
+
+def test_devbridge_devices_endpoint_probes_by_default(monkeypatch):
+    seen = {}
+
+    def fake_collect(*, probe_adb):
+        seen["probe_adb"] = probe_adb
+        return {"devices": []}
+
+    monkeypatch.setattr(api, "collect_devbridge_devices", fake_collect)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/devices")
+
+    assert handler._last_code == 200
+    assert seen["probe_adb"] is True
+    assert _response_json(handler)["data"] == {"devices": []}
+
+
+def test_devbridge_devices_endpoint_probe_can_be_disabled(monkeypatch):
+    seen = {}
+
+    def fake_collect(*, probe_adb):
+        seen["probe_adb"] = probe_adb
+        return {"devices": []}
+
+    monkeypatch.setattr(api, "collect_devbridge_devices", fake_collect)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/devices?probe=0")
+
+    assert handler._last_code == 200
+    assert seen["probe_adb"] is False
+
+
+def test_devbridge_adb_endpoint_passes_ip_and_kind(monkeypatch):
+    seen = {}
+
+    def fake_collect(*, ip, kind):
+        seen["ip"] = ip
+        seen["kind"] = kind
+        return {"kind": kind}
+
+    monkeypatch.setattr(api, "collect_adb_command_report", fake_collect)
+
+    handler = _authed_get(
+        monkeypatch, "/v1/devbridge/adb?ip=192.168.68.23&kind=logcat"
+    )
+
+    assert handler._last_code == 200
+    assert seen == {"ip": "192.168.68.23", "kind": "logcat"}
+    assert _response_json(handler)["data"] == {"kind": "logcat"}
+
+
+def test_devbridge_adb_endpoint_defaults(monkeypatch):
+    seen = {}
+
+    def fake_collect(*, ip, kind):
+        seen["ip"] = ip
+        seen["kind"] = kind
+        return {}
+
+    monkeypatch.setattr(api, "collect_adb_command_report", fake_collect)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/adb")
+
+    assert handler._last_code == 200
+    assert seen == {"ip": None, "kind": "all"}
+
+
+def test_devbridge_adb_endpoint_rejects_invalid_ip(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "collect_adb_command_report",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("collector must not run for invalid parameters")
+        ),
+    )
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/adb?ip=not-an-ip")
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == "invalid_request"
+    assert payload["warnings"] == ["invalid_ip_parameter"]
+
+
+def test_devbridge_adb_endpoint_rejects_invalid_kind(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "collect_adb_command_report",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("collector must not run for invalid parameters")
+        ),
+    )
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/adb?kind=bogus")
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == "invalid_request"
+    assert payload["warnings"] == ["invalid_kind_parameter"]
+    assert payload["data"]["allowed_kinds"] == ["all", "connect", "logcat"]
+
+
+def test_devbridge_readiness_endpoint(monkeypatch):
+    seen = {}
+
+    def fake_collect(*, probe_adb):
+        seen["probe_adb"] = probe_adb
+        return {"overall": "ready"}
+
+    monkeypatch.setattr(api, "collect_devbridge_readiness", fake_collect)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/readiness")
+
+    assert handler._last_code == 200
+    assert seen["probe_adb"] is True
+    assert _response_json(handler)["data"] == {"overall": "ready"}
+
+
+def test_devbridge_endpoints_require_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    for name in (
+        "collect_devbridge_status",
+        "collect_devbridge_devices",
+        "collect_adb_command_report",
+        "collect_devbridge_readiness",
+    ):
+        monkeypatch.setattr(
+            api,
+            name,
+            lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("unauthorized requests must not run collectors")
+            ),
+        )
+
+    for path in (
+        "/v1/devbridge/status",
+        "/v1/devbridge/devices",
+        "/v1/devbridge/adb",
+        "/v1/devbridge/readiness",
+    ):
+        handler = _make_handler(path)
+        handler.do_GET()
+        assert handler._last_code == 401, path
+        assert _response_json(handler)["result_code"] == "unauthorized"

--- a/tests/test_api_support_bundle.py
+++ b/tests/test_api_support_bundle.py
@@ -78,6 +78,16 @@ def _stub_bundle_sources(monkeypatch):
     )
     monkeypatch.setattr(
         api,
+        "collect_devbridge_status",
+        lambda: {
+            "schema_version": 1,
+            "mode": "read_only",
+            "adb_tcp_port": 5555,
+            "host_adb": {"present": False, "path": None},
+        },
+    )
+    monkeypatch.setattr(
+        api,
         "collect_vendor_provenance",
         lambda **kwargs: {
             "report_schema_version": 1,
@@ -145,6 +155,9 @@ def test_support_bundle_returns_zip_headers_and_required_members(monkeypatch):
     assert headers["content-disposition"].endswith(".zip\"")
     assert "manifest.json" in members
     assert "README.txt" in members
+    assert "vr-hotspot/devbridge.json" in members
+    devbridge_member = json.loads(members["vr-hotspot/devbridge.json"].decode("utf-8"))
+    assert devbridge_member["mode"] == "read_only"
     bundle_manifest = json.loads(members["manifest.json"].decode("utf-8"))
     vendor_provenance = json.loads(
         members["vr-hotspot/vendor_provenance.json"].decode("utf-8")

--- a/tests/test_cli_devbridge.py
+++ b/tests/test_cli_devbridge.py
@@ -1,0 +1,194 @@
+import json
+
+import pytest
+
+from vr_hotspotd import cli
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status=200):
+        self.status = status
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+@pytest.fixture(autouse=True)
+def clear_cli_environment(monkeypatch):
+    for key in (*cli._ENV_KEYS, "VR_HOTSPOTD_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _mocked_open(monkeypatch, data, seen):
+    def open_request(request, *, timeout):
+        seen["method"] = request.get_method()
+        seen["url"] = request.full_url
+        seen["headers"] = {key.lower(): value for key, value in request.header_items()}
+        seen["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "correlation_id": "test-cid",
+                "result_code": "ok",
+                "warnings": [],
+                "data": data,
+            }
+        )
+
+    monkeypatch.setattr(cli, "_open_preflight_request", open_request)
+
+
+def _missing_env_args(tmp_path):
+    return ["--env-file", str(tmp_path / "missing-env")]
+
+
+def _run(monkeypatch, tmp_path, data, argv):
+    seen = {}
+    _mocked_open(monkeypatch, data, seen)
+    result = cli.main(
+        [
+            "devbridge",
+            *argv,
+            "--api-url",
+            "http://127.0.0.1:9900",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+    return result, seen
+
+
+def test_devbridge_status_fetches_status_endpoint(monkeypatch, tmp_path, capsys):
+    secret = "devbridge-status-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    data = {"schema_version": 1, "mode": "read_only"}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["status"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == data
+    assert captured.err == ""
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/status"
+    assert seen["headers"]["x-api-token"] == secret
+    assert seen["headers"]["x-correlation-id"].startswith("cli-devbridge-status-")
+    assert secret not in captured.out
+
+
+def test_devbridge_scan_fetches_devices_endpoint(monkeypatch, tmp_path, capsys):
+    data = {"devices": [], "summary": {"devices_detected": 0}}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["scan"])
+
+    assert result == 0
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/devices"
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_devbridge_scan_no_probe_disables_probing(monkeypatch, tmp_path, capsys):
+    result, seen = _run(monkeypatch, tmp_path, {"devices": []}, ["scan", "--no-probe"])
+
+    assert result == 0
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/devices?probe=0"
+
+
+def test_devbridge_adb_command_targets_ip(monkeypatch, tmp_path, capsys):
+    data = {"kind": "connect", "devices": []}
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        ["adb-command", "--ip", "192.168.68.23"],
+    )
+
+    assert result == 0
+    assert seen["url"] == (
+        "http://127.0.0.1:9900/v1/devbridge/adb?kind=connect&ip=192.168.68.23"
+    )
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_devbridge_logcat_command_requests_logcat_kind(monkeypatch, tmp_path, capsys):
+    result, seen = _run(monkeypatch, tmp_path, {"kind": "logcat"}, ["logcat-command"])
+
+    assert result == 0
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb?kind=logcat"
+
+
+def test_devbridge_adb_command_rejects_invalid_ip(monkeypatch, tmp_path, capsys):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError("no request may be sent for an invalid --ip")
+
+    monkeypatch.setattr(cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "devbridge",
+                "adb-command",
+                "--ip",
+                "not-an-ip",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    assert "IPv4" in capsys.readouterr().err
+
+
+def test_devbridge_status_writes_output_file(monkeypatch, tmp_path, capsys):
+    data = {"schema_version": 1}
+    seen = {}
+    _mocked_open(monkeypatch, data, seen)
+    output_path = tmp_path / "devbridge.json"
+
+    result = cli.main(
+        [
+            "devbridge",
+            "status",
+            "--api-url",
+            "http://127.0.0.1:9900",
+            "--output",
+            str(output_path),
+            *_missing_env_args(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == ""
+    assert "Wrote" in captured.err
+    assert json.loads(output_path.read_text(encoding="utf-8")) == data
+
+
+def test_devbridge_api_error_is_reported_concisely(monkeypatch, tmp_path, capsys):
+    def open_request(request, *, timeout):
+        return _FakeResponse(
+            {"result_code": "unauthorized", "warnings": [], "data": {}},
+            status=200,
+        )
+
+    monkeypatch.setattr(cli, "_open_preflight_request", open_request)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(
+            [
+                "devbridge",
+                "status",
+                "--api-url",
+                "http://127.0.0.1:9900",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "unauthorized" in captured.err
+    assert captured.out == ""

--- a/tests/test_devbridge_model.py
+++ b/tests/test_devbridge_model.py
@@ -1,0 +1,408 @@
+import socket
+
+import pytest
+
+from vr_hotspotd.diagnostics import devbridge
+
+
+def test_classify_headset_hostname_matches_known_vendors():
+    assert devbridge.classify_headset_hostname("Quest3-abc") == {
+        "likelihood": devbridge.LIKELIHOOD_LIKELY,
+        "vendor_guess": "Meta Quest",
+    }
+    assert devbridge.classify_headset_hostname("PICO-4-Ultra")["vendor_guess"] == "Pico"
+    assert devbridge.classify_headset_hostname("laptop") == {
+        "likelihood": devbridge.LIKELIHOOD_UNKNOWN,
+        "vendor_guess": None,
+    }
+    assert devbridge.classify_headset_hostname(None)["likelihood"] == (
+        devbridge.LIKELIHOOD_UNKNOWN
+    )
+
+
+def test_subnet_cidr_from_gateway():
+    assert devbridge.subnet_cidr_from_gateway("192.168.68.1") == "192.168.68.0/24"
+    assert devbridge.subnet_cidr_from_gateway(None) is None
+    assert devbridge.subnet_cidr_from_gateway("not-an-ip") is None
+
+
+def test_adb_connect_commands_use_ip_and_port():
+    commands = devbridge.build_adb_connect_commands("192.168.68.23")
+    assert commands["connect"] == "adb connect 192.168.68.23:5555"
+    assert commands["disconnect"] == "adb disconnect 192.168.68.23:5555"
+    assert commands["list_devices"] == "adb devices -l"
+    assert commands["enable_tcpip_over_usb"] == "adb tcpip 5555"
+
+
+def test_adb_connect_commands_fall_back_to_placeholder():
+    commands = devbridge.build_adb_connect_commands(None)
+    assert commands["connect"] == "adb connect <HEADSET_IP>:5555"
+
+
+def test_logcat_commands_target_serial():
+    commands = devbridge.build_logcat_commands("192.168.68.23")
+    assert commands["follow"] == "adb -s 192.168.68.23:5555 logcat"
+    assert commands["unity_only"] == "adb -s 192.168.68.23:5555 logcat -s Unity"
+    assert commands["clear"] == "adb -s 192.168.68.23:5555 logcat -c"
+
+
+def test_pairing_guidance_uses_placeholders_and_never_secrets():
+    guidance = devbridge.build_pairing_guidance()
+    assert guidance["commands"]["pair"] == (
+        "adb pair <HEADSET_IP>:<PAIRING_PORT> <PAIRING_CODE>"
+    )
+    assert guidance["commands"]["connect_after_pairing"] == (
+        "adb connect <HEADSET_IP>:5555"
+    )
+    assert guidance["steps"]
+
+
+def test_probe_adb_tcp_reports_reachable(monkeypatch):
+    class _FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    seen = {}
+
+    def fake_create_connection(address, timeout=None):
+        seen["address"] = address
+        seen["timeout"] = timeout
+        return _FakeConnection()
+
+    monkeypatch.setattr(devbridge.socket, "create_connection", fake_create_connection)
+    result = devbridge.probe_adb_tcp("192.168.68.23")
+
+    assert seen["address"] == ("192.168.68.23", 5555)
+    assert seen["timeout"] == devbridge.ADB_PROBE_TIMEOUT_S
+    assert result["checked"] is True
+    assert result["reachable"] is True
+    assert result["error"] is None
+    assert result["latency_ms"] is not None
+
+
+@pytest.mark.parametrize(
+    "raised, expected_error",
+    [
+        (socket.timeout(), "timeout"),
+        (ConnectionRefusedError(), "connection_refused"),
+        (OSError("no route"), "unreachable"),
+    ],
+)
+def test_probe_adb_tcp_reports_failures(monkeypatch, raised, expected_error):
+    def fake_create_connection(_address, timeout=None):
+        raise raised
+
+    monkeypatch.setattr(devbridge.socket, "create_connection", fake_create_connection)
+    result = devbridge.probe_adb_tcp("192.168.68.23")
+
+    assert result["checked"] is True
+    assert result["reachable"] is False
+    assert result["error"] == expected_error
+    assert result["latency_ms"] is None
+
+
+def _snapshot(clients=(), ap_interface="x0wlan1", warnings=()):
+    return {
+        "conf_dir": None,
+        "ap_interface": ap_interface,
+        "clients": list(clients),
+        "warnings": list(warnings),
+        "sources": {"primary": "iw", "enrichment": ["dnsmasq_leases"]},
+    }
+
+
+def _client(**overrides):
+    client = {
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "ip": "192.168.68.23",
+        "hostname": "Quest3",
+        "source": "iw",
+        "associated": True,
+        "authorized": True,
+        "signal_dbm": -40,
+        "tx_bitrate_mbps": 866.7,
+        "rx_bitrate_mbps": 866.7,
+        "connected_time_s": 120,
+    }
+    client.update(overrides)
+    return client
+
+
+def test_devices_report_projects_clients_and_probes():
+    probe = {
+        "tcp_port": 5555,
+        "checked": True,
+        "reachable": True,
+        "error": None,
+        "latency_ms": 2.5,
+    }
+    report = devbridge.build_devbridge_devices_report(
+        clients_snapshot=_snapshot([_client()]),
+        adb_probes={"192.168.68.23": probe},
+        probe_requested=True,
+        gateway_ip="192.168.68.1",
+    )
+
+    assert report["schema_version"] == devbridge.DEVBRIDGE_SCHEMA_VERSION
+    assert report["subnet_cidr"] == "192.168.68.0/24"
+    assert report["summary"] == {
+        "devices_detected": 1,
+        "likely_headsets": 1,
+        "adb_tcp_reachable": 1,
+    }
+    device = report["devices"][0]
+    assert device["headset_likelihood"] == devbridge.LIKELIHOOD_LIKELY
+    assert device["headset_vendor_guess"] == "Meta Quest"
+    assert device["adb"]["reachable"] is True
+    assert device["commands"]["connect"]["connect"] == "adb connect 192.168.68.23:5555"
+    assert device["commands"]["logcat"]["follow"] == "adb -s 192.168.68.23:5555 logcat"
+
+
+def test_devices_report_without_ip_has_no_commands_and_unchecked_probe():
+    report = devbridge.build_devbridge_devices_report(
+        clients_snapshot=_snapshot([_client(ip=None, hostname=None)]),
+        adb_probes={},
+        probe_requested=False,
+        gateway_ip="192.168.68.1",
+    )
+
+    device = report["devices"][0]
+    assert device["commands"] is None
+    assert device["adb"]["checked"] is False
+    assert device["adb"]["reachable"] is None
+    assert report["probe_requested"] is False
+    assert report["summary"]["adb_tcp_reachable"] == 0
+
+
+def test_status_model_shape():
+    state = {
+        "running": True,
+        "phase": "running",
+        "adapter": "wlan1",
+        "ap_interface": "x0wlan1",
+    }
+    config = {
+        "ssid": "VR-Hotspot",
+        "lan_gateway_ip": "192.168.68.1",
+        "dhcp_start_ip": "192.168.68.10",
+        "dhcp_end_ip": "192.168.68.250",
+    }
+    status = devbridge.build_devbridge_status(
+        state=state,
+        config=config,
+        clients_snapshot=_snapshot([_client()]),
+        host_adb_path="/usr/bin/adb",
+    )
+
+    assert set(status) == {
+        "schema_version",
+        "mode",
+        "adb_tcp_port",
+        "hotspot",
+        "network",
+        "host_adb",
+        "summary",
+        "warnings",
+        "notes",
+    }
+    assert status["mode"] == "read_only"
+    assert status["adb_tcp_port"] == 5555
+    assert status["hotspot"]["ssid"] == "VR-Hotspot"
+    assert status["network"]["subnet_cidr"] == "192.168.68.0/24"
+    assert status["host_adb"] == {"present": True, "path": "/usr/bin/adb"}
+    assert status["summary"] == {"devices_detected": 1, "likely_headsets": 1}
+
+
+def test_adb_command_report_all_kinds_with_devices():
+    report = devbridge.build_adb_command_report(
+        clients=[_client()],
+        host_adb_path="/usr/bin/adb",
+    )
+
+    assert report["kind"] == "all"
+    assert report["host_adb"]["present"] is True
+    assert report["host_adb"]["install_hint"] is None
+    assert report["devices"][0]["ip"] == "192.168.68.23"
+    assert "connect" in report["devices"][0]["commands"]
+    assert "logcat" in report["devices"][0]["commands"]
+    assert report["generic"]["connect"]["connect"] == "adb connect <HEADSET_IP>:5555"
+    assert "pairing" in report
+    assert report["warnings"] == []
+
+
+def test_adb_command_report_kind_filters_sections():
+    connect_report = devbridge.build_adb_command_report(clients=[_client()], kind="connect")
+    assert "connect" in connect_report["generic"]
+    assert "logcat" not in connect_report["generic"]
+    assert "pairing" in connect_report
+
+    logcat_report = devbridge.build_adb_command_report(clients=[_client()], kind="logcat")
+    assert "logcat" in logcat_report["generic"]
+    assert "connect" not in logcat_report["generic"]
+    assert "pairing" not in logcat_report
+
+
+def test_adb_command_report_requested_ip_not_detected_still_gets_commands():
+    report = devbridge.build_adb_command_report(
+        clients=[_client()],
+        ip="192.168.68.99",
+    )
+
+    assert report["warnings"] == ["requested_ip_not_in_client_list"]
+    assert report["devices"] == [
+        {
+            "ip": "192.168.68.99",
+            "hostname": None,
+            "commands": report["devices"][0]["commands"],
+        }
+    ]
+    assert (
+        report["devices"][0]["commands"]["connect"]["connect"]
+        == "adb connect 192.168.68.99:5555"
+    )
+
+
+def _readiness(**overrides):
+    kwargs = {
+        "state": {
+            "running": True,
+            "phase": "running",
+            "ap_interface": "x0wlan1",
+        },
+        "network_config_errors": (),
+        "clients": [_client()],
+        "adb_probes": {
+            "192.168.68.23": {
+                "tcp_port": 5555,
+                "checked": True,
+                "reachable": True,
+                "error": None,
+                "latency_ms": 2.0,
+            }
+        },
+        "host_adb_path": "/usr/bin/adb",
+        "probe_requested": True,
+        "ssid": "VR-Hotspot",
+    }
+    kwargs.update(overrides)
+    return devbridge.build_devbridge_readiness_report(**kwargs)
+
+
+def test_readiness_all_pass_is_ready():
+    report = _readiness()
+
+    assert report["overall"] == devbridge.READINESS_READY
+    assert [check["status"] for check in report["checks"]] == ["pass"] * 7
+    assert [check["code"] for check in report["checks"]] == [
+        "hotspot_running",
+        "ap_interface_present",
+        "network_config_valid",
+        "host_adb_present",
+        "devices_detected",
+        "adb_tcp_reachable",
+        "unity_build_and_run",
+    ]
+    assert report["summary"]["pass"] == 7
+    unity = report["checks"][-1]
+    assert unity["next_step_command"] == "adb connect 192.168.68.23:5555"
+
+
+def test_readiness_hotspot_stopped_is_not_ready_with_copyable_next_steps():
+    report = _readiness(
+        state={"running": False, "phase": "stopped", "ap_interface": None},
+        adb_probes={},
+    )
+
+    assert report["overall"] == devbridge.READINESS_NOT_READY
+    by_code = {check["code"]: check for check in report["checks"]}
+    assert by_code["hotspot_running"]["status"] == devbridge.CHECK_FAIL
+    assert "curl" in by_code["hotspot_running"]["next_step_command"]
+    assert "$VR_HOTSPOTD_API_TOKEN" in by_code["hotspot_running"]["next_step_command"]
+    assert by_code["ap_interface_present"]["status"] == devbridge.CHECK_SKIPPED
+    assert by_code["devices_detected"]["status"] == devbridge.CHECK_SKIPPED
+    for check in report["checks"]:
+        if check["status"] != devbridge.CHECK_PASS:
+            assert check["next_step_command"], check["code"]
+
+
+def test_readiness_no_reachable_device_warns_with_tcpip_next_step():
+    report = _readiness(
+        adb_probes={
+            "192.168.68.23": {
+                "tcp_port": 5555,
+                "checked": True,
+                "reachable": False,
+                "error": "connection_refused",
+                "latency_ms": None,
+            }
+        },
+        host_adb_path=None,
+    )
+
+    assert report["overall"] == devbridge.READINESS_PARTIAL
+    by_code = {check["code"]: check for check in report["checks"]}
+    assert by_code["adb_tcp_reachable"]["status"] == devbridge.CHECK_WARNING
+    assert by_code["adb_tcp_reachable"]["next_step_command"] == "adb tcpip 5555"
+    assert by_code["host_adb_present"]["status"] == devbridge.CHECK_WARNING
+    assert by_code["host_adb_present"]["next_step_command"] == "adb version"
+    assert by_code["unity_build_and_run"]["status"] == devbridge.CHECK_SKIPPED
+
+
+def test_readiness_probe_disabled_reports_unknown():
+    report = _readiness(adb_probes={}, probe_requested=False)
+
+    by_code = {check["code"]: check for check in report["checks"]}
+    assert by_code["adb_tcp_reachable"]["status"] == devbridge.CHECK_UNKNOWN
+    assert report["overall"] == devbridge.READINESS_PARTIAL
+
+
+def test_collectors_never_probe_when_disabled(monkeypatch):
+    monkeypatch.setattr(devbridge, "load_state", lambda: {"running": True, "phase": "running"})
+    monkeypatch.setattr(
+        devbridge,
+        "load_config_snapshot",
+        lambda: {"ssid": "VR-Hotspot", "lan_gateway_ip": "192.168.68.1"},
+    )
+    monkeypatch.setattr(
+        devbridge,
+        "get_clients_snapshot",
+        lambda *_args, **_kwargs: _snapshot([_client()]),
+    )
+    monkeypatch.setattr(devbridge, "validate_network_config", lambda _cfg: [])
+    monkeypatch.setattr(devbridge.shutil, "which", lambda _name: "/usr/bin/adb")
+
+    def forbidden_probe(*_args, **_kwargs):
+        raise AssertionError("probe must not run when probe_adb=False")
+
+    monkeypatch.setattr(devbridge, "probe_adb_tcp", forbidden_probe)
+
+    devices = devbridge.collect_devbridge_devices(probe_adb=False)
+    readiness = devbridge.collect_devbridge_readiness(probe_adb=False)
+
+    assert devices["probe_requested"] is False
+    assert devices["devices"][0]["adb"]["checked"] is False
+    assert readiness["probe_requested"] is False
+
+
+def test_collect_adb_command_report_never_touches_the_network(monkeypatch):
+    monkeypatch.setattr(devbridge, "load_state", lambda: {"running": True, "phase": "running"})
+    monkeypatch.setattr(
+        devbridge,
+        "get_clients_snapshot",
+        lambda *_args, **_kwargs: _snapshot([_client()]),
+    )
+    monkeypatch.setattr(devbridge.shutil, "which", lambda _name: None)
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("collect_adb_command_report must not open sockets")
+
+    monkeypatch.setattr(devbridge.socket, "create_connection", forbidden)
+
+    report = devbridge.collect_adb_command_report(ip="192.168.68.23", kind="connect")
+
+    assert report["devices"][0]["ip"] == "192.168.68.23"
+    assert report["host_adb"]["present"] is False
+    assert report["host_adb"]["install_hint"]

--- a/tests/test_flatpak_local_api_client.py
+++ b/tests/test_flatpak_local_api_client.py
@@ -281,6 +281,10 @@ def test_client_exposes_only_reviewed_routes_and_no_generic_public_request_metho
     assert public_methods == {
         "adapter_readiness",
         "config",
+        "devbridge_adb_commands",
+        "devbridge_devices",
+        "devbridge_readiness",
+        "devbridge_status",
         "health",
         "portal_request",
         "preflight_report",

--- a/tests/test_flatpak_token_pairing.py
+++ b/tests/test_flatpak_token_pairing.py
@@ -256,6 +256,10 @@ def test_pairing_flow_wires_only_health_and_adapter_readiness():
     assert public_client_methods == {
         "adapter_readiness",
         "config",
+        "devbridge_adb_commands",
+        "devbridge_devices",
+        "devbridge_readiness",
+        "devbridge_status",
         "health",
         "portal_request",
         "preflight_report",


### PR DESCRIPTION
## Summary
- Adds the Dev Bridge diagnostics module (`backend/vr_hotspotd/diagnostics/devbridge.py`) with device discovery on the hotspot network, hostname-based headset classification, and optional port-5555 TCP reachability probing.
- New API endpoints: `GET /v1/devbridge/devices` (with `?probe=0` to skip probing) and `GET /v1/devbridge/adb` for copyable `adb connect`, Wireless Debugging pairing, and logcat commands (filterable via `?ip=` and `?kind=`).
- New CLI commands: `vr-hotspot devbridge scan`, `devbridge adb-command`, and `devbridge logcat-command`.
- Support bundle now includes a probe-free `vr-hotspot/devbridge.json` snapshot.
- Documentation in `docs/dev-bridge.md` plus README and changelog updates.

## Safety model
- Read-only foundation: the daemon never executes `adb`, never initiates pairing, and never collects logcat output. Endpoints only report status and produce copyable commands for the user to run themselves.
- The optional reachability check is a plain TCP probe of port 5555 and can be disabled per request.
- The support-bundle snapshot passes through the standard redaction (MAC addresses and public IPs) and contains no logcat output or pairing data.

## Validation
- `pytest tests/test_devbridge_model.py tests/test_api_devbridge.py tests/test_cli_devbridge.py` — 39 passed.
- `ruff check .` — clean.
- `git diff --check` — clean.

## Follow-up
- Interactive pairing and connection management are out of scope here and will build on this foundation in later changes.