### PR TITLE
Remove Flatpak companion during uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,23 @@ curl -sSL https://raw.githubusercontent.com/josethevrtech/VRhotspot/main/uninsta
 sudo bash /tmp/vrhotspot-uninstall.sh
 ```
 
-The daemon uninstaller leaves any user-scoped Flatpak companion and configured
-Flatpak remotes untouched. Remove only this companion explicitly, if desired:
+The uninstaller (and the installer's existing-install cleanup) also removes the
+optional Flatpak companion when present: it stops the running companion/tray,
+uninstalls `io.github.josethevrtech.VRhotspot` from the invoking desktop user's
+user-scoped Flatpak (and best-effort from the system scope), and deletes only
+that user's companion app data
+(`~/.var/app/io.github.josethevrtech.VRhotspot`) and companion autostart entry
+(`~/.config/autostart/io.github.josethevrtech.VRhotspot.desktop`). Every
+companion step is best-effort: a missing `flatpak` binary, a missing app, an
+already-stopped tray, or an undetectable desktop user never fails the
+uninstall. Shared Flatpak runtimes, Flatpak remotes, unrelated Flatpak apps,
+and unrelated autostart files are never touched.
 
-```bash
-flatpak uninstall --user io.github.josethevrtech.VRhotspot
-```
+Removing the app plus its app data removes all companion-local state. A token
+the companion explicitly saved through the desktop keyring (Secret Service)
+cannot be cleared without a live desktop session, so that keyring item may
+remain; it only held the daemon API token, which the uninstall deletes and a
+reinstall regenerates. Remove it from your keyring manager if desired.
 
 ---
 

--- a/docs/FLATPAK_ARCHITECTURE_PLAN.md
+++ b/docs/FLATPAK_ARCHITECTURE_PLAN.md
@@ -478,8 +478,21 @@ bounded-error, and small utility UI infrastructure. Tray controls require a
 daemon token explicitly entered for the session or explicitly saved through
 Secret Service. The companion never discovers a token from `/etc` or `/var/lib`.
 
-Daemon uninstallers do not automatically remove the user-owned companion or any
-Flatpak remote. A user may separately remove only this app with:
+The top-level `uninstall.sh` and the installer's existing-install cleanup
+perform a scoped, best-effort companion removal: they stop the running
+companion/tray, uninstall only `io.github.josethevrtech.VRhotspot` from the
+invoking desktop user's user-scoped Flatpak (and best-effort from the system
+scope), and remove only that user's companion app data
+(`~/.var/app/io.github.josethevrtech.VRhotspot`) and companion autostart entry
+(`~/.config/autostart/io.github.josethevrtech.VRhotspot.desktop`). They never
+touch Flatpak remotes, shared runtimes, other Flatpak apps, or unrelated
+autostart files, and a missing `flatpak` binary, missing app, already-stopped
+tray, or undetectable desktop user never fails the uninstall. The backend
+daemon uninstaller (`backend/scripts/uninstall.sh`) still does not touch
+Flatpak at all. Removing the app plus its app data removes all companion-local
+state; a token explicitly saved through Secret Service cannot be cleared
+without a live desktop session, so that keyring item may remain (it only held
+the daemon token, which the daemon cleanup deletes). Manual removal remains:
 
 ```bash
 flatpak uninstall --user io.github.josethevrtech.VRhotspot

--- a/install.sh
+++ b/install.sh
@@ -896,6 +896,113 @@ _run_rpm_ostree_install() {
     return "$status"
 }
 
+# --- Flatpak Companion Cleanup ---
+# Best-effort removal of the optional user-scoped Flatpak companion app.
+# Every step tolerates a missing flatpak binary, a missing app, a missing
+# desktop user/session, and an already-stopped tray. Only the VRhotspot app
+# ID, its per-user app data, and its own autostart entry are ever touched;
+# shared runtimes, other Flatpak apps, Flatpak remotes, and unrelated
+# autostart files are left alone. Any token the companion saved through the
+# desktop keyring (Secret Service) cannot be cleared without a live user
+# session, so it may remain; it only held the daemon token, which the
+# daemon cleanup deletes.
+resolve_flatpak_cleanup_user() {
+    FLATPAK_CLEANUP_USER=""
+    FLATPAK_CLEANUP_UID=""
+    FLATPAK_CLEANUP_HOME=""
+
+    local candidate uid home
+    if [ "$(id -u)" -eq 0 ]; then
+        candidate="${SUDO_USER:-}"
+        if [ -z "$candidate" ] || [ "$candidate" = "root" ]; then
+            return 1
+        fi
+    else
+        candidate="$(id -un)"
+    fi
+
+    if ! uid="$(id -u "$candidate" 2>/dev/null)" || [ "$uid" -eq 0 ]; then
+        return 1
+    fi
+    if ! command -v getent >/dev/null 2>&1; then
+        return 1
+    fi
+    home="$(getent passwd "$candidate" 2>/dev/null | cut -d: -f6)"
+    if [ -z "$home" ] || [ "$home" = "/" ] || [ ! -d "$home" ]; then
+        return 1
+    fi
+
+    FLATPAK_CLEANUP_USER="$candidate"
+    FLATPAK_CLEANUP_UID="$uid"
+    FLATPAK_CLEANUP_HOME="$home"
+}
+
+run_as_flatpak_cleanup_user() {
+    if [ "$(id -u)" -eq "$FLATPAK_CLEANUP_UID" ]; then
+        "$@"
+    elif command -v runuser >/dev/null 2>&1; then
+        runuser -u "$FLATPAK_CLEANUP_USER" -- "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo -H -u "$FLATPAK_CLEANUP_USER" -- "$@"
+    else
+        return 127
+    fi
+}
+
+cleanup_flatpak_companion() {
+    local have_flatpak=0 have_user=0
+    if command -v flatpak >/dev/null 2>&1; then
+        have_flatpak=1
+    else
+        print_info "flatpak is not installed; skipping Flatpak companion uninstall."
+    fi
+    if resolve_flatpak_cleanup_user; then
+        have_user=1
+    else
+        print_info "No non-root desktop user found; skipping user-scoped Flatpak companion cleanup."
+    fi
+
+    if [ "$have_flatpak" -eq 1 ] && [ "$have_user" -eq 1 ]; then
+        # Stop a running companion/tray instance; an already-stopped tray
+        # simply makes this a harmless no-op failure.
+        if run_as_flatpak_cleanup_user env "XDG_RUNTIME_DIR=/run/user/$FLATPAK_CLEANUP_UID" \
+            flatpak kill "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            print_info "Stopped the running Flatpak companion for $FLATPAK_CLEANUP_USER."
+        fi
+        if run_as_flatpak_cleanup_user flatpak info --user "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            if run_as_flatpak_cleanup_user flatpak uninstall --user -y "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+                print_success "Removed the user-scoped Flatpak companion for $FLATPAK_CLEANUP_USER."
+            else
+                print_warning "Could not remove the user-scoped Flatpak companion; run: flatpak uninstall --user $FLATPAK_COMPANION_APP_ID"
+            fi
+        fi
+    fi
+
+    if [ "$have_flatpak" -eq 1 ]; then
+        if flatpak info --system "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            if flatpak uninstall --system -y "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+                print_success "Removed the system-scoped Flatpak companion."
+            else
+                print_warning "Could not remove the system-scoped Flatpak companion; run: flatpak uninstall --system $FLATPAK_COMPANION_APP_ID"
+            fi
+        fi
+    fi
+
+    if [ "$have_user" -eq 1 ]; then
+        local app_data="$FLATPAK_CLEANUP_HOME/.var/app/$FLATPAK_COMPANION_APP_ID"
+        if [ -d "$app_data" ]; then
+            rm -rf -- "$app_data"
+            print_info "Removed Flatpak companion app data at $app_data."
+        fi
+        local autostart_entry="$FLATPAK_CLEANUP_HOME/.config/autostart/$FLATPAK_COMPANION_APP_ID.desktop"
+        if [ -f "$autostart_entry" ]; then
+            rm -f -- "$autostart_entry"
+            print_info "Removed Flatpak companion autostart entry at $autostart_entry."
+        fi
+    fi
+    return 0
+}
+
 # --- Pre-flight & Cleanup ---
 check_root() {
     if [ "$EUID" -ne 0 ]; then
@@ -926,6 +1033,9 @@ cleanup_previous_install() {
         systemctl disable "$unit" &>/dev/null || true
     done
     pkill -f "vr_hotspotd/main.py" &>/dev/null || true
+
+    print_info "Cleaning up the optional Flatpak companion..."
+    cleanup_flatpak_companion
 
     print_info "Rolling back recorded firewall rules..."
     rollback_owned_firewall_rules

--- a/tests/test_flatpak_companion_cleanup.py
+++ b/tests/test_flatpak_companion_cleanup.py
@@ -1,0 +1,315 @@
+"""Flatpak companion cleanup in install.sh existing-install cleanup and uninstall.sh.
+
+Both scripts share the same best-effort `cleanup_flatpak_companion` behavior:
+stop the running companion, uninstall only the VRhotspot app ID from the user
+scope (and best-effort from the system scope), and remove only the invoking
+desktop user's companion app data and companion autostart entry.
+"""
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import stat
+import subprocess
+from typing import Optional
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install.sh"
+UNINSTALLER = ROOT / "uninstall.sh"
+APP_ID = "io.github.josethevrtech.VRhotspot"
+
+FAKE_FLATPAK = """#!/bin/sh
+printf '%s\\n' "$*" >> "$FAKE_FLATPAK_LOG"
+case "$1" in
+    kill)
+        exit "${FAKE_FLATPAK_KILL_STATUS:-0}"
+        ;;
+    info)
+        if [ "$2" = "--user" ] && [ "${FAKE_FLATPAK_USER_INSTALLED:-0}" -eq 1 ]; then
+            exit 0
+        fi
+        if [ "$2" = "--system" ] && [ "${FAKE_FLATPAK_SYSTEM_INSTALLED:-0}" -eq 1 ]; then
+            exit 0
+        fi
+        exit 1
+        ;;
+    uninstall)
+        exit "${FAKE_FLATPAK_UNINSTALL_STATUS:-0}"
+        ;;
+esac
+exit 0
+"""
+
+
+def run_bash(
+    script: str, *, env: Optional[dict[str, str]] = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", "-c", script],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def make_fake_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    owned_app_data = home / ".var" / "app" / APP_ID / "config"
+    owned_app_data.mkdir(parents=True)
+    (owned_app_data / "state.json").write_text("{}", encoding="utf-8")
+    unrelated_app_data = home / ".var" / "app" / "org.unrelated.OtherApp"
+    unrelated_app_data.mkdir(parents=True)
+    (unrelated_app_data / "keep.txt").write_text("keep", encoding="utf-8")
+    autostart = home / ".config" / "autostart"
+    autostart.mkdir(parents=True)
+    (autostart / f"{APP_ID}.desktop").write_text("[Desktop Entry]\n", encoding="utf-8")
+    (autostart / "org.unrelated.OtherApp.desktop").write_text(
+        "[Desktop Entry]\n", encoding="utf-8"
+    )
+    return home
+
+
+def make_cleanup_path(tmp_path: Path, *, with_flatpak: bool = True) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for tool in ("id", "rm", "env"):
+        real_tool = shutil.which(tool)
+        assert real_tool, f"required tool missing on test host: {tool}"
+        (fake_bin / tool).symlink_to(real_tool)
+    if with_flatpak:
+        stub = fake_bin / "flatpak"
+        stub.write_text(FAKE_FLATPAK, encoding="utf-8")
+        stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    return fake_bin
+
+
+def cleanup_env(tmp_path: Path, fake_bin: Path, **fake_vars: str) -> dict[str, str]:
+    log = tmp_path / "flatpak.log"
+    log.touch()
+    env = os.environ.copy()
+    env.update({"PATH": str(fake_bin), "FAKE_FLATPAK_LOG": str(log)})
+    env.update(fake_vars)
+    return env
+
+
+def cleanup_script(script_path: Path, home: Path, overrides: str = "") -> str:
+    return f"""
+    source {shlex.quote(str(script_path))}
+    resolve_flatpak_cleanup_user() {{
+        FLATPAK_CLEANUP_USER="$(id -un)"
+        FLATPAK_CLEANUP_UID="$(id -u)"
+        FLATPAK_CLEANUP_HOME={shlex.quote(str(home))}
+    }}
+    {overrides}
+    cleanup_flatpak_companion
+    echo cleanup-done
+    """
+
+
+def flatpak_log_lines(env: dict[str, str]) -> list[str]:
+    return Path(env["FAKE_FLATPAK_LOG"]).read_text(encoding="utf-8").splitlines()
+
+
+@pytest.fixture(params=[INSTALLER, UNINSTALLER], ids=["install.sh", "uninstall.sh"])
+def script_path(request):
+    return request.param
+
+
+def test_cleanup_kills_tray_before_user_uninstall_and_removes_only_owned_artifacts(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path)
+    env = cleanup_env(tmp_path, fake_bin, FAKE_FLATPAK_USER_INSTALLED="1")
+
+    result = run_bash(cleanup_script(script_path, home), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+
+    log = flatpak_log_lines(env)
+    kill_index = log.index(f"kill {APP_ID}")
+    uninstall_index = log.index(f"uninstall --user -y {APP_ID}")
+    assert kill_index < uninstall_index
+    assert all(APP_ID in line for line in log if line.startswith("uninstall"))
+    assert not any("--system" in line and line.startswith("uninstall") for line in log)
+
+    assert not (home / ".var" / "app" / APP_ID).exists()
+    assert (home / ".var" / "app" / "org.unrelated.OtherApp" / "keep.txt").exists()
+    assert not (home / ".config" / "autostart" / f"{APP_ID}.desktop").exists()
+    assert (home / ".config" / "autostart" / "org.unrelated.OtherApp.desktop").exists()
+
+
+def test_cleanup_attempts_system_scope_best_effort_and_failures_are_nonfatal(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path)
+    env = cleanup_env(
+        tmp_path,
+        fake_bin,
+        FAKE_FLATPAK_USER_INSTALLED="1",
+        FAKE_FLATPAK_SYSTEM_INSTALLED="1",
+        FAKE_FLATPAK_UNINSTALL_STATUS="1",
+    )
+
+    result = run_bash(cleanup_script(script_path, home), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+    assert "Could not remove the user-scoped Flatpak companion" in result.stdout
+    assert "Could not remove the system-scoped Flatpak companion" in result.stdout
+
+    log = flatpak_log_lines(env)
+    assert f"uninstall --user -y {APP_ID}" in log
+    assert f"uninstall --system -y {APP_ID}" in log
+    # Owned local artifacts are still removed even when flatpak uninstall fails.
+    assert not (home / ".var" / "app" / APP_ID).exists()
+    assert not (home / ".config" / "autostart" / f"{APP_ID}.desktop").exists()
+
+
+def test_missing_flatpak_is_nonfatal_and_still_removes_owned_user_artifacts(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path, with_flatpak=False)
+    env = cleanup_env(tmp_path, fake_bin)
+
+    result = run_bash(cleanup_script(script_path, home), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+    assert "flatpak is not installed" in result.stdout
+    assert flatpak_log_lines(env) == []
+    assert not (home / ".var" / "app" / APP_ID).exists()
+    assert not (home / ".config" / "autostart" / f"{APP_ID}.desktop").exists()
+    assert (home / ".var" / "app" / "org.unrelated.OtherApp" / "keep.txt").exists()
+    assert (home / ".config" / "autostart" / "org.unrelated.OtherApp.desktop").exists()
+
+
+def test_missing_app_is_nonfatal_and_never_calls_flatpak_uninstall(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path)
+    env = cleanup_env(tmp_path, fake_bin)
+
+    result = run_bash(cleanup_script(script_path, home), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+    assert not any(
+        line.startswith("uninstall") for line in flatpak_log_lines(env)
+    )
+
+
+def test_unknown_desktop_user_is_nonfatal_and_skips_user_scope_only(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path)
+    env = cleanup_env(
+        tmp_path,
+        fake_bin,
+        FAKE_FLATPAK_USER_INSTALLED="1",
+        FAKE_FLATPAK_SYSTEM_INSTALLED="1",
+    )
+
+    result = run_bash(
+        cleanup_script(
+            script_path,
+            home,
+            overrides="resolve_flatpak_cleanup_user() { return 1; }",
+        ),
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+    assert "skipping user-scoped Flatpak companion cleanup" in result.stdout
+
+    log = flatpak_log_lines(env)
+    assert not any("--user" in line for line in log)
+    assert f"uninstall --system -y {APP_ID}" in log
+    # Without a resolved desktop user, no home directory content is touched.
+    assert (home / ".var" / "app" / APP_ID).exists()
+    assert (home / ".config" / "autostart" / f"{APP_ID}.desktop").exists()
+
+
+def test_already_stopped_tray_is_nonfatal_and_uninstall_proceeds(
+    tmp_path, script_path
+):
+    home = make_fake_home(tmp_path)
+    fake_bin = make_cleanup_path(tmp_path)
+    env = cleanup_env(
+        tmp_path,
+        fake_bin,
+        FAKE_FLATPAK_USER_INSTALLED="1",
+        FAKE_FLATPAK_KILL_STATUS="1",
+    )
+
+    result = run_bash(cleanup_script(script_path, home), env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "cleanup-done" in result.stdout
+    assert f"uninstall --user -y {APP_ID}" in flatpak_log_lines(env)
+    assert not (home / ".var" / "app" / APP_ID).exists()
+
+
+def test_installer_existing_install_cleanup_invokes_companion_cleanup(tmp_path):
+    install_root = tmp_path / "install-root"
+    install_root.mkdir()
+
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(INSTALLER))}
+        INTERACTIVE=0
+        INSTALL_ROOT={shlex.quote(str(install_root))}
+        CONFIG_DIR={shlex.quote(str(tmp_path / "config-dir"))}
+        function systemctl {{ :; }}
+        pkill() {{ :; }}
+        rm() {{ :; }}
+        rollback_owned_firewall_rules() {{ echo firewall-rollback-called; }}
+        cleanup_flatpak_companion() {{ echo companion-cleanup-called; }}
+        cleanup_previous_install
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "companion-cleanup-called" in result.stdout
+    assert "firewall-rollback-called" in result.stdout
+    assert result.stdout.index("companion-cleanup-called") < result.stdout.index(
+        "firewall-rollback-called"
+    )
+    assert "Cleanup complete" in result.stdout
+
+
+def test_uninstaller_main_invokes_companion_cleanup_after_stopping_services():
+    result = run_bash(
+        f"""
+        source {shlex.quote(str(UNINSTALLER))}
+        check_root() {{ :; }}
+        clear() {{ :; }}
+        detect_os() {{ :; }}
+        function systemctl {{ :; }}
+        rm() {{ :; }}
+        rollback_owned_firewall_rules() {{ :; }}
+        cleanup_flatpak_companion() {{ echo companion-cleanup-called; }}
+        main --yes
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "companion-cleanup-called" in result.stdout
+    assert result.stdout.index("Services stopped and disabled") < result.stdout.index(
+        "companion-cleanup-called"
+    )
+    assert result.stdout.index("companion-cleanup-called") < result.stdout.index(
+        "successfully uninstalled"
+    )

--- a/tests/test_installer_flatpak_companion.py
+++ b/tests/test_installer_flatpak_companion.py
@@ -669,9 +669,24 @@ def test_flatpak_manifest_permissions_remain_minimal_and_unchanged():
     }
 
 
-def test_daemon_uninstallers_do_not_remove_user_flatpaks_or_remotes():
-    for path in (TOP_UNINSTALLER, BACKEND_UNINSTALLER):
-        uninstaller = path.read_text(encoding="utf-8")
-        assert "flatpak uninstall" not in uninstaller
-        assert "flatpak remote" not in uninstaller
-        assert "io.github.josethevrtech.VRhotspot" not in uninstaller
+def test_backend_daemon_uninstaller_does_not_touch_flatpak():
+    uninstaller = BACKEND_UNINSTALLER.read_text(encoding="utf-8")
+    assert "flatpak" not in uninstaller
+    assert "io.github.josethevrtech.VRhotspot" not in uninstaller
+
+
+def test_companion_cleanup_flatpak_use_is_scoped_to_the_app_id():
+    for path in (TOP_UNINSTALLER, INSTALLER):
+        text = path.read_text(encoding="utf-8")
+        assert "flatpak remote" not in text
+        assert "--unused" not in text
+        assert "--delete-data" not in text
+        for line in text.splitlines():
+            if "flatpak uninstall" not in line:
+                continue
+            assert (
+                "$FLATPAK_COMPANION_APP_ID" in line
+                or "io.github.josethevrtech.VRhotspot" in line
+            ), line
+            assert "--all" not in line
+            assert "runtime" not in line

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,6 +13,7 @@ INSTALL_ROOT="/var/lib/vr-hotspot"
 FIREWALL_LEDGER="$INSTALL_ROOT/firewall-rules.json"
 CONFIG_DIR="/etc/vr-hotspot"
 SYSTEMD_DIR="/etc/systemd/system"
+FLATPAK_COMPANION_APP_ID="io.github.josethevrtech.VRhotspot"
 
 # --- Colors and Formatting ---
 RED='\033[0;31m'
@@ -154,6 +155,113 @@ rollback_owned_firewall_rules() {
     done <<< "$records"
 }
 
+# --- Flatpak Companion Cleanup ---
+# Best-effort removal of the optional user-scoped Flatpak companion app.
+# Every step tolerates a missing flatpak binary, a missing app, a missing
+# desktop user/session, and an already-stopped tray. Only the VRhotspot app
+# ID, its per-user app data, and its own autostart entry are ever touched;
+# shared runtimes, other Flatpak apps, Flatpak remotes, and unrelated
+# autostart files are left alone. Any token the companion saved through the
+# desktop keyring (Secret Service) cannot be cleared without a live user
+# session, so it may remain; it only held the daemon token, which the
+# daemon cleanup deletes.
+resolve_flatpak_cleanup_user() {
+    FLATPAK_CLEANUP_USER=""
+    FLATPAK_CLEANUP_UID=""
+    FLATPAK_CLEANUP_HOME=""
+
+    local candidate uid home
+    if [ "$(id -u)" -eq 0 ]; then
+        candidate="${SUDO_USER:-}"
+        if [ -z "$candidate" ] || [ "$candidate" = "root" ]; then
+            return 1
+        fi
+    else
+        candidate="$(id -un)"
+    fi
+
+    if ! uid="$(id -u "$candidate" 2>/dev/null)" || [ "$uid" -eq 0 ]; then
+        return 1
+    fi
+    if ! command -v getent >/dev/null 2>&1; then
+        return 1
+    fi
+    home="$(getent passwd "$candidate" 2>/dev/null | cut -d: -f6)"
+    if [ -z "$home" ] || [ "$home" = "/" ] || [ ! -d "$home" ]; then
+        return 1
+    fi
+
+    FLATPAK_CLEANUP_USER="$candidate"
+    FLATPAK_CLEANUP_UID="$uid"
+    FLATPAK_CLEANUP_HOME="$home"
+}
+
+run_as_flatpak_cleanup_user() {
+    if [ "$(id -u)" -eq "$FLATPAK_CLEANUP_UID" ]; then
+        "$@"
+    elif command -v runuser >/dev/null 2>&1; then
+        runuser -u "$FLATPAK_CLEANUP_USER" -- "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo -H -u "$FLATPAK_CLEANUP_USER" -- "$@"
+    else
+        return 127
+    fi
+}
+
+cleanup_flatpak_companion() {
+    local have_flatpak=0 have_user=0
+    if command -v flatpak >/dev/null 2>&1; then
+        have_flatpak=1
+    else
+        print_info "flatpak is not installed; skipping Flatpak companion uninstall."
+    fi
+    if resolve_flatpak_cleanup_user; then
+        have_user=1
+    else
+        print_info "No non-root desktop user found; skipping user-scoped Flatpak companion cleanup."
+    fi
+
+    if [ "$have_flatpak" -eq 1 ] && [ "$have_user" -eq 1 ]; then
+        # Stop a running companion/tray instance; an already-stopped tray
+        # simply makes this a harmless no-op failure.
+        if run_as_flatpak_cleanup_user env "XDG_RUNTIME_DIR=/run/user/$FLATPAK_CLEANUP_UID" \
+            flatpak kill "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            print_info "Stopped the running Flatpak companion for $FLATPAK_CLEANUP_USER."
+        fi
+        if run_as_flatpak_cleanup_user flatpak info --user "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            if run_as_flatpak_cleanup_user flatpak uninstall --user -y "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+                print_success "Removed the user-scoped Flatpak companion for $FLATPAK_CLEANUP_USER."
+            else
+                print_warning "Could not remove the user-scoped Flatpak companion; run: flatpak uninstall --user $FLATPAK_COMPANION_APP_ID"
+            fi
+        fi
+    fi
+
+    if [ "$have_flatpak" -eq 1 ]; then
+        if flatpak info --system "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+            if flatpak uninstall --system -y "$FLATPAK_COMPANION_APP_ID" >/dev/null 2>&1; then
+                print_success "Removed the system-scoped Flatpak companion."
+            else
+                print_warning "Could not remove the system-scoped Flatpak companion; run: flatpak uninstall --system $FLATPAK_COMPANION_APP_ID"
+            fi
+        fi
+    fi
+
+    if [ "$have_user" -eq 1 ]; then
+        local app_data="$FLATPAK_CLEANUP_HOME/.var/app/$FLATPAK_COMPANION_APP_ID"
+        if [ -d "$app_data" ]; then
+            rm -rf -- "$app_data"
+            print_info "Removed Flatpak companion app data at $app_data."
+        fi
+        local autostart_entry="$FLATPAK_CLEANUP_HOME/.config/autostart/$FLATPAK_COMPANION_APP_ID.desktop"
+        if [ -f "$autostart_entry" ]; then
+            rm -f -- "$autostart_entry"
+            print_info "Removed Flatpak companion autostart entry at $autostart_entry."
+        fi
+    fi
+    return 0
+}
+
 # --- Main Uninstallation Logic ---
 check_root() {
     if [ "$EUID" -ne 0 ]; then
@@ -205,6 +313,10 @@ main() {
         systemctl disable "$unit" &>/dev/null || true
     done
     print_success "Services stopped and disabled."
+
+    print_step "Removing the Flatpak companion app (if present)..."
+    cleanup_flatpak_companion
+    print_success "Flatpak companion cleanup complete."
 
     print_step "Rolling back recorded firewall rules..."
     rollback_owned_firewall_rules


### PR DESCRIPTION
# Summary
- Remove VRhotspot Flatpak companion artifacts during uninstall and existing-install cleanup.
- Stop the running tray, uninstall the app from user/system Flatpak scopes, and remove app data/autostart files.
- Keep cleanup best-effort and non-fatal.

# Safety model
- Only io.github.josethevrtech.VRhotspot is targeted.
- No shared Flatpak runtimes, SDKs, remotes, flatpak-builder, distro packages, or unrelated apps are removed.
- App data and autostart cleanup are scoped to the resolved desktop user, not root.
- Missing flatpak, missing app, missing user session, and already-stopped tray do not fail uninstall.
- Daemon/service cleanup and firewall rollback behavior are preserved.

# Validation
- Review approved with no blockers.
- Targeted installer/uninstall suites: 39 passed.
- Full suite: 994 passed, 4 subtests passed.
- Ruff passed.
- bash -n passed for install.sh, uninstall.sh, and backend/scripts/uninstall.sh.
- Shellcheck only reported a pre-existing SC2129 style note.
- Install matrix check passed.
- git diff --check passed.

# Release note
- Fixes v1.1.0 RC release blocker where uninstall could leave the desktop companion app, tray process, or app data behind.
