### PR TITLE
Add Platform-Tools pin metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate vendor manifest and generate deterministic vendor-only SBOM
         run: python tools/ci/vendor_manifest_check.py --sbom-output /tmp/vrhotspot-vendor-sbom.json
 
+      - name: Validate Dev Bridge Platform-Tools pin metadata
+        run: python tools/ci/platform_tools_pin_check.py
+
       - name: Pytest
         run: pytest -q
 

--- a/backend/vr_hotspotd/devtools/platform_tools_pin.json
+++ b/backend/vr_hotspotd/devtools/platform_tools_pin.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "version": "r36.0.0",
+  "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-linux.zip",
+  "archive_sha256": "BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED",
+  "implementation_blocked": true,
+  "max_archive_bytes": 100000000,
+  "arch": "x86_64",
+  "extract_allowlist": [
+    "platform-tools/NOTICE.txt",
+    "platform-tools/adb"
+  ],
+  "license_name": "Android SDK License Agreement",
+  "license_terms_url": "https://developer.android.com/studio/terms",
+  "license_review": {
+    "reviewed_at": "2026-07-25",
+    "reviewer": "josethevrtech",
+    "terms_url": "https://developer.android.com/studio/terms",
+    "decision": "user_driven_download_with_explicit_acceptance_no_redistribution",
+    "rationale": "Option B in docs/devbridge-platform-tools-license-decision.md: the user explicitly accepts Google's Android SDK License Agreement at install time and VRhotspot acts only as that user's agent, downloading the pinned official archive directly from dl.google.com to that user's machine. VRhotspot never becomes a distributor of Platform-Tools bytes and never accepts the terms on the user's behalf.",
+    "restrictions": [
+      "No redistribution: never commit, mirror, re-host, proxy, or re-serve the archive or extracted binaries via the repository, releases, CI artifacts, the daemon API, the Web Portal, the support bundle, the Flatpak companion, or any package.",
+      "Explicit user acceptance of the Android SDK License Agreement is required before every download; acceptance is never defaulted, implied by an unrelated confirmation, or performed by VRhotspot for the user.",
+      "Download only the single pinned versioned URL over HTTPS from dl.google.com, only on explicit user action; never a latest endpoint, never pre-fetched, never in the background.",
+      "Verify the archive against the pinned SHA-256 before any extraction; delete the downloaded archive after extraction; retain no archive cache.",
+      "Extraction is allowlist-only and must include the platform-tools/NOTICE.txt notice file.",
+      "A pin version bump re-requires a dated terms re-review and re-dates this license_review block."
+    ],
+    "record": "docs/devbridge-platform-tools-license-review.md"
+  },
+  "notes": [
+    "archive_sha256 is an intentionally invalid placeholder: the SHA-256 of the pinned archive has not been independently verified, so implementation_blocked is true and downloader/install code must not be implemented against this pin.",
+    "The pinned version must be re-confirmed as the intended current release when the real SHA-256 is computed; filling the hash and flipping implementation_blocked to false happen together in one reviewed diff.",
+    "This file records reviewed metadata and policy only; it does not download, vendor, or install anything."
+  ]
+}

--- a/docs/devbridge-platform-tools-license-review.md
+++ b/docs/devbridge-platform-tools-license-review.md
@@ -1,0 +1,102 @@
+# Dev Bridge Platform-Tools license review record
+
+Status: license review record and pin metadata — no downloader, install
+endpoint, or UI behavior in this PR
+
+Date: 2026-07-25
+
+Reviewer: josethevrtech (VRhotspot maintainer)
+
+This is the review record referenced by
+`backend/vr_hotspotd/devtools/platform_tools_pin.json` (`license_review.record`).
+It records the dated maintainer review that
+`docs/devbridge-platform-tools-license-decision.md` requires before any
+Platform-Tools download path may be implemented, and it states exactly what
+remains blocked after this record lands.
+
+## What was reviewed
+
+- The Android SDK License Agreement as published at
+  <https://developer.android.com/studio/terms>, which governs the prebuilt
+  `platform-tools_*.zip` archives served from `dl.google.com`.
+- The licensing analysis and path selection in
+  `docs/devbridge-platform-tools-license-decision.md` (Option B: user-driven
+  download with explicit license notice and acceptance), governed by the
+  policy rules in `docs/VENDOR_PROVENANCE_SBOM_PLAN.md`.
+
+## Decision
+
+**User-driven download with explicit acceptance; no redistribution**
+(`user_driven_download_with_explicit_acceptance_no_redistribution` in the pin
+file).
+
+The user-accepted, user-triggered, direct-from-Google, no-redistribution
+model specified in the decision document is the reviewed and recorded path:
+
+- VRhotspot must **not** redistribute Platform-Tools in any form — no
+  repository bytes, releases, CI artifacts, mirrors, proxies, API-served
+  bytes, Flatpak payloads, or installer payloads.
+- VRhotspot must **not** silently accept Google's terms. Explicit user
+  acceptance of the Android SDK License Agreement remains required at install
+  time on every surface (installer, CLI, Web Portal), before every download,
+  including upgrades, exactly as the decision document's UX section defines.
+- The bytes travel once, from Google to the accepting user's own machine, on
+  that user's explicit instruction, from the single pinned versioned
+  `dl.google.com` HTTPS URL — never a `latest` endpoint.
+- The downloaded archive must be **deleted after extraction** in the future
+  implementation; no archive cache is retained. The only persisted artifacts
+  are the allowlisted extracted files (which must include
+  `platform-tools/NOTICE.txt`) and the installed-tools ledger.
+- A pin version bump re-requires a dated terms re-review and re-dates the
+  pin's `license_review` block.
+
+This record and the pin file record metadata and policy only. Nothing is
+downloaded, vendored, or installed by this change, and
+`backend/vendor/VENDOR_MANIFEST.json` scope is unchanged — no Platform-Tools
+bytes are ever repo-vendored.
+
+## What remains blocked
+
+**Downloader implementation remains blocked.** The pin's `archive_sha256` is
+an intentionally invalid, obvious placeholder
+(`BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED`)
+because the SHA-256 of the pinned archive has not been independently
+verified, and per vendor-policy rule 8 CI must never fetch the archive and
+trust the response. Accordingly the pin sets `implementation_blocked: true`,
+and `tools/ci/platform_tools_pin_check.py` rejects a pin whose hash is the
+placeholder without that flag.
+
+Until the real hash is recorded, all of the following stay unimplemented:
+downloader code, `/v1/devbridge/tools` install/remove endpoints, installer
+and CLI opt-ins, and any Web Portal / Flatpak UI for tools install.
+
+To unblock, one reviewed diff must:
+
+1. Record the real lowercase SHA-256 of the exact pinned archive,
+   independently computed (download the pinned URL after personally accepting
+   the Android SDK License Agreement, hash it, and cross-check the digest
+   from a second independent host/network path — never from a single fetch
+   treated as truth).
+2. Re-confirm that the pinned `version`/`url` is the intended current
+   release, and re-read the then-current terms text, re-dating the pin's
+   `license_review` if the pin version changes.
+3. Flip `implementation_blocked` to `false` in the same diff.
+
+Everything else the decision document gates on (acceptance UX and API
+enforcement, `docs/security.md` egress-honesty section, `docs/dev-bridge.md`
+read-only wording update, SELinux verification, `unsupported_arch` handling)
+remains binding on the implementation PRs and is not resolved here.
+
+## CI check
+
+`tools/ci/platform_tools_pin_check.py` (run in CI alongside the vendor
+manifest check, covered by `tests/test_platform_tools_pin.py`) validates the
+pin offline and deterministically: schema and required fields; HTTPS with the
+host exactly `dl.google.com`; a specific versioned archive URL (never
+`latest`); a well-formed lowercase SHA-256 or the explicit blocked
+placeholder coupled to `implementation_blocked: true`; a non-empty sorted
+`extract_allowlist` containing `platform-tools/adb` and
+`platform-tools/NOTICE.txt`; the exact `license_name` and
+`license_terms_url`; and a complete, non-empty `license_review` block whose
+`record` path exists in the repository. CI never fetches the archive or the
+terms page.

--- a/tests/test_platform_tools_pin.py
+++ b/tests/test_platform_tools_pin.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import pytest
+
+from tools.ci import platform_tools_pin_check as checker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN_FILE = ROOT / checker.PIN_PATH
+
+
+def _pin():
+    return checker.load_pin(PIN_FILE)
+
+
+def test_repository_pin_is_valid_and_implementation_remains_blocked():
+    pin = _pin()
+
+    assert checker.validate_pin(pin) == []
+    assert pin["archive_sha256"] == checker.BLOCKED_SHA256_PLACEHOLDER
+    assert pin["implementation_blocked"] is True
+    assert pin["license_review"]["record"] == "docs/devbridge-platform-tools-license-review.md"
+
+
+def test_pin_json_parse_failure_is_reported(tmp_path):
+    invalid_pin = tmp_path / "platform_tools_pin.json"
+    invalid_pin.write_text('{"schema_version":', encoding="utf-8")
+
+    with pytest.raises(checker.PinLoadError, match="cannot parse"):
+        checker.load_pin(invalid_pin)
+
+
+def test_pin_requires_schema_fields_and_complete_license_review():
+    pin = _pin()
+    pin.pop("schema_version")
+    pin["license_review"].pop("decision")
+    pin["license_review"]["restrictions"] = []
+
+    errors = checker.validate_pin(pin)
+
+    assert "pin is missing required field: schema_version" in errors
+    assert "license_review is missing required field: decision" in errors
+    assert "license_review.restrictions must not be empty" in errors
+
+
+def test_pin_rejects_http_wrong_host_latest_and_unversioned_urls():
+    http_pin = _pin()
+    http_pin["url"] = http_pin["url"].replace("https://", "http://")
+    assert any("must use https" in error for error in checker.validate_pin(http_pin))
+
+    host_pin = _pin()
+    host_pin["url"] = "https://example.com/android/repository/platform-tools_r36.0.0-linux.zip"
+    assert any("host must be exactly 'dl.google.com'" in error for error in checker.validate_pin(host_pin))
+
+    latest_pin = _pin()
+    latest_pin["url"] = "https://dl.google.com/android/repository/platform-tools-latest-linux.zip"
+    latest_errors = checker.validate_pin(latest_pin)
+    assert any("never a latest endpoint" in error for error in latest_errors)
+    assert any("versioned archive name" in error for error in latest_errors)
+
+    mismatched_pin = _pin()
+    mismatched_pin["url"] = "https://dl.google.com/android/repository/platform-tools_r35.0.2-linux.zip"
+    assert any("versioned archive name" in error for error in checker.validate_pin(mismatched_pin))
+
+
+def test_pin_couples_placeholder_sha256_to_implementation_blocked():
+    unblocked_pin = _pin()
+    unblocked_pin["implementation_blocked"] = False
+    assert (
+        "implementation_blocked must be true while archive_sha256 is the blocked placeholder"
+        in checker.validate_pin(unblocked_pin)
+    )
+
+    malformed_pin = _pin()
+    malformed_pin["archive_sha256"] = "A" * 64
+    assert any(
+        "64 lowercase hexadecimal characters" in error
+        for error in checker.validate_pin(malformed_pin)
+    )
+
+    real_pin = _pin()
+    real_pin["archive_sha256"] = "0" * 64
+    real_pin["implementation_blocked"] = False
+    assert checker.validate_pin(real_pin) == []
+
+
+def test_pin_allowlist_requires_notice_adb_normalized_sorted_unique_entries():
+    empty_pin = _pin()
+    empty_pin["extract_allowlist"] = []
+    empty_errors = checker.validate_pin(empty_pin)
+    assert "extract_allowlist must not be empty" in empty_errors
+    assert "extract_allowlist must include 'platform-tools/NOTICE.txt'" in empty_errors
+    assert "extract_allowlist must include 'platform-tools/adb'" in empty_errors
+
+    traversal_pin = _pin()
+    traversal_pin["extract_allowlist"] = [
+        "/etc/passwd",
+        "platform-tools/../adb",
+        "platform-tools/NOTICE.txt",
+        "platform-tools/adb",
+    ]
+    traversal_errors = checker.validate_pin(traversal_pin)
+    assert any("not a normalized relative path" in error for error in traversal_errors)
+
+    outside_pin = _pin()
+    outside_pin["extract_allowlist"] = ["other-tools/adb", "platform-tools/NOTICE.txt"]
+    outside_errors = checker.validate_pin(outside_pin)
+    assert any("must be under platform-tools/" in error for error in outside_errors)
+    assert "extract_allowlist must include 'platform-tools/adb'" in outside_errors
+
+    unsorted_pin = _pin()
+    unsorted_pin["extract_allowlist"] = ["platform-tools/adb", "platform-tools/NOTICE.txt"]
+    assert (
+        "extract_allowlist entries must be sorted lexicographically"
+        in checker.validate_pin(unsorted_pin)
+    )
+
+    duplicate_pin = _pin()
+    duplicate_pin["extract_allowlist"] = [
+        "platform-tools/NOTICE.txt",
+        "platform-tools/adb",
+        "platform-tools/adb",
+    ]
+    assert "extract_allowlist entries must be unique" in checker.validate_pin(duplicate_pin)
+
+
+def test_pin_license_fields_and_review_values_are_exact():
+    name_pin = _pin()
+    name_pin["license_name"] = "Apache-2.0"
+    assert any("license_name must be" in error for error in checker.validate_pin(name_pin))
+
+    terms_pin = _pin()
+    terms_pin["license_terms_url"] = "http://developer.android.com/studio/terms"
+    terms_pin["license_review"]["terms_url"] = "https://example.com/terms"
+    terms_errors = checker.validate_pin(terms_pin)
+    assert any("license_terms_url must be" in error for error in terms_errors)
+    assert any("license_review.terms_url must be" in error for error in terms_errors)
+
+    date_pin = _pin()
+    date_pin["license_review"]["reviewed_at"] = "July 25, 2026"
+    assert (
+        "license_review.reviewed_at must be an ISO date (YYYY-MM-DD)"
+        in checker.validate_pin(date_pin)
+    )
+
+    record_pin = _pin()
+    record_pin["license_review"]["record"] = "docs/does-not-exist.md"
+    assert any(
+        "license_review.record does not exist" in error
+        for error in checker.validate_pin(record_pin)
+    )
+
+
+def test_pin_rejects_wrong_arch_version_and_size_values():
+    pin = _pin()
+    pin["arch"] = "arm64"
+    pin["version"] = "latest"
+    pin["max_archive_bytes"] = 0
+
+    errors = checker.validate_pin(pin)
+
+    assert any("arch must be 'x86_64'" in error for error in errors)
+    assert "version must be a specific release of the form rMAJOR.MINOR.PATCH" in errors
+    assert "max_archive_bytes must be a positive integer" in errors

--- a/tools/ci/platform_tools_pin_check.py
+++ b/tools/ci/platform_tools_pin_check.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Validate the Dev Bridge Platform-Tools pin metadata file.
+
+This CI tool checks the reviewed pin schema offline and deterministically. It never
+fetches the pinned archive or the license terms page, and it is metadata validation
+only — not downloader, installer, or runtime behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PIN_PATH = "backend/vr_hotspotd/devtools/platform_tools_pin.json"
+BLOCKED_SHA256_PLACEHOLDER = (
+    "BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED"
+)
+EXPECTED_HOST = "dl.google.com"
+EXPECTED_LICENSE_NAME = "Android SDK License Agreement"
+EXPECTED_LICENSE_TERMS_URL = "https://developer.android.com/studio/terms"
+REQUIRED_ALLOWLIST_ENTRIES = ("platform-tools/NOTICE.txt", "platform-tools/adb")
+
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+VERSION_RE = re.compile(r"r[0-9]+\.[0-9]+\.[0-9]+")
+DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+
+REQUIRED_PIN_FIELDS = frozenset(
+    {
+        "schema_version",
+        "version",
+        "url",
+        "archive_sha256",
+        "implementation_blocked",
+        "max_archive_bytes",
+        "arch",
+        "extract_allowlist",
+        "license_name",
+        "license_terms_url",
+        "license_review",
+    }
+)
+REQUIRED_REVIEW_FIELDS = frozenset(
+    {
+        "reviewed_at",
+        "reviewer",
+        "terms_url",
+        "decision",
+        "rationale",
+        "restrictions",
+        "record",
+    }
+)
+
+
+class PinLoadError(ValueError):
+    """The pin file could not be loaded as a JSON object."""
+
+
+def load_pin(path: Path) -> dict[str, Any]:
+    try:
+        pin = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PinLoadError(f"cannot parse {path}: {exc}") from exc
+    if not isinstance(pin, dict):
+        raise PinLoadError(f"cannot parse {path}: top-level JSON value must be an object")
+    return pin
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_string_list(
+    errors: list[str], value: Any, label: str, *, require_nonempty: bool = False
+) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be an array of non-empty strings")
+        return
+    if require_nonempty and not value:
+        errors.append(f"{label} must not be empty")
+    for index, item in enumerate(value):
+        if not _is_nonempty_string(item):
+            errors.append(f"{label}[{index}] must be a non-empty string")
+
+
+def _validate_url(pin: dict[str, Any], errors: list[str]) -> None:
+    url = pin.get("url")
+    if not _is_nonempty_string(url):
+        errors.append("url must be a non-empty string")
+        return
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        errors.append(f"url must use https: {url!r}")
+    if parsed.netloc != EXPECTED_HOST:
+        errors.append(f"url host must be exactly {EXPECTED_HOST!r}: {url!r}")
+    if "latest" in url:
+        errors.append(f"url must pin a specific release, never a latest endpoint: {url!r}")
+    version = pin.get("version")
+    if _is_nonempty_string(version) and not url.endswith(f"platform-tools_{version}-linux.zip"):
+        errors.append(
+            f"url must end with the versioned archive name platform-tools_{version}-linux.zip: "
+            f"{url!r}"
+        )
+
+
+def _validate_archive_sha256(pin: dict[str, Any], errors: list[str]) -> None:
+    sha256 = pin.get("archive_sha256")
+    if not isinstance(sha256, str):
+        errors.append("archive_sha256 must be a string")
+        return
+    if sha256 == BLOCKED_SHA256_PLACEHOLDER:
+        if pin.get("implementation_blocked") is not True:
+            errors.append(
+                "implementation_blocked must be true while archive_sha256 is the "
+                "blocked placeholder"
+            )
+        return
+    if SHA256_RE.fullmatch(sha256) is None:
+        errors.append(
+            "archive_sha256 must be exactly 64 lowercase hexadecimal characters or the "
+            f"blocked placeholder {BLOCKED_SHA256_PLACEHOLDER!r}"
+        )
+
+
+def _validate_extract_allowlist(pin: dict[str, Any], errors: list[str]) -> None:
+    allowlist = pin.get("extract_allowlist")
+    _validate_string_list(errors, allowlist, "extract_allowlist", require_nonempty=True)
+    if not isinstance(allowlist, list):
+        return
+    entries = [entry for entry in allowlist if _is_nonempty_string(entry)]
+    for entry in entries:
+        parts = entry.split("/")
+        if entry.startswith("/") or "\\" in entry or any(part in {"", ".", ".."} for part in parts):
+            errors.append(f"extract_allowlist entry is not a normalized relative path: {entry!r}")
+        elif not entry.startswith("platform-tools/"):
+            errors.append(f"extract_allowlist entry must be under platform-tools/: {entry!r}")
+    if len(set(entries)) != len(entries):
+        errors.append("extract_allowlist entries must be unique")
+    if entries != sorted(entries):
+        errors.append("extract_allowlist entries must be sorted lexicographically")
+    for required in REQUIRED_ALLOWLIST_ENTRIES:
+        if required not in entries:
+            errors.append(f"extract_allowlist must include {required!r}")
+
+
+def _validate_license_review(pin: dict[str, Any], errors: list[str]) -> None:
+    review = pin.get("license_review")
+    if not isinstance(review, dict):
+        errors.append("license_review must be an object")
+        return
+    for field in sorted(REQUIRED_REVIEW_FIELDS.difference(review)):
+        errors.append(f"license_review is missing required field: {field}")
+
+    for field in ("reviewer", "decision", "rationale"):
+        if field in review and not _is_nonempty_string(review.get(field)):
+            errors.append(f"license_review.{field} must be a non-empty string")
+
+    reviewed_at = review.get("reviewed_at")
+    if "reviewed_at" in review and (
+        not isinstance(reviewed_at, str) or DATE_RE.fullmatch(reviewed_at) is None
+    ):
+        errors.append("license_review.reviewed_at must be an ISO date (YYYY-MM-DD)")
+
+    if "terms_url" in review and review.get("terms_url") != EXPECTED_LICENSE_TERMS_URL:
+        errors.append(f"license_review.terms_url must be {EXPECTED_LICENSE_TERMS_URL!r}")
+
+    if "restrictions" in review:
+        _validate_string_list(
+            errors, review.get("restrictions"), "license_review.restrictions", require_nonempty=True
+        )
+
+    record = review.get("record")
+    if "record" in review:
+        if not _is_nonempty_string(record) or record.startswith("/") or ".." in record:
+            errors.append("license_review.record must be a normalized repository-relative path")
+        elif not (REPO_ROOT / record).is_file():
+            errors.append(f"license_review.record does not exist in the repository: {record!r}")
+
+
+def validate_pin(pin: dict[str, Any]) -> list[str]:
+    """Return deterministic validation errors for the pin metadata."""
+
+    errors: list[str] = []
+    for field in sorted(REQUIRED_PIN_FIELDS.difference(pin)):
+        errors.append(f"pin is missing required field: {field}")
+
+    if pin.get("schema_version") != 1:
+        errors.append("schema_version must be the supported value 1")
+
+    version = pin.get("version")
+    if not isinstance(version, str) or VERSION_RE.fullmatch(version) is None:
+        errors.append("version must be a specific release of the form rMAJOR.MINOR.PATCH")
+
+    _validate_url(pin, errors)
+    _validate_archive_sha256(pin, errors)
+
+    if type(pin.get("implementation_blocked")) is not bool:
+        errors.append("implementation_blocked must be a boolean")
+
+    max_archive_bytes = pin.get("max_archive_bytes")
+    if type(max_archive_bytes) is not int or max_archive_bytes <= 0:
+        errors.append("max_archive_bytes must be a positive integer")
+
+    if pin.get("arch") != "x86_64":
+        errors.append("arch must be 'x86_64' (Linux Platform-Tools are published for x86_64 only)")
+
+    _validate_extract_allowlist(pin, errors)
+
+    if pin.get("license_name") != EXPECTED_LICENSE_NAME:
+        errors.append(f"license_name must be {EXPECTED_LICENSE_NAME!r}")
+    if pin.get("license_terms_url") != EXPECTED_LICENSE_TERMS_URL:
+        errors.append(f"license_terms_url must be {EXPECTED_LICENSE_TERMS_URL!r}")
+
+    _validate_license_review(pin, errors)
+
+    if "notes" in pin:
+        _validate_string_list(errors, pin.get("notes"), "notes")
+
+    return errors
+
+
+def main() -> int:
+    pin_file = REPO_ROOT / PIN_PATH
+    try:
+        pin = load_pin(pin_file)
+    except PinLoadError as exc:
+        print(f"platform-tools pin validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate_pin(pin)
+    if errors:
+        print("platform-tools pin validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"platform-tools pin validation passed: {PIN_PATH}")
+    if pin["archive_sha256"] == BLOCKED_SHA256_PLACEHOLDER:
+        print(
+            "downloader implementation remains blocked: archive_sha256 is the placeholder "
+            "and implementation_blocked is true"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Summary
- Add reviewed Platform-Tools pin metadata for future Dev Bridge managed ADB tools.
- Add a license review record for the Android SDK Platform-Tools download path.
- Add an offline CI/schema check so downloader implementation remains blocked until the real SHA-256 and review state are committed.

# Safety boundaries
- No Platform-Tools archive downloaded.
- No binaries vendored.
- No downloader implementation.
- No install endpoint.
- No UI changes.
- No redistribution assumed.
- User acceptance remains required before any future download.

# Validation
- Review approved.
- Platform-Tools pin check passed.
- Targeted tests passed: 8 passed.
- Full pytest passed: 1002 passed, 4 subtests passed.
- Ruff passed.
- git diff --check passed.
