### PR TITLE
Add Dev Bridge tools status foundation

### DIFF
--- a/backend/vr_hotspotd/api.py
+++ b/backend/vr_hotspotd/api.py
@@ -45,6 +45,7 @@ from vr_hotspotd.diagnostics.devbridge import (
     collect_devbridge_status,
     is_valid_ipv4,
 )
+from vr_hotspotd.devtools.platform_tools import collect_devbridge_tools_status
 from vr_hotspotd.diagnostics.ping import run_ping, ping_available
 from vr_hotspotd.diagnostics.load import LoadGenerator, validate_curl_url, validate_network_host
 from vr_hotspotd.diagnostics.udp_latency import run_udp_latency_test
@@ -1108,6 +1109,26 @@ class APIHandler(BaseHTTPRequestHandler):
         try:
             files.append(
                 self._support_bundle_json_file(
+                    "vr-hotspot/devbridge_tools.json",
+                    "vr hotspot dev bridge tools",
+                    collect_devbridge_tools_status(),
+                )
+            )
+        except Exception as exc:
+            warnings.append("devbridge_tools_unavailable")
+            files.append(
+                self._support_bundle_json_file(
+                    "vr-hotspot/devbridge_tools.json",
+                    "vr hotspot dev bridge tools",
+                    {},
+                    status=CollectorStatus.FAILED,
+                    error_summary=f"dev bridge tools status unavailable: {exc}",
+                )
+            )
+
+        try:
+            files.append(
+                self._support_bundle_json_file(
                     "vr-hotspot/vendor_provenance.json",
                     "vendor provenance",
                     collect_vendor_provenance(generated_at=generated_at),
@@ -1412,6 +1433,16 @@ class APIHandler(BaseHTTPRequestHandler):
                 self._envelope(
                     correlation_id=cid,
                     data=collect_devbridge_readiness(probe_adb=probe),
+                ),
+            )
+            return
+
+        if path == "/v1/devbridge/tools/status":
+            self._respond(
+                200,
+                self._envelope(
+                    correlation_id=cid,
+                    data=collect_devbridge_tools_status(),
                 ),
             )
             return

--- a/backend/vr_hotspotd/cli.py
+++ b/backend/vr_hotspotd/cli.py
@@ -24,6 +24,7 @@ DEVBRIDGE_STATUS_PATH = "/v1/devbridge/status"
 DEVBRIDGE_DEVICES_PATH = "/v1/devbridge/devices"
 DEVBRIDGE_ADB_PATH = "/v1/devbridge/adb"
 DEVBRIDGE_READINESS_PATH = "/v1/devbridge/readiness"
+DEVBRIDGE_TOOLS_STATUS_PATH = "/v1/devbridge/tools/status"
 
 _ENV_KEYS = {
     "VR_HOTSPOTD_API_TOKEN",
@@ -446,6 +447,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target headset IPv4 address to generate commands for.",
     )
 
+    devbridge_tools_parser = devbridge_commands.add_parser(
+        "tools",
+        help=(
+            "Read-only Dev Bridge developer-tools helpers. Nothing is downloaded, "
+            "installed, or executed."
+        ),
+    )
+    devbridge_tools_commands = devbridge_tools_parser.add_subparsers(
+        dest="devbridge_tools_command",
+        required=True,
+    )
+    devbridge_tools_status_parser = devbridge_tools_commands.add_parser(
+        "status",
+        help=(
+            "Print the Dev Bridge tools status: Platform-Tools pin metadata, "
+            "managed/system adb discovery, and the effective adb source."
+        ),
+    )
+    _add_client_arguments(devbridge_tools_status_parser)
+
     devbridge_logcat_parser = devbridge_commands.add_parser(
         "logcat-command",
         help="Print copyable logcat helper commands; logcat is never collected for you.",
@@ -569,6 +590,15 @@ def _devbridge_request(args: argparse.Namespace) -> Tuple[str, str, str]:
         if args.no_probe:
             path += "?" + urlencode({"probe": "0"})
         return path, "cli-devbridge-scan", "a Dev Bridge device scan"
+    if subcommand == "tools":
+        tools_subcommand = getattr(args, "devbridge_tools_command", None)
+        if tools_subcommand == "status":
+            return (
+                DEVBRIDGE_TOOLS_STATUS_PATH,
+                "cli-devbridge-tools-status",
+                "a Dev Bridge tools status report",
+            )
+        raise CLIError(f"unknown devbridge tools command: {tools_subcommand}")
     if subcommand in ("adb-command", "logcat-command"):
         kind = "connect" if subcommand == "adb-command" else "logcat"
         query = {"kind": kind}

--- a/backend/vr_hotspotd/devtools/__init__.py
+++ b/backend/vr_hotspotd/devtools/__init__.py
@@ -1,0 +1,8 @@
+"""Dev Bridge managed developer-tools metadata and read-only status.
+
+This package holds the reviewed Platform-Tools pin metadata
+(``platform_tools_pin.json``) and the read-only status/discovery code built
+on top of it. Nothing in this package downloads, installs, removes, or
+executes anything; installer/downloader behavior is intentionally absent and
+remains blocked by the pin's ``implementation_blocked`` flag.
+"""

--- a/backend/vr_hotspotd/devtools/platform_tools.py
+++ b/backend/vr_hotspotd/devtools/platform_tools.py
@@ -1,0 +1,322 @@
+"""Read-only Platform-Tools pin loading, adb discovery, and tools status.
+
+This module reads the reviewed pin metadata shipped with the package,
+discovers whether a VRhotspot-managed or system ``adb`` exists on the host,
+and builds the Dev Bridge tools status model.
+
+Hard boundaries, enforced by construction:
+
+- No network access of any kind. The pinned URL is parsed for its host name
+  only and is never fetched.
+- ``adb`` is never executed; discovery is filesystem/PATH inspection only.
+- Nothing is installed, removed, or modified anywhere on the host.
+- While the pin's ``archive_sha256`` is the review placeholder, the status
+  always reports ``implementation_blocked`` true regardless of the flag.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import urlsplit
+
+
+TOOLS_STATUS_SCHEMA_VERSION = 1
+
+PIN_FILENAME = "platform_tools_pin.json"
+BLOCKED_SHA256_PLACEHOLDER = (
+    "BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED"
+)
+PIN_URL_ALLOWED_HOST = "dl.google.com"
+
+DEVTOOLS_ROOT = "/var/lib/vr-hotspot/devtools"
+MANAGED_ADB_PATH = DEVTOOLS_ROOT + "/platform-tools/adb"
+
+ADB_SOURCE_MANAGED = "managed"
+ADB_SOURCE_SYSTEM = "system"
+ADB_SOURCE_MISSING = "missing"
+
+BLOCKED_REASON_PLACEHOLDER_SHA256 = "archive_sha256_placeholder"
+BLOCKED_REASON_PIN_FLAG = "implementation_blocked_by_pin"
+BLOCKED_REASON_PIN_UNAVAILABLE = "pin_unavailable"
+
+_ARCH_ALIASES = {
+    "amd64": "x86_64",
+    "x64": "x86_64",
+    "arm64": "aarch64",
+}
+
+_TOOLS_STATUS_NOTES = (
+    "Dev Bridge tools status is read-only: nothing is downloaded, installed, "
+    "removed, or executed.",
+    "The Platform-Tools pin is reviewed metadata only; downloader/installer "
+    "code is intentionally not implemented while implementation_blocked is true.",
+)
+
+
+class PinError(ValueError):
+    """The Platform-Tools pin metadata is missing, unreadable, or invalid."""
+
+
+def default_pin_path() -> Path:
+    """Path of the pin file shipped inside this package."""
+
+    return Path(__file__).resolve().parent / PIN_FILENAME
+
+
+def _is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_pin(pin: Mapping[str, Any]) -> List[str]:
+    """Runtime schema validation; a subset of tools/ci/platform_tools_pin_check.py."""
+
+    errors: List[str] = []
+    if pin.get("schema_version") != 1:
+        errors.append("schema_version must be the supported value 1")
+    if not _is_nonempty_string(pin.get("version")):
+        errors.append("version must be a non-empty string")
+
+    url = pin.get("url")
+    if not _is_nonempty_string(url):
+        errors.append("url must be a non-empty string")
+    else:
+        parsed = urlsplit(url)
+        if parsed.scheme != "https":
+            errors.append("url must use https")
+        if parsed.netloc != PIN_URL_ALLOWED_HOST:
+            errors.append(f"url host must be exactly {PIN_URL_ALLOWED_HOST!r}")
+
+    sha256 = pin.get("archive_sha256")
+    if not isinstance(sha256, str):
+        errors.append("archive_sha256 must be a string")
+    elif sha256 != BLOCKED_SHA256_PLACEHOLDER and not (
+        len(sha256) == 64 and all(c in "0123456789abcdef" for c in sha256)
+    ):
+        errors.append(
+            "archive_sha256 must be 64 lowercase hex characters or the blocked placeholder"
+        )
+
+    if not isinstance(pin.get("implementation_blocked"), bool):
+        errors.append("implementation_blocked must be a boolean")
+    if not _is_nonempty_string(pin.get("arch")):
+        errors.append("arch must be a non-empty string")
+
+    allowlist = pin.get("extract_allowlist")
+    if (
+        not isinstance(allowlist, list)
+        or not allowlist
+        or not all(_is_nonempty_string(entry) for entry in allowlist)
+    ):
+        errors.append("extract_allowlist must be a non-empty array of non-empty strings")
+
+    return errors
+
+
+def load_platform_tools_pin(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load and validate the pin metadata. Raises PinError; never touches the network."""
+
+    pin_path = Path(path) if path is not None else default_pin_path()
+    try:
+        raw = pin_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PinError(f"cannot read Platform-Tools pin {pin_path}: {exc}") from exc
+    try:
+        pin = json.loads(raw)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise PinError(f"cannot parse Platform-Tools pin {pin_path}: {exc}") from exc
+    if not isinstance(pin, dict):
+        raise PinError(
+            f"cannot parse Platform-Tools pin {pin_path}: top-level value must be an object"
+        )
+    errors = _validate_pin(pin)
+    if errors:
+        raise PinError(
+            f"invalid Platform-Tools pin {pin_path}: " + "; ".join(errors)
+        )
+    return pin
+
+
+def pin_is_blocked(pin: Mapping[str, Any]) -> bool:
+    """Fail safe: the placeholder hash blocks implementation regardless of the flag."""
+
+    if pin.get("archive_sha256") == BLOCKED_SHA256_PLACEHOLDER:
+        return True
+    return bool(pin.get("implementation_blocked"))
+
+
+def pin_blocked_reason(pin: Mapping[str, Any]) -> Optional[str]:
+    if pin.get("archive_sha256") == BLOCKED_SHA256_PLACEHOLDER:
+        return BLOCKED_REASON_PLACEHOLDER_SHA256
+    if pin.get("implementation_blocked"):
+        return BLOCKED_REASON_PIN_FLAG
+    return None
+
+
+def pin_url_host(pin: Mapping[str, Any]) -> Optional[str]:
+    """Host name of the pinned URL only; the full URL is never reported."""
+
+    url = pin.get("url")
+    if not _is_nonempty_string(url):
+        return None
+    try:
+        return urlsplit(url).hostname
+    except ValueError:
+        return None
+
+
+def normalize_arch(machine: Optional[str]) -> Optional[str]:
+    if not _is_nonempty_string(machine):
+        return None
+    normalized = machine.strip().lower()
+    return _ARCH_ALIASES.get(normalized, normalized)
+
+
+def discover_adb(
+    *,
+    managed_path: str = MANAGED_ADB_PATH,
+    which=shutil.which,
+) -> Dict[str, Any]:
+    """Filesystem/PATH discovery of adb. Never executes anything."""
+
+    managed = Path(managed_path)
+    try:
+        managed_present = managed.exists() or managed.is_symlink()
+        managed_installed = (
+            managed.is_file()
+            and not managed.is_symlink()
+            and os.access(managed_path, os.X_OK)
+        )
+    except OSError:
+        managed_present = False
+        managed_installed = False
+
+    try:
+        system_path = which("adb")
+    except Exception:
+        system_path = None
+
+    if managed_installed:
+        source = ADB_SOURCE_MANAGED
+        effective_path: Optional[str] = managed_path
+    elif system_path:
+        source = ADB_SOURCE_SYSTEM
+        effective_path = system_path
+    else:
+        source = ADB_SOURCE_MISSING
+        effective_path = None
+
+    return {
+        "managed": {
+            "path": managed_path,
+            "present": managed_present,
+            "installed": managed_installed,
+            # No managed install exists in the status foundation, so there is
+            # no installed-tools ledger to verify bytes against yet.
+            "verified": None,
+        },
+        "system": {
+            "present": bool(system_path),
+            "path": system_path,
+        },
+        "source": source,
+        "path": effective_path,
+    }
+
+
+def build_devbridge_tools_status(
+    *,
+    pin: Optional[Mapping[str, Any]],
+    pin_error: Optional[str],
+    discovery: Mapping[str, Any],
+    host_machine: Optional[str],
+) -> Dict[str, Any]:
+    """Pure read-only tools status model shared by API, CLI, and support bundle."""
+
+    warnings: List[str] = []
+    host_arch = normalize_arch(host_machine)
+
+    if pin is not None:
+        pin_view: Dict[str, Any] = {
+            "available": True,
+            "version": pin.get("version"),
+            "url_host": pin_url_host(pin),
+            "arch": pin.get("arch"),
+            "implementation_blocked": pin_is_blocked(pin),
+            "blocked_reason": pin_blocked_reason(pin),
+            "error": None,
+        }
+        arch_supported: Optional[bool] = host_arch == normalize_arch(pin.get("arch"))
+        if not arch_supported:
+            warnings.append("unsupported_arch")
+    else:
+        pin_view = {
+            "available": False,
+            "version": None,
+            "url_host": None,
+            "arch": None,
+            # Fail safe: without a readable pin nothing may be implemented.
+            "implementation_blocked": True,
+            "blocked_reason": BLOCKED_REASON_PIN_UNAVAILABLE,
+            "error": pin_error or "pin unavailable",
+        }
+        arch_supported = None
+        warnings.append("platform_tools_pin_unavailable")
+
+    return {
+        "schema_version": TOOLS_STATUS_SCHEMA_VERSION,
+        "mode": "read_only",
+        "platform_tools_pin": pin_view,
+        "host": {
+            "machine": host_machine,
+            "arch": host_arch,
+            "arch_supported": arch_supported,
+        },
+        "adb": dict(discovery),
+        "warnings": warnings,
+        "notes": list(_TOOLS_STATUS_NOTES),
+    }
+
+
+def collect_devbridge_tools_status() -> Dict[str, Any]:
+    """Gather the read-only Dev Bridge tools status. Never raises."""
+
+    pin: Optional[Dict[str, Any]] = None
+    pin_error: Optional[str] = None
+    try:
+        pin = load_platform_tools_pin()
+    except PinError as exc:
+        pin_error = str(exc)
+    except Exception as exc:  # defensive: status must never fail the caller
+        pin_error = f"unexpected pin load failure: {type(exc).__name__}"
+
+    try:
+        discovery = discover_adb()
+    except Exception:
+        discovery = {
+            "managed": {
+                "path": MANAGED_ADB_PATH,
+                "present": False,
+                "installed": False,
+                "verified": None,
+            },
+            "system": {"present": False, "path": None},
+            "source": ADB_SOURCE_MISSING,
+            "path": None,
+        }
+
+    try:
+        host_machine: Optional[str] = platform.machine() or None
+    except Exception:
+        host_machine = None
+
+    return build_devbridge_tools_status(
+        pin=pin,
+        pin_error=pin_error,
+        discovery=discovery,
+        host_machine=host_machine,
+    )

--- a/docs/dev-bridge.md
+++ b/docs/dev-bridge.md
@@ -28,6 +28,7 @@ All endpoints require the same API token as other `/v1` routes.
 | `GET /v1/devbridge/devices` | Devices on the hotspot network with hostname-based headset classification and optional port-5555 reachability (`?probe=0` to skip). |
 | `GET /v1/devbridge/adb` | Copyable `adb connect`, Wireless Debugging pairing, and logcat commands. Filters: `?ip=<IPv4>`, `?kind=connect\|logcat\|all`. Never probes, never executes. |
 | `GET /v1/devbridge/readiness` | Ordered readiness checks for Unity Build & Run; every non-passing check carries `next_step` text and a copyable `next_step_command`. |
+| `GET /v1/devbridge/tools/status` | Read-only Dev Bridge tools status: Platform-Tools pin metadata (version, URL host only, `implementation_blocked`), managed/system `adb` discovery, and the effective `adb` source. Never downloads, installs, or executes anything. |
 
 All payloads carry `schema_version` and are built by pure model builders in
 `backend/vr_hotspotd/diagnostics/devbridge.py`, so the CLI, HTTP API, support
@@ -44,6 +45,7 @@ vr-hotspot devbridge scan              # GET /v1/devbridge/devices
 vr-hotspot devbridge scan --no-probe   # skip the port-5555 TCP check
 vr-hotspot devbridge adb-command --ip 192.168.68.23     # connect/pairing commands
 vr-hotspot devbridge logcat-command --ip 192.168.68.23  # logcat helper commands
+vr-hotspot devbridge tools status      # GET /v1/devbridge/tools/status
 ```
 
 The shared connection flags from `vr-hotspot preflight` apply
@@ -60,12 +62,41 @@ are `pass`, `warning`, `fail`, `skipped`, or `unknown`; `overall` is `ready`,
 `skipped` (not failed) while it is down, and each carries a copyable next
 step.
 
+## Developer tools status (read-only)
+
+`GET /v1/devbridge/tools/status` and `vr-hotspot devbridge tools status`
+report the state of the Dev Bridge developer tools without changing anything:
+
+- **Platform-Tools pin.** The reviewed pin metadata shipped at
+  `backend/vr_hotspotd/devtools/platform_tools_pin.json` is loaded and
+  validated at runtime. The status reports the pinned `version`, the URL
+  **host only** (`dl.google.com` — the full URL is never reported), the pin's
+  target `arch`, `implementation_blocked`, and a `blocked_reason`
+  (`archive_sha256_placeholder` while the pin's SHA-256 is the review
+  placeholder). While blocked, no downloader or installer exists; see
+  `docs/devbridge-adb-tools-plan.md` for the plan those features must follow.
+- **adb discovery.** Discovery is filesystem/PATH inspection only, in this
+  order: the managed path
+  `/var/lib/vr-hotspot/devtools/platform-tools/adb` (counted as installed
+  only when it is a regular, non-symlinked, executable file), then
+  `adb` on `PATH`. The effective `source` is `managed`, `system`, or
+  `missing`. `managed.verified` is `null` in this foundation: no managed
+  install (and therefore no installed-tools ledger) exists yet.
+- **Host architecture.** If the host architecture does not match the pin's
+  `arch` (Linux Platform-Tools are published for x86_64 only), the status
+  carries an `unsupported_arch` warning.
+
+There are no install or remove endpoints. `adb` is never executed, no network
+request is ever made by the status path, and the pin is metadata only.
+
 ## Support bundle
 
 `vr-hotspot/devbridge.json` in the support bundle contains the probe-free Dev
 Bridge status. It passes through the standard support-bundle redaction (MAC
 addresses and public IPs are redacted) and never contains logcat output or
-pairing data.
+pairing data. `vr-hotspot/devbridge_tools.json` contains the read-only tools
+status above (pin version and URL host only, discovery results) through the
+same redaction path; it never contains tool bytes or the full pinned URL.
 
 ## Non-goals
 

--- a/docs/support-bundle.md
+++ b/docs/support-bundle.md
@@ -35,9 +35,12 @@ The implemented web support bundle is intentionally limited but useful:
   and a timestamped `vr-hotspot-support-bundle-YYYYMMDD-HHMMSS.zip` filename.
 - Current archive content includes `manifest.json`, `README.txt`,
   `vr-hotspot/version.json`, `vr-hotspot/status.json`,
-  `vr-hotspot/adapters.json`, `vr-hotspot/readiness.json`, and
+  `vr-hotspot/adapters.json`, `vr-hotspot/readiness.json`,
   `vr-hotspot/devbridge.json` (read-only ADB Dev Bridge status; no logcat
-  content, no pairing codes).
+  content, no pairing codes), and `vr-hotspot/devbridge_tools.json`
+  (read-only Dev Bridge tools status: Platform-Tools pin version and URL
+  host only, managed/system adb discovery; never the full pinned URL and
+  never any tool bytes).
 - API tokens, passphrases, private keys, PSKs, emails, usernames, public IPs,
   and MAC addresses are redacted before files enter the archive.
 - The Pro web UI includes a "Download support bundle" action.
@@ -194,6 +197,7 @@ vr-hotspot/
   adapters.json
   readiness.json
   devbridge.json
+  devbridge_tools.json
   config.redacted.json
 wireless/
   iw-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ package-dir = {"" = "backend"}
 [tool.setuptools.packages.find]
 where = ["backend"]
 
+[tool.setuptools.package-data]
+"vr_hotspotd.devtools" = ["platform_tools_pin.json"]
+
 [tool.ruff]
 target-version = "py39"
 line-length = 100

--- a/tests/test_api_devbridge.py
+++ b/tests/test_api_devbridge.py
@@ -168,6 +168,23 @@ def test_devbridge_readiness_endpoint(monkeypatch):
     assert _response_json(handler)["data"] == {"overall": "ready"}
 
 
+def test_devbridge_tools_status_endpoint(monkeypatch):
+    sentinel = {
+        "schema_version": 1,
+        "mode": "read_only",
+        "platform_tools_pin": {"implementation_blocked": True},
+    }
+    monkeypatch.setattr(api, "collect_devbridge_tools_status", lambda: sentinel)
+
+    handler = _authed_get(monkeypatch, "/v1/devbridge/tools/status")
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert set(payload) == {"correlation_id", "result_code", "warnings", "data"}
+    assert payload["result_code"] == "ok"
+    assert payload["data"] == sentinel
+
+
 def test_devbridge_endpoints_require_auth(monkeypatch):
     monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     for name in (
@@ -175,6 +192,7 @@ def test_devbridge_endpoints_require_auth(monkeypatch):
         "collect_devbridge_devices",
         "collect_adb_command_report",
         "collect_devbridge_readiness",
+        "collect_devbridge_tools_status",
     ):
         monkeypatch.setattr(
             api,
@@ -189,6 +207,7 @@ def test_devbridge_endpoints_require_auth(monkeypatch):
         "/v1/devbridge/devices",
         "/v1/devbridge/adb",
         "/v1/devbridge/readiness",
+        "/v1/devbridge/tools/status",
     ):
         handler = _make_handler(path)
         handler.do_GET()

--- a/tests/test_api_support_bundle.py
+++ b/tests/test_api_support_bundle.py
@@ -88,6 +88,27 @@ def _stub_bundle_sources(monkeypatch):
     )
     monkeypatch.setattr(
         api,
+        "collect_devbridge_tools_status",
+        lambda: {
+            "schema_version": 1,
+            "mode": "read_only",
+            "platform_tools_pin": {
+                "available": True,
+                "version": "r36.0.0",
+                "url_host": "dl.google.com",
+                "implementation_blocked": True,
+                "blocked_reason": "archive_sha256_placeholder",
+            },
+            "adb": {
+                "managed": {"present": False, "installed": False, "verified": None},
+                "system": {"present": False, "path": None},
+                "source": "missing",
+                "path": None,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        api,
         "collect_vendor_provenance",
         lambda **kwargs: {
             "report_schema_version": 1,
@@ -158,6 +179,14 @@ def test_support_bundle_returns_zip_headers_and_required_members(monkeypatch):
     assert "vr-hotspot/devbridge.json" in members
     devbridge_member = json.loads(members["vr-hotspot/devbridge.json"].decode("utf-8"))
     assert devbridge_member["mode"] == "read_only"
+    assert "vr-hotspot/devbridge_tools.json" in members
+    tools_member = json.loads(
+        members["vr-hotspot/devbridge_tools.json"].decode("utf-8")
+    )
+    assert tools_member["mode"] == "read_only"
+    assert tools_member["platform_tools_pin"]["implementation_blocked"] is True
+    assert tools_member["platform_tools_pin"]["url_host"] == "dl.google.com"
+    assert b"https://dl.google.com" not in members["vr-hotspot/devbridge_tools.json"]
     bundle_manifest = json.loads(members["manifest.json"].decode("utf-8"))
     vendor_provenance = json.loads(
         members["vr-hotspot/vendor_provenance.json"].decode("utf-8")

--- a/tests/test_cli_devbridge.py
+++ b/tests/test_cli_devbridge.py
@@ -98,6 +98,42 @@ def test_devbridge_scan_no_probe_disables_probing(monkeypatch, tmp_path, capsys)
     assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/devices?probe=0"
 
 
+def test_devbridge_tools_status_fetches_tools_status_endpoint(
+    monkeypatch, tmp_path, capsys
+):
+    secret = "devbridge-tools-status-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    data = {
+        "schema_version": 1,
+        "mode": "read_only",
+        "platform_tools_pin": {"implementation_blocked": True},
+        "adb": {"source": "missing"},
+    }
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["tools", "status"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == data
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/tools/status"
+    assert seen["headers"]["x-api-token"] == secret
+    assert seen["headers"]["x-correlation-id"].startswith("cli-devbridge-tools-status-")
+    assert secret not in captured.out
+
+
+def test_devbridge_tools_requires_a_subcommand(monkeypatch, tmp_path, capsys):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError("no request may be sent without a tools subcommand")
+
+    monkeypatch.setattr(cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["devbridge", "tools", *_missing_env_args(tmp_path)])
+
+    assert excinfo.value.code == 2
+
+
 def test_devbridge_adb_command_targets_ip(monkeypatch, tmp_path, capsys):
     data = {"kind": "connect", "devices": []}
 

--- a/tests/test_devbridge_tools_status.py
+++ b/tests/test_devbridge_tools_status.py
@@ -1,0 +1,354 @@
+"""Read-only Dev Bridge tools status: pin loading, discovery, and safety rails."""
+
+import json
+import os
+import socket
+import subprocess
+import urllib.request
+
+import pytest
+
+from vr_hotspotd.devtools import platform_tools
+from vr_hotspotd.devtools.platform_tools import (
+    ADB_SOURCE_MANAGED,
+    ADB_SOURCE_MISSING,
+    ADB_SOURCE_SYSTEM,
+    BLOCKED_REASON_PIN_FLAG,
+    BLOCKED_REASON_PIN_UNAVAILABLE,
+    BLOCKED_REASON_PLACEHOLDER_SHA256,
+    BLOCKED_SHA256_PLACEHOLDER,
+    MANAGED_ADB_PATH,
+    PinError,
+    build_devbridge_tools_status,
+    collect_devbridge_tools_status,
+    default_pin_path,
+    discover_adb,
+    load_platform_tools_pin,
+    normalize_arch,
+    pin_blocked_reason,
+    pin_is_blocked,
+)
+
+
+VALID_PIN = {
+    "schema_version": 1,
+    "version": "r36.0.0",
+    "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-linux.zip",
+    "archive_sha256": "a" * 64,
+    "implementation_blocked": False,
+    "max_archive_bytes": 100000000,
+    "arch": "x86_64",
+    "extract_allowlist": ["platform-tools/NOTICE.txt", "platform-tools/adb"],
+}
+
+
+def _write_pin(tmp_path, pin):
+    path = tmp_path / "platform_tools_pin.json"
+    path.write_text(json.dumps(pin), encoding="utf-8")
+    return path
+
+
+# --- pin loading ---
+
+
+def test_packaged_pin_file_exists_next_to_module():
+    assert default_pin_path().is_file()
+
+
+def test_repo_pin_loads_and_reports_blocked_placeholder():
+    pin = load_platform_tools_pin()
+
+    assert pin["schema_version"] == 1
+    assert pin["archive_sha256"] == BLOCKED_SHA256_PLACEHOLDER
+    assert pin["implementation_blocked"] is True
+    assert pin_is_blocked(pin) is True
+    assert pin_blocked_reason(pin) == BLOCKED_REASON_PLACEHOLDER_SHA256
+
+
+def test_load_valid_pin(tmp_path):
+    path = _write_pin(tmp_path, VALID_PIN)
+
+    pin = load_platform_tools_pin(path)
+
+    assert pin["version"] == "r36.0.0"
+    assert pin_is_blocked(pin) is False
+    assert pin_blocked_reason(pin) is None
+
+
+def test_load_missing_pin_raises(tmp_path):
+    with pytest.raises(PinError):
+        load_platform_tools_pin(tmp_path / "missing.json")
+
+
+def test_load_unparseable_pin_raises(tmp_path):
+    path = tmp_path / "platform_tools_pin.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(PinError):
+        load_platform_tools_pin(path)
+
+
+def test_load_non_object_pin_raises(tmp_path):
+    path = tmp_path / "platform_tools_pin.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(PinError):
+        load_platform_tools_pin(path)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"schema_version": 2},
+        {"version": ""},
+        {"url": "http://dl.google.com/android/repository/platform-tools_r36.0.0-linux.zip"},
+        {"url": "https://evil.example.com/platform-tools.zip"},
+        {"archive_sha256": "not-a-hash"},
+        {"archive_sha256": "A" * 64},
+        {"implementation_blocked": "yes"},
+        {"arch": ""},
+        {"extract_allowlist": []},
+        {"extract_allowlist": "platform-tools/adb"},
+    ],
+)
+def test_load_invalid_pin_raises(tmp_path, mutation):
+    pin = dict(VALID_PIN)
+    pin.update(mutation)
+    path = _write_pin(tmp_path, pin)
+
+    with pytest.raises(PinError):
+        load_platform_tools_pin(path)
+
+
+def test_placeholder_hash_blocks_even_if_flag_is_false():
+    pin = dict(VALID_PIN)
+    pin["archive_sha256"] = BLOCKED_SHA256_PLACEHOLDER
+    pin["implementation_blocked"] = False
+
+    assert pin_is_blocked(pin) is True
+    assert pin_blocked_reason(pin) == BLOCKED_REASON_PLACEHOLDER_SHA256
+
+
+def test_flag_alone_blocks_with_pin_flag_reason():
+    pin = dict(VALID_PIN)
+    pin["implementation_blocked"] = True
+
+    assert pin_is_blocked(pin) is True
+    assert pin_blocked_reason(pin) == BLOCKED_REASON_PIN_FLAG
+
+
+# --- adb discovery ---
+
+
+def _managed_adb(tmp_path, *, executable=True):
+    managed = tmp_path / "platform-tools" / "adb"
+    managed.parent.mkdir(parents=True)
+    managed.write_bytes(b"#!/bin/false\n")
+    if executable:
+        managed.chmod(0o755)
+    return managed
+
+
+def test_discovery_prefers_managed_adb(tmp_path):
+    managed = _managed_adb(tmp_path)
+
+    discovery = discover_adb(
+        managed_path=str(managed), which=lambda _name: "/usr/bin/adb"
+    )
+
+    assert discovery["managed"]["present"] is True
+    assert discovery["managed"]["installed"] is True
+    assert discovery["managed"]["verified"] is None
+    assert discovery["system"] == {"present": True, "path": "/usr/bin/adb"}
+    assert discovery["source"] == ADB_SOURCE_MANAGED
+    assert discovery["path"] == str(managed)
+
+
+def test_discovery_falls_back_to_system_adb(tmp_path):
+    discovery = discover_adb(
+        managed_path=str(tmp_path / "platform-tools" / "adb"),
+        which=lambda _name: "/usr/bin/adb",
+    )
+
+    assert discovery["managed"]["present"] is False
+    assert discovery["managed"]["installed"] is False
+    assert discovery["source"] == ADB_SOURCE_SYSTEM
+    assert discovery["path"] == "/usr/bin/adb"
+
+
+def test_discovery_reports_missing(tmp_path):
+    discovery = discover_adb(
+        managed_path=str(tmp_path / "platform-tools" / "adb"),
+        which=lambda _name: None,
+    )
+
+    assert discovery["source"] == ADB_SOURCE_MISSING
+    assert discovery["path"] is None
+    assert discovery["system"] == {"present": False, "path": None}
+
+
+def test_discovery_rejects_non_executable_managed_adb(tmp_path):
+    managed = _managed_adb(tmp_path, executable=False)
+
+    discovery = discover_adb(managed_path=str(managed), which=lambda _name: None)
+
+    assert discovery["managed"]["present"] is True
+    assert discovery["managed"]["installed"] is False
+    assert discovery["source"] == ADB_SOURCE_MISSING
+
+
+def test_discovery_rejects_symlinked_managed_adb(tmp_path):
+    real = tmp_path / "real-adb"
+    real.write_bytes(b"#!/bin/false\n")
+    real.chmod(0o755)
+    link = tmp_path / "adb"
+    link.symlink_to(real)
+
+    discovery = discover_adb(managed_path=str(link), which=lambda _name: None)
+
+    assert discovery["managed"]["present"] is True
+    assert discovery["managed"]["installed"] is False
+    assert discovery["source"] == ADB_SOURCE_MISSING
+
+
+def test_default_managed_path_is_the_planned_location():
+    assert MANAGED_ADB_PATH == "/var/lib/vr-hotspot/devtools/platform-tools/adb"
+
+
+# --- status model ---
+
+
+def _status(**overrides):
+    kwargs = {
+        "pin": load_platform_tools_pin(),
+        "pin_error": None,
+        "discovery": discover_adb(
+            managed_path=str(MANAGED_ADB_PATH), which=lambda _name: None
+        ),
+        "host_machine": "x86_64",
+    }
+    kwargs.update(overrides)
+    return build_devbridge_tools_status(**kwargs)
+
+
+def test_status_model_reports_pin_and_blocked_reason():
+    status = _status()
+
+    assert status["schema_version"] == 1
+    assert status["mode"] == "read_only"
+    pin_view = status["platform_tools_pin"]
+    assert pin_view["available"] is True
+    assert pin_view["version"] == "r36.0.0"
+    assert pin_view["url_host"] == "dl.google.com"
+    assert pin_view["implementation_blocked"] is True
+    assert pin_view["blocked_reason"] == BLOCKED_REASON_PLACEHOLDER_SHA256
+    assert status["host"]["arch_supported"] is True
+    assert "unsupported_arch" not in status["warnings"]
+
+
+def test_status_model_never_contains_full_pin_url():
+    pin = load_platform_tools_pin()
+    rendered = json.dumps(_status())
+
+    assert pin["url"] not in rendered
+    assert "https://dl.google.com" not in rendered
+
+
+def test_status_model_flags_unsupported_arch():
+    status = _status(host_machine="aarch64")
+
+    assert status["host"]["arch"] == "aarch64"
+    assert status["host"]["arch_supported"] is False
+    assert "unsupported_arch" in status["warnings"]
+
+
+def test_status_model_normalizes_amd64():
+    status = _status(host_machine="amd64")
+
+    assert status["host"]["arch"] == "x86_64"
+    assert status["host"]["arch_supported"] is True
+
+
+def test_status_model_fails_safe_without_pin():
+    status = _status(pin=None, pin_error="cannot read pin")
+
+    pin_view = status["platform_tools_pin"]
+    assert pin_view["available"] is False
+    assert pin_view["implementation_blocked"] is True
+    assert pin_view["blocked_reason"] == BLOCKED_REASON_PIN_UNAVAILABLE
+    assert pin_view["error"] == "cannot read pin"
+    assert status["host"]["arch_supported"] is None
+    assert "platform_tools_pin_unavailable" in status["warnings"]
+
+
+def test_normalize_arch():
+    assert normalize_arch("x86_64") == "x86_64"
+    assert normalize_arch("AMD64") == "x86_64"
+    assert normalize_arch("arm64") == "aarch64"
+    assert normalize_arch(None) is None
+    assert normalize_arch("") is None
+
+
+# --- collector safety rails ---
+
+
+def _forbid_network(monkeypatch):
+    def _no_network(*_args, **_kwargs):
+        raise AssertionError("tools status must never touch the network")
+
+    monkeypatch.setattr(socket, "socket", _no_network)
+    monkeypatch.setattr(socket, "create_connection", _no_network)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+
+
+def _forbid_subprocesses(monkeypatch):
+    def _no_exec(*_args, **_kwargs):
+        raise AssertionError("tools status must never execute commands")
+
+    for name in ("run", "check_output", "check_call", "call", "Popen"):
+        monkeypatch.setattr(subprocess, name, _no_exec)
+    for name in ("system", "popen"):
+        monkeypatch.setattr(os, name, _no_exec)
+
+
+def test_collect_makes_no_network_calls_and_executes_nothing(monkeypatch):
+    _forbid_network(monkeypatch)
+    _forbid_subprocesses(monkeypatch)
+
+    status = collect_devbridge_tools_status()
+
+    assert status["schema_version"] == 1
+    assert status["platform_tools_pin"]["available"] is True
+    assert status["platform_tools_pin"]["implementation_blocked"] is True
+    assert status["adb"]["source"] in (
+        ADB_SOURCE_MANAGED,
+        ADB_SOURCE_SYSTEM,
+        ADB_SOURCE_MISSING,
+    )
+
+
+def test_collect_never_raises_when_pin_is_broken(monkeypatch):
+    monkeypatch.setattr(
+        platform_tools,
+        "load_platform_tools_pin",
+        lambda path=None: (_ for _ in ()).throw(PinError("broken pin")),
+    )
+
+    status = collect_devbridge_tools_status()
+
+    assert status["platform_tools_pin"]["available"] is False
+    assert status["platform_tools_pin"]["implementation_blocked"] is True
+    assert status["platform_tools_pin"]["error"] == "broken pin"
+
+
+def test_collect_never_raises_when_discovery_is_broken(monkeypatch):
+    monkeypatch.setattr(
+        platform_tools,
+        "discover_adb",
+        lambda **_kwargs: (_ for _ in ()).throw(OSError("filesystem exploded")),
+    )
+
+    status = collect_devbridge_tools_status()
+
+    assert status["adb"]["source"] == ADB_SOURCE_MISSING
+    assert status["adb"]["managed"]["installed"] is False


### PR DESCRIPTION
# Summary
- Add read-only Dev Bridge tools status foundation.
- Load and validate the Platform-Tools pin metadata at runtime.
- Discover managed/system adb availability without executing adb.
- Add authenticated GET /v1/devbridge/tools/status and CLI support.
- Add safe support-bundle status output.

# Safety boundaries
- No downloader implementation.
- No Platform-Tools archive downloaded.
- No binaries vendored.
- No install/remove endpoints.
- No Web UI or Flatpak UI changes.
- No arbitrary adb command passthrough.
- No APK install support.
- implementation_blocked remains enforced.

# Validation
- Review approved with no blockers.
- Targeted Dev Bridge/tools tests passed: 79 passed.
- Full pytest passed: 1038 passed, 4 subtests passed.
- Ruff passed.
- Platform-Tools pin check passed.
- Installer matrix check passed.
- git diff --check passed.
