### PR TITLE
Unblock Platform-Tools pin

### DIFF
--- a/backend/vr_hotspotd/devtools/platform_tools_pin.json
+++ b/backend/vr_hotspotd/devtools/platform_tools_pin.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "version": "r36.0.0",
-  "url": "https://dl.google.com/android/repository/platform-tools_r36.0.0-linux.zip",
-  "archive_sha256": "BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED",
-  "implementation_blocked": true,
+  "version": "r37.0.0",
+  "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip",
+  "archive_sha256": "198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07",
+  "implementation_blocked": false,
   "max_archive_bytes": 100000000,
   "arch": "x86_64",
   "extract_allowlist": [
@@ -29,8 +29,8 @@
     "record": "docs/devbridge-platform-tools-license-review.md"
   },
   "notes": [
-    "archive_sha256 is an intentionally invalid placeholder: the SHA-256 of the pinned archive has not been independently verified, so implementation_blocked is true and downloader/install code must not be implemented against this pin.",
-    "The pinned version must be re-confirmed as the intended current release when the real SHA-256 is computed; filling the hash and flipping implementation_blocked to false happen together in one reviewed diff.",
-    "This file records reviewed metadata and policy only; it does not download, vendor, or install anything."
+    "archive_sha256 was computed on 2026-07-25 from the official archive downloaded from the pinned URL, hashed twice from independent fetches (byte-identical), and cross-checked against Google's SDK repository manifest (repository2-3.xml), whose linux entry for r37.0.0 publishes SHA-1 bcf323933980a59dccc3f14c339aed5fb2171163 and size 9167924 bytes, both of which matched. The archive was deleted after hashing; no archive or binary bytes entered the repository.",
+    "The pin was re-confirmed against Google's SDK repository manifest on 2026-07-25: the prior placeholder pin's r36.0.0 has been removed from the manifest entirely, and r37.0.1 is a dev-channel release under the android-sdk-preview-license, so r37.0.0 — the stable-channel release governed by the reviewed android-sdk-license (Android SDK License Agreement) — is the pinned version.",
+    "This file records reviewed metadata and policy only; it does not download, vendor, or install anything. Downloader, install/remove endpoints, and UI remain unimplemented and are gated on their own reviewed PRs per docs/devbridge-platform-tools-license-decision.md."
   ]
 }

--- a/docs/devbridge-platform-tools-license-review.md
+++ b/docs/devbridge-platform-tools-license-review.md
@@ -11,8 +11,8 @@ This is the review record referenced by
 `backend/vr_hotspotd/devtools/platform_tools_pin.json` (`license_review.record`).
 It records the dated maintainer review that
 `docs/devbridge-platform-tools-license-decision.md` requires before any
-Platform-Tools download path may be implemented, and it states exactly what
-remains blocked after this record lands.
+Platform-Tools download path may be implemented, and it records the verified
+pin values that unblock the future downloader implementation PR.
 
 ## What was reviewed
 
@@ -55,37 +55,70 @@ downloaded, vendored, or installed by this change, and
 `backend/vendor/VENDOR_MANIFEST.json` scope is unchanged — no Platform-Tools
 bytes are ever repo-vendored.
 
-## What remains blocked
+## Verified pin (2026-07-25)
 
-**Downloader implementation remains blocked.** The pin's `archive_sha256` is
-an intentionally invalid, obvious placeholder
-(`BLOCKED-PLACEHOLDER-DO-NOT-IMPLEMENT-DOWNLOADER-SHA256-NOT-INDEPENDENTLY-VERIFIED`)
-because the SHA-256 of the pinned archive has not been independently
-verified, and per vendor-policy rule 8 CI must never fetch the archive and
-trust the response. Accordingly the pin sets `implementation_blocked: true`,
-and `tools/ci/platform_tools_pin_check.py` rejects a pin whose hash is the
-placeholder without that flag.
+| Field | Value |
+| --- | --- |
+| Version | `r37.0.0` |
+| URL | `https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip` |
+| SHA-256 | `198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07` |
+| Size | 9,167,924 bytes |
+| Verified at | 2026-07-25 |
+| Verified by | josethevrtech (VRhotspot maintainer) |
 
-Until the real hash is recorded, all of the following stay unimplemented:
-downloader code, `/v1/devbridge/tools` install/remove endpoints, installer
-and CLI opt-ins, and any Web Portal / Flatpak UI for tools install.
+How the hash was verified, per this record's cross-check requirement:
 
-To unblock, one reviewed diff must:
+- The archive was downloaded from the exact versioned URL above (never a
+  `latest` endpoint) to a temporary directory outside the repository, hashed
+  with SHA-256, downloaded a second time, and the two fetches compared
+  byte-for-byte (identical).
+- The digest was cross-checked against a second Google-published artifact:
+  the official SDK repository manifest
+  (`https://dl.google.com/android/repository/repository2-3.xml`) — the same
+  metadata `sdkmanager` itself trusts — whose linux `r37.0.0` entry publishes
+  SHA-1 `bcf323933980a59dccc3f14c339aed5fb2171163` and size `9167924`; both
+  matched the downloaded archive exactly.
+- Archive integrity was verified (`unzip -t`) and the listing confirmed the
+  allowlisted paths `platform-tools/adb` and `platform-tools/NOTICE.txt`
+  exist in the archive.
+- The downloaded archives were **deleted after hashing**. No archive, binary,
+  or extracted bytes entered the repository; only this metadata was recorded.
 
-1. Record the real lowercase SHA-256 of the exact pinned archive,
-   independently computed (download the pinned URL after personally accepting
-   the Android SDK License Agreement, hash it, and cross-check the digest
-   from a second independent host/network path — never from a single fetch
-   treated as truth).
-2. Re-confirm that the pinned `version`/`url` is the intended current
-   release, and re-read the then-current terms text, re-dating the pin's
-   `license_review` if the pin version changes.
-3. Flip `implementation_blocked` to `false` in the same diff.
+### Version re-confirmation
 
-Everything else the decision document gates on (acceptance UX and API
-enforcement, `docs/security.md` egress-honesty section, `docs/dev-bridge.md`
-read-only wording update, SELinux verification, `unsupported_arch` handling)
-remains binding on the implementation PRs and is not resolved here.
+The placeholder pin named `r36.0.0`. On 2026-07-25 Google's SDK repository
+manifest no longer lists `r36.0.0` at all (superseded), and `r37.0.1` is a
+**dev-channel** release governed by the `android-sdk-preview-license`, not
+the reviewed Android SDK License Agreement. `r37.0.0` is the current
+**stable-channel** release governed by `android-sdk-license` (the Android SDK
+License Agreement this record reviews), so the pin was re-confirmed as
+`r37.0.0`. This version change is part of the same dated review recorded
+here, satisfying the "version bump re-requires a dated terms re-review"
+restriction.
+
+## What this unblocks — and what it does not
+
+With the real SHA-256 recorded and this dated maintainer review in place,
+the pin sets `implementation_blocked: false`: the future downloader
+implementation PR now has an auditable source of truth to build against.
+
+Nothing else changes in this diff. All of the following remain
+**unimplemented** and gated on their own reviewed PRs, exactly as the
+decision document specifies: downloader code, extraction code,
+`/v1/devbridge/tools` install/remove endpoints, installer and CLI opt-ins,
+and any Web Portal / Flatpak UI for tools install. The implementation PRs
+remain bound by the decision document in full, including:
+
+- **No redistribution**, ever, in any form.
+- **Explicit user acceptance** of the Android SDK License Agreement is still
+  required at install time, before every download, on every surface;
+  acceptance is never defaulted or implied.
+- The implementation must verify the archive against this pin's SHA-256
+  **before extraction**, **delete the archive after extraction**, and retain
+  **no archive cache**.
+- `docs/security.md` egress-honesty section, `docs/dev-bridge.md` read-only
+  wording update, SELinux verification, and `unsupported_arch` handling
+  remain binding on the implementation PRs and are not resolved here.
 
 ## CI check
 

--- a/tests/test_devbridge_tools_status.py
+++ b/tests/test_devbridge_tools_status.py
@@ -55,14 +55,14 @@ def test_packaged_pin_file_exists_next_to_module():
     assert default_pin_path().is_file()
 
 
-def test_repo_pin_loads_and_reports_blocked_placeholder():
+def test_repo_pin_loads_verified_and_unblocked():
     pin = load_platform_tools_pin()
 
     assert pin["schema_version"] == 1
-    assert pin["archive_sha256"] == BLOCKED_SHA256_PLACEHOLDER
-    assert pin["implementation_blocked"] is True
-    assert pin_is_blocked(pin) is True
-    assert pin_blocked_reason(pin) == BLOCKED_REASON_PLACEHOLDER_SHA256
+    assert pin["archive_sha256"] != BLOCKED_SHA256_PLACEHOLDER
+    assert pin["implementation_blocked"] is False
+    assert pin_is_blocked(pin) is False
+    assert pin_blocked_reason(pin) is None
 
 
 def test_load_valid_pin(tmp_path):
@@ -238,10 +238,10 @@ def test_status_model_reports_pin_and_blocked_reason():
     assert status["mode"] == "read_only"
     pin_view = status["platform_tools_pin"]
     assert pin_view["available"] is True
-    assert pin_view["version"] == "r36.0.0"
+    assert pin_view["version"] == "r37.0.0"
     assert pin_view["url_host"] == "dl.google.com"
-    assert pin_view["implementation_blocked"] is True
-    assert pin_view["blocked_reason"] == BLOCKED_REASON_PLACEHOLDER_SHA256
+    assert pin_view["implementation_blocked"] is False
+    assert pin_view["blocked_reason"] is None
     assert status["host"]["arch_supported"] is True
     assert "unsupported_arch" not in status["warnings"]
 
@@ -319,7 +319,7 @@ def test_collect_makes_no_network_calls_and_executes_nothing(monkeypatch):
 
     assert status["schema_version"] == 1
     assert status["platform_tools_pin"]["available"] is True
-    assert status["platform_tools_pin"]["implementation_blocked"] is True
+    assert status["platform_tools_pin"]["implementation_blocked"] is False
     assert status["adb"]["source"] in (
         ADB_SOURCE_MANAGED,
         ADB_SOURCE_SYSTEM,

--- a/tests/test_platform_tools_pin.py
+++ b/tests/test_platform_tools_pin.py
@@ -13,12 +13,13 @@ def _pin():
     return checker.load_pin(PIN_FILE)
 
 
-def test_repository_pin_is_valid_and_implementation_remains_blocked():
+def test_repository_pin_is_valid_verified_and_unblocked():
     pin = _pin()
 
     assert checker.validate_pin(pin) == []
-    assert pin["archive_sha256"] == checker.BLOCKED_SHA256_PLACEHOLDER
-    assert pin["implementation_blocked"] is True
+    assert checker.SHA256_RE.fullmatch(pin["archive_sha256"]) is not None
+    assert pin["archive_sha256"] != checker.BLOCKED_SHA256_PLACEHOLDER
+    assert pin["implementation_blocked"] is False
     assert pin["license_review"]["record"] == "docs/devbridge-platform-tools-license-review.md"
 
 
@@ -49,7 +50,7 @@ def test_pin_rejects_http_wrong_host_latest_and_unversioned_urls():
     assert any("must use https" in error for error in checker.validate_pin(http_pin))
 
     host_pin = _pin()
-    host_pin["url"] = "https://example.com/android/repository/platform-tools_r36.0.0-linux.zip"
+    host_pin["url"] = f"https://example.com/android/repository/platform-tools_{host_pin['version']}-linux.zip"
     assert any("host must be exactly 'dl.google.com'" in error for error in checker.validate_pin(host_pin))
 
     latest_pin = _pin()
@@ -64,12 +65,18 @@ def test_pin_rejects_http_wrong_host_latest_and_unversioned_urls():
 
 
 def test_pin_couples_placeholder_sha256_to_implementation_blocked():
-    unblocked_pin = _pin()
-    unblocked_pin["implementation_blocked"] = False
+    unblocked_placeholder_pin = _pin()
+    unblocked_placeholder_pin["archive_sha256"] = checker.BLOCKED_SHA256_PLACEHOLDER
+    unblocked_placeholder_pin["implementation_blocked"] = False
     assert (
         "implementation_blocked must be true while archive_sha256 is the blocked placeholder"
-        in checker.validate_pin(unblocked_pin)
+        in checker.validate_pin(unblocked_placeholder_pin)
     )
+
+    blocked_placeholder_pin = _pin()
+    blocked_placeholder_pin["archive_sha256"] = checker.BLOCKED_SHA256_PLACEHOLDER
+    blocked_placeholder_pin["implementation_blocked"] = True
+    assert checker.validate_pin(blocked_placeholder_pin) == []
 
     malformed_pin = _pin()
     malformed_pin["archive_sha256"] = "A" * 64


### PR DESCRIPTION
# Summary
- Replace the blocked Platform-Tools placeholder pin with a verified r37.0.0 pin.
- Record the exact versioned Google URL and SHA-256.
- Update the license review record with the maintainer-reviewed decision.
- Flip implementation_blocked to false for the future downloader PR.

# Safety boundaries
- No downloader implementation.
- No install/remove endpoints.
- No Web UI changes.
- No archive or binary committed.
- No Platform-Tools redistribution assumed.
- Explicit user acceptance remains required before any future download.
- Future implementation remains bound to hash-check-before-extract, no-cache/delete-after-extract, and allowlist-only extraction.

# Pin
- Version: r37.0.0
- URL: https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip
- SHA-256: 198ae156ab285fa555987219af237b31102fefe8b9d2bc274708a8d4f2865a07

# Validation
- Review approved with no blockers.
- Platform-Tools pin check passed.
- Targeted tests passed: 41 passed.
- Full pytest passed: 1038 passed, 4 subtests passed.
- Ruff passed.
- git diff --check passed.
