### PR TITLE
Add Developer Hub ADB API endpoints

### DIFF
--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -1,0 +1,132 @@
+"""Authenticated Developer Hub API routes for typed ADB operations.
+
+The main VRhotspot API remains the base handler. This subclass intercepts only
+Developer Hub ADB routes and delegates every other request to the established
+APIHandler implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Mapping, Optional
+
+from vr_hotspotd.api import APIHandler
+from vr_hotspotd.devtools.adb_operations import (
+    RESULT_FAILED,
+    RESULT_INVALID_REQUEST,
+    RESULT_OK,
+    RESULT_OUTPUT_LIMIT,
+    RESULT_TIMEOUT,
+    RESULT_TOOLS_UNAVAILABLE,
+    execute_adb_operation,
+)
+
+
+log = logging.getLogger("vr_hotspotd.devhub_api")
+
+_GET_OPERATIONS = {
+    "/v1/devbridge/adb/version": "version",
+    "/v1/devbridge/adb/devices": "devices",
+}
+
+_POST_OPERATIONS = {
+    "/v1/devbridge/adb/pair": "pair",
+    "/v1/devbridge/adb/connect": "connect",
+    "/v1/devbridge/adb/disconnect": "disconnect",
+}
+
+_RESULT_HTTP_STATUS = {
+    RESULT_OK: 200,
+    RESULT_INVALID_REQUEST: 400,
+    RESULT_TOOLS_UNAVAILABLE: 503,
+    RESULT_TIMEOUT: 504,
+    RESULT_OUTPUT_LIMIT: 502,
+    RESULT_FAILED: 409,
+}
+
+_BODY_ERROR_WARNINGS = {
+    "body_too_large",
+    "body_read_failed",
+    "body_not_object",
+    "body_json_parse_failed",
+}
+
+
+class DevHubAPIHandler(APIHandler):
+    """Extend the daemon API with executable Developer Hub operations."""
+
+    def _respond_adb_operation(
+        self,
+        *,
+        cid: str,
+        operation: str,
+        request: Optional[Mapping[str, Any]] = None,
+        warnings: Optional[list[str]] = None,
+    ) -> None:
+        result = execute_adb_operation(operation, request)
+        result_code = str(result.get("result_code") or RESULT_FAILED)
+        status = _RESULT_HTTP_STATUS.get(result_code, 500)
+        self._respond(
+            status,
+            self._envelope(
+                correlation_id=cid,
+                result_code=result_code,
+                data=result,
+                warnings=list(warnings or []),
+            ),
+        )
+
+    def _respond_invalid_body(self, cid: str, warnings: list[str]) -> None:
+        status = 413 if "body_too_large" in warnings else 400
+        self._respond(
+            status,
+            self._envelope(
+                correlation_id=cid,
+                result_code=RESULT_INVALID_REQUEST,
+                warnings=warnings,
+                data={},
+            ),
+        )
+
+    def do_GET(self):
+        cid = self._cid()
+        path, _qs = self._parse_url()
+        operation = _GET_OPERATIONS.get(path)
+        if operation is None:
+            super().do_GET()
+            return
+
+        log.info(
+            "request",
+            extra={"correlation_id": cid, "method": "GET", "path": self.path},
+        )
+        if not self._require_auth(cid):
+            return
+        self._respond_adb_operation(cid=cid, operation=operation)
+
+    def do_POST(self):
+        cid = self._cid()
+        path, _qs = self._parse_url()
+        operation = _POST_OPERATIONS.get(path)
+        if operation is None:
+            super().do_POST()
+            return
+
+        log.info(
+            "request",
+            extra={"correlation_id": cid, "method": "POST", "path": self.path},
+        )
+        if not self._require_auth(cid):
+            return
+
+        body, warnings = self._read_json_body()
+        if any(warning in _BODY_ERROR_WARNINGS for warning in warnings):
+            self._respond_invalid_body(cid, warnings)
+            return
+
+        self._respond_adb_operation(
+            cid=cid,
+            operation=operation,
+            request=body,
+            warnings=warnings,
+        )

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -8,7 +8,7 @@ APIHandler implementation.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 from vr_hotspotd.api import APIHandler
 from vr_hotspotd.devtools.adb_operations import (

--- a/backend/vr_hotspotd/server.py
+++ b/backend/vr_hotspotd/server.py
@@ -3,7 +3,7 @@ import logging
 import os
 from http.server import ThreadingHTTPServer
 
-from vr_hotspotd.api import APIHandler
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
 
 log = logging.getLogger("vr_hotspotd.server")
 
@@ -30,7 +30,7 @@ def build_server() -> ThreadingHTTPServer:
         log.error("refusing to bind non-loopback without VR_HOTSPOTD_API_TOKEN")
         raise SystemExit(1)
 
-    server = ThreadingHTTPServer((host, port), APIHandler)
+    server = ThreadingHTTPServer((host, port), DevHubAPIHandler)
     server.daemon_threads = True
     log.info("listening", extra={"bind": f"http://{host}:{port}"})
     return server

--- a/tests/test_api_devhub_adb.py
+++ b/tests/test_api_devhub_adb.py
@@ -1,0 +1,255 @@
+import io
+import json
+from email.message import Message
+
+import vr_hotspotd.devtools.devhub_api as devhub_api
+from vr_hotspotd.api import APIHandler
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
+
+
+def _make_handler(path: str, *, method: str = "GET", body=None):
+    raw = b"" if body is None else json.dumps(body).encode("utf-8")
+    handler = DevHubAPIHandler.__new__(DevHubAPIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    if raw:
+        handler.headers["Content-Length"] = str(len(raw))
+    handler.command = method
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _authorize(monkeypatch, handler):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    handler.headers["X-Api-Token"] = "secret"
+    return handler
+
+
+def _ok_result(operation, **data):
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "success": True,
+        "result_code": "ok",
+        "returncode": 0,
+        "stdout": "",
+        "stderr": "",
+        "data": data,
+    }
+
+
+def test_devices_endpoint_executes_typed_operation(monkeypatch):
+    seen = {}
+
+    def fake_execute(operation, request=None):
+        seen["operation"] = operation
+        seen["request"] = request
+        return _ok_result("devices", devices=[])
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/adb/devices"),
+    )
+
+    handler.do_GET()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert seen == {"operation": "devices", "request": None}
+    assert payload["result_code"] == "ok"
+    assert payload["data"]["data"]["devices"] == []
+
+
+def test_version_endpoint_executes_typed_operation(monkeypatch):
+    monkeypatch.setattr(
+        devhub_api,
+        "execute_adb_operation",
+        lambda operation, request=None: _ok_result(operation),
+    )
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/adb/version"),
+    )
+
+    handler.do_GET()
+
+    assert handler._last_code == 200
+    assert _response_json(handler)["data"]["operation"] == "version"
+
+
+def test_pair_endpoint_passes_structured_body(monkeypatch):
+    seen = {}
+
+    def fake_execute(operation, request=None):
+        seen["operation"] = operation
+        seen["request"] = dict(request or {})
+        return _ok_result("pair", target="192.168.68.23:37143")
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+    request = {
+        "ip": "192.168.68.23",
+        "port": 37143,
+        "pairing_code": "123456",
+    }
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/adb/pair", method="POST", body=request),
+    )
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert seen == {"operation": "pair", "request": request}
+    assert payload["data"]["data"] == {"target": "192.168.68.23:37143"}
+    assert "123456" not in json.dumps(payload)
+
+
+def test_connect_and_disconnect_route_to_expected_operations(monkeypatch):
+    calls = []
+
+    def fake_execute(operation, request=None):
+        calls.append((operation, dict(request or {})))
+        return _ok_result(operation)
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+
+    connect = _authorize(
+        monkeypatch,
+        _make_handler(
+            "/v1/devbridge/adb/connect",
+            method="POST",
+            body={"ip": "192.168.68.23", "port": 5555},
+        ),
+    )
+    connect.do_POST()
+
+    disconnect = _authorize(
+        monkeypatch,
+        _make_handler(
+            "/v1/devbridge/adb/disconnect",
+            method="POST",
+            body={"serial": "192.168.68.23:5555"},
+        ),
+    )
+    disconnect.do_POST()
+
+    assert connect._last_code == 200
+    assert disconnect._last_code == 200
+    assert calls == [
+        ("connect", {"ip": "192.168.68.23", "port": 5555}),
+        ("disconnect", {"serial": "192.168.68.23:5555"}),
+    ]
+
+
+def test_operation_result_codes_map_to_http_status(monkeypatch):
+    cases = {
+        "invalid_request": 400,
+        "tools_unavailable": 503,
+        "timeout": 504,
+        "output_limit_exceeded": 502,
+        "failed": 409,
+    }
+
+    for result_code, expected_status in cases.items():
+        monkeypatch.setattr(
+            devhub_api,
+            "execute_adb_operation",
+            lambda operation, request=None, code=result_code: {
+                "schema_version": 1,
+                "operation": operation,
+                "success": False,
+                "result_code": code,
+                "returncode": None,
+                "stdout": "",
+                "stderr": code,
+                "data": {},
+            },
+        )
+        handler = _authorize(
+            monkeypatch,
+            _make_handler("/v1/devbridge/adb/devices"),
+        )
+        handler.do_GET()
+        assert handler._last_code == expected_status
+        assert _response_json(handler)["result_code"] == result_code
+
+
+def test_devhub_adb_routes_require_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    monkeypatch.setattr(
+        devhub_api,
+        "execute_adb_operation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unauthorized request executed ADB")
+        ),
+    )
+
+    requests = (
+        ("GET", "/v1/devbridge/adb/version", None),
+        ("GET", "/v1/devbridge/adb/devices", None),
+        ("POST", "/v1/devbridge/adb/pair", {}),
+        ("POST", "/v1/devbridge/adb/connect", {}),
+        ("POST", "/v1/devbridge/adb/disconnect", {}),
+    )
+    for method, path, body in requests:
+        handler = _make_handler(path, method=method, body=body)
+        if method == "GET":
+            handler.do_GET()
+        else:
+            handler.do_POST()
+        assert handler._last_code == 401, path
+        assert _response_json(handler)["result_code"] == "unauthorized"
+
+
+def test_invalid_json_body_is_rejected_before_execution(monkeypatch):
+    monkeypatch.setattr(
+        devhub_api,
+        "execute_adb_operation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid body executed ADB")
+        ),
+    )
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/adb/connect", method="POST"),
+    )
+    handler.rfile = io.BytesIO(b"{")
+    handler.headers["Content-Length"] = "1"
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 400
+    assert payload["result_code"] == "invalid_request"
+    assert payload["warnings"] == ["body_json_parse_failed"]
+
+
+def test_non_devhub_routes_delegate_to_base_handler(monkeypatch):
+    seen = {}
+
+    def fake_base_get(self):
+        seen["path"] = self.path
+
+    monkeypatch.setattr(APIHandler, "do_GET", fake_base_get)
+    handler = _make_handler("/v1/status")
+
+    handler.do_GET()
+
+    assert seen == {"path": "/v1/status"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ import pytest
 
 import vr_hotspotd.server as api_server
 from vr_hotspotd.api import APIHandler
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
 
 
 def _handler_with_headers(headers, *, path="/v1/info", method="GET", body=b"{}"):
@@ -244,6 +245,6 @@ def test_loopback_bind_without_token_still_starts_for_public_routes(monkeypatch)
 
     assert seen == {
         "address": ("127.0.0.1", 9876),
-        "handler_class": APIHandler,
+        "handler_class": DevHubAPIHandler,
     }
     assert built.daemon_threads is True


### PR DESCRIPTION
## Summary

Expose the typed ADB operation service through the authenticated VRhotspot daemon API.

## Endpoints

- `GET /v1/devbridge/adb/version`
- `GET /v1/devbridge/adb/devices`
- `POST /v1/devbridge/adb/pair`
- `POST /v1/devbridge/adb/connect`
- `POST /v1/devbridge/adb/disconnect`

## Implementation

- Adds a focused `DevHubAPIHandler` subclass that intercepts only Developer Hub ADB routes.
- Delegates every existing route to the established `APIHandler` unchanged.
- Wires the daemon server to the extended handler.
- Calls the shared typed ADB operation dispatcher added in PR #109.
- Maps operation results to stable HTTP statuses for invalid requests, unavailable tools, timeouts, bounded-output failures, command failures, and success.
- Rejects malformed or oversized JSON bodies before any ADB operation runs.
- Keeps the pairing code out of returned payloads.

## Tests

Adds coverage for:

- Version and device enumeration routes
- Structured pairing, connection, and disconnection payloads
- Authentication on every new endpoint
- Result-code to HTTP-status mapping
- Invalid JSON rejection
- Delegation of all non-Developer-Hub routes to the existing API handler
- The daemon server's extended handler contract

## Validation

- CI passed on Python 3.11, 3.12, and 3.13.
- Full pytest passed: 1053 passed, 4 subtests passed.
- Ruff passed.
- Shellcheck passed.
- Vendor manifest and deterministic SBOM validation passed.
- Platform-Tools pin validation passed.
- Installer detection matrix passed.