### PR TITLE
Add Developer Hub ADB CLI

### DIFF
--- a/backend/vr_hotspotd/devtools/adb_cli.py
+++ b/backend/vr_hotspotd/devtools/adb_cli.py
@@ -1,0 +1,317 @@
+"""Direct command-line client for typed Developer Hub ADB operations.
+
+The daemon owns ADB execution. This client only sends structured, authenticated
+requests to the allowlisted Developer Hub API endpoints; it never accepts an
+arbitrary adb command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import re
+import sys
+from typing import Any, Dict, Mapping, Optional, Sequence
+from urllib.request import Request
+import uuid
+
+from vr_hotspotd import cli as base_cli
+
+
+ADB_VERSION_PATH = "/v1/devbridge/adb/version"
+ADB_DEVICES_PATH = "/v1/devbridge/adb/devices"
+ADB_PAIR_PATH = "/v1/devbridge/adb/pair"
+ADB_CONNECT_PATH = "/v1/devbridge/adb/connect"
+ADB_DISCONNECT_PATH = "/v1/devbridge/adb/disconnect"
+ADB_DEFAULT_PORT = 5555
+_PAIRING_CODE_RE = re.compile(r"^[0-9]{6}$")
+_SERIAL_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+
+
+class ADBCLIError(base_cli.CLIError):
+    """Expected Developer Hub CLI error suitable for terminal output."""
+
+
+def _validated_port_argument(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer between 1 and 65535") from exc
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("must be an integer between 1 and 65535")
+    return port
+
+
+def _validated_serial_argument(value: str) -> str:
+    if not _SERIAL_RE.fullmatch(value or ""):
+        raise argparse.ArgumentTypeError(
+            "contains unsupported characters; expected an adb serial such as "
+            "192.168.68.23:5555"
+        )
+    return value
+
+
+def _read_pairing_code() -> str:
+    try:
+        if sys.stdin.isatty():
+            code = getpass.getpass("Wireless Debugging pairing code: ", stream=sys.stderr)
+        else:
+            code = sys.stdin.readline(65).rstrip("\r\n")
+    except (EOFError, OSError, UnicodeError) as exc:
+        raise ADBCLIError("Unable to read the Wireless Debugging pairing code.") from exc
+    if not _PAIRING_CODE_RE.fullmatch(code):
+        raise ADBCLIError("Wireless Debugging pairing code must contain exactly six digits.")
+    return code
+
+
+def _redact_values(value: object, secrets: Sequence[str]) -> str:
+    text = base_cli._redacted_error_text(value, "")
+    for secret in secrets:
+        if secret:
+            text = text.replace(secret, "[redacted]")
+    return text
+
+
+def _sanitized_cli_error(exc: Exception, secrets: Sequence[str]) -> ADBCLIError:
+    return ADBCLIError(_redact_values(exc, secrets))
+
+
+def _contains_any_secret(value: Any, secrets: Sequence[str]) -> bool:
+    return any(secret and base_cli._contains_secret(value, secret) for secret in secrets)
+
+
+def _request_api_data(
+    api_url: str,
+    path: str,
+    *,
+    method: str,
+    token: str,
+    timeout: float,
+    correlation_prefix: str,
+    payload_description: str,
+    body: Optional[Mapping[str, Any]] = None,
+    sensitive_values: Sequence[str] = (),
+) -> Dict[str, Any]:
+    endpoint = base_cli._validated_api_url(api_url) + path
+    token = base_cli._validated_token(token)
+    secrets = tuple(value for value in (token, *sensitive_values) if value)
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "vr-hotspot-adb-cli",
+        "X-Correlation-Id": f"{correlation_prefix}-{uuid.uuid4()}",
+    }
+    request_data = None
+    if body is not None:
+        request_data = json.dumps(dict(body), separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["X-Api-Token"] = token
+
+    transport_exc: Optional[Exception] = None
+    try:
+        request = Request(endpoint, data=request_data, headers=headers, method=method)
+        with base_cli._open_preflight_request(request, timeout=timeout) as response:
+            status = int(getattr(response, "status", 200))
+            raw = response.read()
+    except base_cli.CLIError as exc:
+        raise _sanitized_cli_error(exc, secrets) from None
+    except Exception as exc:
+        transport_exc = exc
+
+    if transport_exc is not None:
+        transport_error = base_cli._transport_cli_error(
+            transport_exc,
+            endpoint=endpoint,
+            token=token,
+        )
+        transport_exc = None
+        raise _sanitized_cli_error(transport_error, secrets) from None
+
+    if 300 <= status < 400:
+        raise _sanitized_cli_error(base_cli._redirect_error(status), secrets) from None
+    if status != 200:
+        error = base_cli._api_failure_cli_error(status, raw, token=token)
+        raise _sanitized_cli_error(error, secrets) from None
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ADBCLIError("The VR Hotspot API returned invalid JSON.") from None
+    if not isinstance(payload, Mapping):
+        raise ADBCLIError("The VR Hotspot API returned an invalid response envelope.")
+
+    result_code = payload.get("result_code")
+    if result_code not in (None, "ok"):
+        safe_code = _redact_values(result_code, secrets)
+        raise ADBCLIError(f"The VR Hotspot API returned {safe_code}.")
+
+    report = payload.get("data")
+    if not isinstance(report, Mapping):
+        raise ADBCLIError(
+            f"The VR Hotspot API response did not contain {payload_description}."
+        )
+    if _contains_any_secret(report, secrets):
+        raise ADBCLIError(
+            "The VR Hotspot API returned a response containing a sensitive request "
+            "value; refusing to print or export it."
+        )
+    return dict(report)
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    base_cli._add_client_arguments(parser)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vr-hotspot-adb",
+        description=(
+            "Run explicit, allowlisted ADB operations through the authenticated "
+            "VRhotspot Developer Hub daemon."
+        ),
+    )
+    commands = parser.add_subparsers(dest="operation", required=True)
+
+    version_parser = commands.add_parser("version", help="Show the effective adb version.")
+    _add_common_arguments(version_parser)
+
+    devices_parser = commands.add_parser(
+        "devices",
+        help="List devices reported by adb devices -l.",
+    )
+    _add_common_arguments(devices_parser)
+
+    pair_parser = commands.add_parser(
+        "pair",
+        help=(
+            "Pair with Android Wireless Debugging. The six-digit code is read from "
+            "hidden input or stdin and is never accepted in argv."
+        ),
+    )
+    _add_common_arguments(pair_parser)
+    pair_parser.add_argument(
+        "--ip",
+        required=True,
+        type=base_cli._validated_ipv4_argument,
+        metavar="IPV4",
+        help="Headset Wireless Debugging IPv4 address.",
+    )
+    pair_parser.add_argument(
+        "--port",
+        required=True,
+        type=_validated_port_argument,
+        metavar="PORT",
+        help="Temporary Wireless Debugging pairing port shown by the headset.",
+    )
+
+    connect_parser = commands.add_parser(
+        "connect",
+        help="Connect adb to a previously paired headset.",
+    )
+    _add_common_arguments(connect_parser)
+    connect_parser.add_argument(
+        "--ip",
+        required=True,
+        type=base_cli._validated_ipv4_argument,
+        metavar="IPV4",
+        help="Headset IPv4 address.",
+    )
+    connect_parser.add_argument(
+        "--port",
+        default=ADB_DEFAULT_PORT,
+        type=_validated_port_argument,
+        metavar="PORT",
+        help=f"ADB connection port (default: {ADB_DEFAULT_PORT}).",
+    )
+
+    disconnect_parser = commands.add_parser(
+        "disconnect",
+        help="Disconnect one adb serial without affecting other devices.",
+    )
+    _add_common_arguments(disconnect_parser)
+    disconnect_parser.add_argument(
+        "--serial",
+        required=True,
+        type=_validated_serial_argument,
+        metavar="SERIAL",
+        help="Exact adb serial, usually IPV4:PORT.",
+    )
+
+    return parser
+
+
+def _operation_request(args: argparse.Namespace) -> tuple[str, str, str, Optional[Dict[str, Any]], tuple[str, ...]]:
+    operation = args.operation
+    if operation == "version":
+        return ADB_VERSION_PATH, "GET", "an ADB version result", None, ()
+    if operation == "devices":
+        return ADB_DEVICES_PATH, "GET", "an ADB device result", None, ()
+    if operation == "pair":
+        if args.token_stdin:
+            raise ADBCLIError(
+                "pair cannot use --token-stdin because stdin is reserved for the "
+                "six-digit pairing code; use the daemon env file, environment variable, "
+                "or --token for API authentication."
+            )
+        pairing_code = _read_pairing_code()
+        return (
+            ADB_PAIR_PATH,
+            "POST",
+            "an ADB pairing result",
+            {"ip": args.ip, "port": args.port, "pairing_code": pairing_code},
+            (pairing_code,),
+        )
+    if operation == "connect":
+        return (
+            ADB_CONNECT_PATH,
+            "POST",
+            "an ADB connection result",
+            {"ip": args.ip, "port": args.port},
+            (),
+        )
+    if operation == "disconnect":
+        return (
+            ADB_DISCONNECT_PATH,
+            "POST",
+            "an ADB disconnection result",
+            {"serial": args.serial},
+            (),
+        )
+    raise ADBCLIError(f"unknown ADB operation: {operation}")
+
+
+def _run(args: argparse.Namespace) -> int:
+    path, method, description, body, sensitive_values = _operation_request(args)
+    api_url, token = base_cli._resolve_client_settings(args)
+    result = _request_api_data(
+        api_url,
+        path,
+        method=method,
+        token=token,
+        timeout=args.timeout,
+        correlation_prefix=f"cli-devhub-adb-{args.operation}",
+        payload_description=description,
+        body=body,
+        sensitive_values=sensitive_values,
+    )
+    return base_cli._emit_json_result(
+        args,
+        result,
+        token=token,
+        description=description,
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return _run(args)
+    except base_cli.CLIError as exc:
+        parser.exit(1, f"vr-hotspot-adb: error: {exc}\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.9"
 
 [project.scripts]
 vr-hotspot = "vr_hotspotd.cli:main"
+vr-hotspot-adb = "vr_hotspotd.devtools.adb_cli:main"
 vr-hotspotd = "vr_hotspotd.main:main"
 
 [tool.setuptools]

--- a/tests/test_devhub_adb_cli.py
+++ b/tests/test_devhub_adb_cli.py
@@ -1,0 +1,356 @@
+import io
+import json
+
+import pytest
+
+from vr_hotspotd import cli as base_cli
+from vr_hotspotd.devtools import adb_cli
+
+
+class _FakeResponse:
+    def __init__(self, data, *, status=200, result_code="ok"):
+        self.status = status
+        self._raw = json.dumps(
+            {
+                "correlation_id": "test-cid",
+                "result_code": result_code,
+                "warnings": [],
+                "data": data,
+            }
+        ).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+@pytest.fixture(autouse=True)
+def clear_cli_environment(monkeypatch):
+    for key in (*base_cli._ENV_KEYS, "VR_HOTSPOTD_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _missing_env_args(tmp_path):
+    return ["--env-file", str(tmp_path / "missing-env")]
+
+
+def _mocked_open(monkeypatch, response_data, seen):
+    def open_request(request, *, timeout):
+        seen["method"] = request.get_method()
+        seen["url"] = request.full_url
+        seen["headers"] = {key.lower(): value for key, value in request.header_items()}
+        seen["timeout"] = timeout
+        seen["body"] = (
+            None if request.data is None else json.loads(request.data.decode("utf-8"))
+        )
+        return _FakeResponse(response_data)
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", open_request)
+
+
+def _run(monkeypatch, tmp_path, response_data, argv):
+    seen = {}
+    _mocked_open(monkeypatch, response_data, seen)
+    result = adb_cli.main(
+        [
+            *argv,
+            "--api-url",
+            "http://127.0.0.1:9900",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+    return result, seen
+
+
+def test_version_uses_authenticated_get(monkeypatch, tmp_path, capsys):
+    secret = "adb-version-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    data = {"operation": "version", "success": True, "stdout": "Android Debug Bridge"}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["version"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == data
+    assert captured.err == ""
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/version"
+    assert seen["body"] is None
+    assert seen["headers"]["x-api-token"] == secret
+    assert seen["headers"]["x-correlation-id"].startswith("cli-devhub-adb-version-")
+    assert secret not in captured.out
+
+
+def test_devices_uses_devices_endpoint(monkeypatch, tmp_path, capsys):
+    data = {"operation": "devices", "success": True, "data": {"devices": []}}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["devices"])
+
+    assert result == 0
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/devices"
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_connect_sends_structured_post(monkeypatch, tmp_path, capsys):
+    data = {"operation": "connect", "success": True, "data": {"target": "192.168.68.23:5555"}}
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        ["connect", "--ip", "192.168.68.23"],
+    )
+
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/connect"
+    assert seen["headers"]["content-type"] == "application/json"
+    assert seen["body"] == {"ip": "192.168.68.23", "port": 5555}
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_connect_accepts_explicit_port(monkeypatch, tmp_path, capsys):
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        {"operation": "connect", "success": True},
+        ["connect", "--ip", "192.168.68.23", "--port", "42117"],
+    )
+
+    assert result == 0
+    assert seen["body"] == {"ip": "192.168.68.23", "port": 42117}
+    capsys.readouterr()
+
+
+def test_disconnect_sends_exact_serial(monkeypatch, tmp_path, capsys):
+    serial = "192.168.68.23:5555"
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        {"operation": "disconnect", "success": True},
+        ["disconnect", "--serial", serial],
+    )
+
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/disconnect"
+    assert seen["body"] == {"serial": serial}
+    capsys.readouterr()
+
+
+def test_pair_reads_code_from_stdin_and_never_returns_it(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    pairing_code = "123456"
+    secret = "pair-api-token"
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", secret)
+    monkeypatch.setattr(adb_cli.sys, "stdin", io.StringIO(f"{pairing_code}\n"))
+    data = {
+        "operation": "pair",
+        "success": True,
+        "data": {"target": "192.168.68.23:37143"},
+    }
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        ["pair", "--ip", "192.168.68.23", "--port", "37143"],
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/pair"
+    assert seen["body"] == {
+        "ip": "192.168.68.23",
+        "port": 37143,
+        "pairing_code": pairing_code,
+    }
+    assert pairing_code not in seen["url"]
+    assert pairing_code not in json.dumps(seen["headers"])
+    assert pairing_code not in captured.out
+    assert pairing_code not in captured.err
+    assert secret not in captured.out
+    assert json.loads(captured.out) == data
+
+
+def test_pair_uses_hidden_tty_prompt(monkeypatch, tmp_path, capsys):
+    pairing_code = "654321"
+
+    class InteractiveInput:
+        @staticmethod
+        def isatty():
+            return True
+
+    monkeypatch.setattr(adb_cli.sys, "stdin", InteractiveInput())
+    monkeypatch.setattr(
+        adb_cli.getpass,
+        "getpass",
+        lambda prompt, *, stream: pairing_code,
+    )
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        {"operation": "pair", "success": True},
+        ["pair", "--ip", "192.168.68.23", "--port", "37143"],
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert seen["body"]["pairing_code"] == pairing_code
+    assert pairing_code not in captured.out
+    assert pairing_code not in captured.err
+
+
+def test_pair_rejects_api_token_stdin_without_reading_or_requesting(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError(f"request must not run with timeout {timeout}")
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", must_not_open)
+    monkeypatch.setattr(adb_cli.sys, "stdin", io.StringIO("123456\n"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main(
+            [
+                "pair",
+                "--ip",
+                "192.168.68.23",
+                "--port",
+                "37143",
+                "--token-stdin",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "stdin is reserved" in captured.err
+    assert captured.out == ""
+
+
+@pytest.mark.parametrize("code", ("", "12345", "1234567", "12a456"))
+def test_pair_rejects_invalid_code_before_request(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    code,
+):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError(f"request must not run with timeout {timeout}")
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", must_not_open)
+    monkeypatch.setattr(adb_cli.sys, "stdin", io.StringIO(f"{code}\n"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main(
+            [
+                "pair",
+                "--ip",
+                "192.168.68.23",
+                "--port",
+                "37143",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "exactly six digits" in captured.err
+    assert code not in captured.out
+
+
+def test_pair_refuses_reflected_pairing_code(monkeypatch, tmp_path, capsys):
+    pairing_code = "123456"
+    monkeypatch.setattr(adb_cli.sys, "stdin", io.StringIO(f"{pairing_code}\n"))
+    seen = {}
+    _mocked_open(
+        monkeypatch,
+        {"operation": "pair", "success": True, "stdout": pairing_code},
+        seen,
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main(
+            [
+                "pair",
+                "--ip",
+                "192.168.68.23",
+                "--port",
+                "37143",
+                "--api-url",
+                "http://127.0.0.1:9900",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "sensitive request value" in captured.err
+    assert pairing_code not in captured.out
+    assert pairing_code not in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["connect", "--ip", "not-an-ip"],
+        ["connect", "--ip", "192.168.68.23", "--port", "0"],
+        ["pair", "--ip", "192.168.68.23", "--port", "70000"],
+        ["disconnect", "--serial", "bad serial with spaces"],
+    ),
+)
+def test_invalid_arguments_are_rejected_before_request(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    argv,
+):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError(f"request must not run with timeout {timeout}")
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main([*argv, *_missing_env_args(tmp_path)])
+
+    assert excinfo.value.code == 2
+    assert capsys.readouterr().out == ""
+
+
+def test_result_can_be_exported_to_private_file(monkeypatch, tmp_path, capsys):
+    seen = {}
+    data = {"operation": "devices", "success": True, "data": {"devices": []}}
+    _mocked_open(monkeypatch, data, seen)
+    output = tmp_path / "adb-devices.json"
+
+    result = adb_cli.main(
+        [
+            "devices",
+            "--api-url",
+            "http://127.0.0.1:9900",
+            "--output",
+            str(output),
+            *_missing_env_args(tmp_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == ""
+    assert "Wrote an ADB device result" in captured.err
+    assert json.loads(output.read_text(encoding="utf-8")) == data

--- a/tests/test_devhub_adb_cli.py
+++ b/tests/test_devhub_adb_cli.py
@@ -271,7 +271,9 @@ def test_pair_rejects_invalid_code_before_request(
     captured = capsys.readouterr()
     assert excinfo.value.code == 1
     assert "exactly six digits" in captured.err
-    assert code not in captured.out
+    if code:
+        assert code not in captured.out
+        assert code not in captured.err
 
 
 def test_pair_refuses_reflected_pairing_code(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary

Add a direct command-line control surface for the typed Developer Hub ADB operations merged in PRs #109 and #110.

## Command

Registers a new `vr-hotspot-adb` executable with explicit subcommands:

- `vr-hotspot-adb version`
- `vr-hotspot-adb devices`
- `vr-hotspot-adb pair --ip IPV4 --port PORT`
- `vr-hotspot-adb connect --ip IPV4 [--port PORT]`
- `vr-hotspot-adb disconnect --serial SERIAL`

## Security and behavior

- Uses only the authenticated, allowlisted daemon API endpoints.
- Does not accept arbitrary adb arguments or command strings.
- Reads the six-digit Wireless Debugging pairing code from hidden terminal input or stdin only; no pairing-code argv option exists.
- Refuses `--token-stdin` during pairing because stdin is reserved for the pairing code.
- Rejects reflected API tokens or pairing codes before printing or exporting a response.
- Preserves the existing CLI transport protections: authenticated requests, redirect rejection, bounded HTTP timeouts, token-safe errors, and mode-0600 output files.
- Leaves the existing `vr-hotspot` read-only CLI unchanged.

## Tests

Adds focused coverage for:

- Version and device GET requests
- Structured connect, pair, and disconnect POST bodies
- Default and explicit connection ports
- Hidden and piped pairing-code input
- Pairing-code non-disclosure in URL, headers, stdout, and stderr
- Reflected-secret refusal
- API-token stdin conflict during pairing
- Invalid IPv4, port, serial, and pairing-code rejection before network access
- Protected JSON export

## Validation

- CI passed on Python 3.11, 3.12, and 3.13.
- Full pytest passed: 1071 passed, 4 subtests passed.
- Ruff passed.
- Shellcheck passed.
- Vendor manifest and deterministic SBOM validation passed.
- Platform-Tools pin validation passed.
- Installer detection matrix passed.