### PR TITLE
Add Developer Hub APK workflow

### DIFF
--- a/backend/vr_hotspotd/devtools/adb_cli.py
+++ b/backend/vr_hotspotd/devtools/adb_cli.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import argparse
 import getpass
 import json
+from pathlib import Path
 import re
 import sys
 from typing import Any, Dict, Mapping, Optional, Sequence
+from urllib.parse import urlencode
 from urllib.request import Request
 import uuid
 
@@ -24,9 +26,18 @@ ADB_DEVICES_PATH = "/v1/devbridge/adb/devices"
 ADB_PAIR_PATH = "/v1/devbridge/adb/pair"
 ADB_CONNECT_PATH = "/v1/devbridge/adb/connect"
 ADB_DISCONNECT_PATH = "/v1/devbridge/adb/disconnect"
+ADB_PACKAGES_PATH = "/v1/devbridge/adb/packages"
+ADB_INSTALL_PATH = "/v1/devbridge/adb/install"
+ADB_LAUNCH_PATH = "/v1/devbridge/adb/launch"
+ADB_STOP_PATH = "/v1/devbridge/adb/stop"
+ADB_CLEAR_DATA_PATH = "/v1/devbridge/adb/clear-data"
+ADB_UNINSTALL_PATH = "/v1/devbridge/adb/uninstall"
 ADB_DEFAULT_PORT = 5555
 _PAIRING_CODE_RE = re.compile(r"^[0-9]{6}$")
 _SERIAL_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+_PACKAGE_NAME_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$"
+)
 
 
 class ADBCLIError(base_cli.CLIError):
@@ -50,6 +61,23 @@ def _validated_serial_argument(value: str) -> str:
             "192.168.68.23:5555"
         )
     return value
+
+
+def _validated_package_argument(value: str) -> str:
+    if not _PACKAGE_NAME_RE.fullmatch(value or ""):
+        raise argparse.ArgumentTypeError(
+            "must be an Android package name such as com.example.application"
+        )
+    return value
+
+
+def _validated_apk_path_argument(value: str) -> str:
+    if not value or len(value) > 4096 or "\x00" in value:
+        raise argparse.ArgumentTypeError("must be an absolute path ending in .apk")
+    path = Path(value)
+    if not path.is_absolute() or path.suffix.lower() != ".apk":
+        raise argparse.ArgumentTypeError("must be an absolute path ending in .apk")
+    return str(path)
 
 
 def _read_pairing_code() -> str:
@@ -163,11 +191,31 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
     base_cli._add_client_arguments(parser)
 
 
+def _add_serial_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--serial",
+        required=True,
+        type=_validated_serial_argument,
+        metavar="SERIAL",
+        help="Exact adb device serial, usually IPV4:PORT.",
+    )
+
+
+def _add_package_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--package",
+        required=True,
+        type=_validated_package_argument,
+        metavar="PACKAGE",
+        help="Android application package name.",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="vr-hotspot-adb",
         description=(
-            "Run explicit, allowlisted ADB operations through the authenticated "
+            "Run explicit ADB device and application operations through the authenticated "
             "VRhotspot Developer Hub daemon."
         ),
     )
@@ -230,18 +278,82 @@ def build_parser() -> argparse.ArgumentParser:
         help="Disconnect one adb serial without affecting other devices.",
     )
     _add_common_arguments(disconnect_parser)
-    disconnect_parser.add_argument(
-        "--serial",
+    _add_serial_argument(disconnect_parser)
+
+    packages_parser = commands.add_parser(
+        "packages",
+        help="List installed application packages on one headset.",
+    )
+    _add_common_arguments(packages_parser)
+    _add_serial_argument(packages_parser)
+    packages_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Include system packages instead of listing third-party apps only.",
+    )
+
+    install_parser = commands.add_parser(
+        "install",
+        help="Install or update an APK on one headset.",
+    )
+    _add_common_arguments(install_parser)
+    install_parser.set_defaults(timeout=300.0)
+    _add_serial_argument(install_parser)
+    install_parser.add_argument(
+        "--apk",
         required=True,
-        type=_validated_serial_argument,
-        metavar="SERIAL",
-        help="Exact adb serial, usually IPV4:PORT.",
+        type=_validated_apk_path_argument,
+        metavar="PATH",
+        help="Absolute host path to the APK file.",
+    )
+    install_parser.add_argument(
+        "--no-reinstall",
+        action="store_true",
+        help="Do not pass adb install -r; fail if the package is already installed.",
+    )
+    install_parser.add_argument(
+        "--grant-permissions",
+        action="store_true",
+        help="Grant runtime permissions requested by the APK during installation.",
+    )
+
+    launch_parser = commands.add_parser("launch", help="Launch an installed application.")
+    _add_common_arguments(launch_parser)
+    _add_serial_argument(launch_parser)
+    _add_package_argument(launch_parser)
+
+    stop_parser = commands.add_parser("stop", help="Force-stop an installed application.")
+    _add_common_arguments(stop_parser)
+    _add_serial_argument(stop_parser)
+    _add_package_argument(stop_parser)
+
+    clear_parser = commands.add_parser(
+        "clear-data",
+        help="Clear an application's local data on the selected headset.",
+    )
+    _add_common_arguments(clear_parser)
+    _add_serial_argument(clear_parser)
+    _add_package_argument(clear_parser)
+
+    uninstall_parser = commands.add_parser(
+        "uninstall",
+        help="Uninstall an application from one headset.",
+    )
+    _add_common_arguments(uninstall_parser)
+    _add_serial_argument(uninstall_parser)
+    _add_package_argument(uninstall_parser)
+    uninstall_parser.add_argument(
+        "--keep-data",
+        action="store_true",
+        help="Keep application data and cache directories during uninstall.",
     )
 
     return parser
 
 
-def _operation_request(args: argparse.Namespace) -> tuple[str, str, str, Optional[Dict[str, Any]], tuple[str, ...]]:
+def _operation_request(
+    args: argparse.Namespace,
+) -> tuple[str, str, str, Optional[Dict[str, Any]], tuple[str, ...]]:
     operation = args.operation
     if operation == "version":
         return ADB_VERSION_PATH, "GET", "an ADB version result", None, ()
@@ -276,6 +388,69 @@ def _operation_request(args: argparse.Namespace) -> tuple[str, str, str, Optiona
             "POST",
             "an ADB disconnection result",
             {"serial": args.serial},
+            (),
+        )
+    if operation == "packages":
+        query = urlencode(
+            {
+                "serial": args.serial,
+                "third_party_only": "0" if args.all else "1",
+            }
+        )
+        return (
+            ADB_PACKAGES_PATH + "?" + query,
+            "GET",
+            "an installed package result",
+            None,
+            (),
+        )
+    if operation == "install":
+        return (
+            ADB_INSTALL_PATH,
+            "POST",
+            "an APK installation result",
+            {
+                "serial": args.serial,
+                "apk_path": args.apk,
+                "reinstall": not args.no_reinstall,
+                "grant_permissions": args.grant_permissions,
+            },
+            (),
+        )
+    if operation == "launch":
+        return (
+            ADB_LAUNCH_PATH,
+            "POST",
+            "an application launch result",
+            {"serial": args.serial, "package": args.package},
+            (),
+        )
+    if operation == "stop":
+        return (
+            ADB_STOP_PATH,
+            "POST",
+            "an application stop result",
+            {"serial": args.serial, "package": args.package},
+            (),
+        )
+    if operation == "clear-data":
+        return (
+            ADB_CLEAR_DATA_PATH,
+            "POST",
+            "an application data-clear result",
+            {"serial": args.serial, "package": args.package},
+            (),
+        )
+    if operation == "uninstall":
+        return (
+            ADB_UNINSTALL_PATH,
+            "POST",
+            "an application uninstall result",
+            {
+                "serial": args.serial,
+                "package": args.package,
+                "keep_data": args.keep_data,
+            },
             (),
         )
     raise ADBCLIError(f"unknown ADB operation: {operation}")

--- a/backend/vr_hotspotd/devtools/adb_operations.py
+++ b/backend/vr_hotspotd/devtools/adb_operations.py
@@ -1,6 +1,6 @@
 """Typed ADB operations for the VRhotspot Developer Hub.
 
-This module is the executable ADB boundary used by future API, CLI, Flatpak,
+This module is the executable ADB boundary used by the API, CLI, Flatpak,
 and Web Portal surfaces. Callers choose an operation and provide structured
 values; they never supply a command line or arbitrary adb arguments.
 """
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import ipaddress
+from pathlib import Path
 import re
+import stat
 import subprocess
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
@@ -18,9 +20,15 @@ from vr_hotspotd.devtools.platform_tools import collect_devbridge_tools_status
 
 ADB_DEFAULT_PORT = 5555
 ADB_OPERATION_TIMEOUT_S = 15.0
+ADB_INSTALL_TIMEOUT_S = 300.0
+ADB_APP_OPERATION_TIMEOUT_S = 60.0
 ADB_OUTPUT_LIMIT_BYTES = 256 * 1024
+APK_MAX_BYTES = 8 * 1024 * 1024 * 1024
 PAIRING_CODE_RE = re.compile(r"^[0-9]{6}$")
 SERIAL_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+PACKAGE_NAME_RE = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$"
+)
 
 RESULT_OK = "ok"
 RESULT_INVALID_REQUEST = "invalid_request"
@@ -74,6 +82,39 @@ def _valid_serial(value: Any) -> str:
     if not isinstance(value, str) or not SERIAL_RE.fullmatch(value):
         raise ADBOperationError("serial contains unsupported characters")
     return value
+
+
+def _valid_package_name(value: Any) -> str:
+    if not isinstance(value, str) or not PACKAGE_NAME_RE.fullmatch(value):
+        raise ADBOperationError("package must be a valid Android package name")
+    return value
+
+
+def _valid_bool(value: Any, *, name: str, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ADBOperationError(f"{name} must be a boolean")
+    return value
+
+
+def _valid_apk_path(value: Any) -> str:
+    if not isinstance(value, str) or not value or len(value) > 4096 or "\x00" in value:
+        raise ADBOperationError("apk_path must be an absolute path to an APK file")
+    path = Path(value)
+    if not path.is_absolute() or path.suffix.lower() != ".apk":
+        raise ADBOperationError("apk_path must be an absolute path to an APK file")
+    try:
+        file_stat = path.lstat()
+    except OSError as exc:
+        raise ADBOperationError("apk_path does not exist or is not readable") from exc
+    if stat.S_ISLNK(file_stat.st_mode) or not stat.S_ISREG(file_stat.st_mode):
+        raise ADBOperationError("apk_path must reference a regular non-symlink file")
+    if file_stat.st_size <= 0:
+        raise ADBOperationError("apk_path must not be empty")
+    if file_stat.st_size > APK_MAX_BYTES:
+        raise ADBOperationError("apk_path exceeds the supported size limit")
+    return str(path)
 
 
 def _target(ip: Any, port: Any = ADB_DEFAULT_PORT) -> str:
@@ -137,6 +178,10 @@ def _result(operation: str, execution: ADBExecution, **data: Any) -> Dict[str, A
         "stderr": execution.stderr,
         "data": data,
     }
+
+
+def _device_argv(adb: str, serial: Any, *arguments: str) -> tuple[str, ...]:
+    return (adb, "-s", _valid_serial(serial), *arguments)
 
 
 def adb_version(
@@ -217,6 +262,192 @@ def adb_disconnect(
     )
 
 
+def adb_packages(
+    serial: Any,
+    third_party_only: Any = True,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    only_third_party = _valid_bool(
+        third_party_only,
+        name="third_party_only",
+        default=True,
+    )
+    argv = list(_device_argv(adb, validated_serial, "shell", "pm", "list", "packages"))
+    if only_third_party:
+        argv.append("-3")
+    execution = _run(argv, timeout_s=ADB_APP_OPERATION_TIMEOUT_S, runner=runner)
+    packages = []
+    if execution.returncode == 0:
+        for line in execution.stdout.splitlines():
+            value = line.strip()
+            if value.startswith("package:"):
+                package = value[len("package:") :]
+                if PACKAGE_NAME_RE.fullmatch(package):
+                    packages.append(package)
+    return _result(
+        "packages",
+        execution,
+        serial=validated_serial,
+        third_party_only=only_third_party,
+        packages=packages,
+    )
+
+
+def adb_install(
+    serial: Any,
+    apk_path: Any,
+    reinstall: Any = True,
+    grant_permissions: Any = False,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    validated_path = _valid_apk_path(apk_path)
+    should_reinstall = _valid_bool(reinstall, name="reinstall", default=True)
+    should_grant = _valid_bool(
+        grant_permissions,
+        name="grant_permissions",
+        default=False,
+    )
+    argv = list(_device_argv(adb, validated_serial, "install"))
+    if should_reinstall:
+        argv.append("-r")
+    if should_grant:
+        argv.append("-g")
+    argv.append(validated_path)
+    execution = _run(argv, timeout_s=ADB_INSTALL_TIMEOUT_S, runner=runner)
+    return _result(
+        "install",
+        execution,
+        serial=validated_serial,
+        apk_path=validated_path,
+        reinstall=should_reinstall,
+        grant_permissions=should_grant,
+    )
+
+
+def adb_launch(
+    serial: Any,
+    package: Any,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    validated_package = _valid_package_name(package)
+    argv = _device_argv(
+        adb,
+        validated_serial,
+        "shell",
+        "monkey",
+        "-p",
+        validated_package,
+        "-c",
+        "android.intent.category.LAUNCHER",
+        "1",
+    )
+    execution = _run(argv, timeout_s=ADB_APP_OPERATION_TIMEOUT_S, runner=runner)
+    return _result(
+        "launch",
+        execution,
+        serial=validated_serial,
+        package=validated_package,
+    )
+
+
+def adb_stop(
+    serial: Any,
+    package: Any,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    validated_package = _valid_package_name(package)
+    execution = _run(
+        _device_argv(
+            adb,
+            validated_serial,
+            "shell",
+            "am",
+            "force-stop",
+            validated_package,
+        ),
+        timeout_s=ADB_APP_OPERATION_TIMEOUT_S,
+        runner=runner,
+    )
+    return _result(
+        "stop",
+        execution,
+        serial=validated_serial,
+        package=validated_package,
+    )
+
+
+def adb_clear_data(
+    serial: Any,
+    package: Any,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    validated_package = _valid_package_name(package)
+    execution = _run(
+        _device_argv(
+            adb,
+            validated_serial,
+            "shell",
+            "pm",
+            "clear",
+            validated_package,
+        ),
+        timeout_s=ADB_APP_OPERATION_TIMEOUT_S,
+        runner=runner,
+    )
+    return _result(
+        "clear_data",
+        execution,
+        serial=validated_serial,
+        package=validated_package,
+    )
+
+
+def adb_uninstall(
+    serial: Any,
+    package: Any,
+    keep_data: Any = False,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    adb = _effective_adb_path(tools_status)
+    validated_serial = _valid_serial(serial)
+    validated_package = _valid_package_name(package)
+    should_keep_data = _valid_bool(keep_data, name="keep_data", default=False)
+    argv = list(_device_argv(adb, validated_serial, "uninstall"))
+    if should_keep_data:
+        argv.append("-k")
+    argv.append(validated_package)
+    execution = _run(argv, timeout_s=ADB_APP_OPERATION_TIMEOUT_S, runner=runner)
+    return _result(
+        "uninstall",
+        execution,
+        serial=validated_serial,
+        package=validated_package,
+        keep_data=should_keep_data,
+    )
+
+
 def execute_adb_operation(
     operation: str,
     request: Optional[Mapping[str, Any]] = None,
@@ -250,6 +481,51 @@ def execute_adb_operation(
         if operation == "disconnect":
             return adb_disconnect(
                 payload.get("serial"),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "packages":
+            return adb_packages(
+                payload.get("serial"),
+                payload.get("third_party_only", True),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "install":
+            return adb_install(
+                payload.get("serial"),
+                payload.get("apk_path"),
+                payload.get("reinstall", True),
+                payload.get("grant_permissions", False),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "launch":
+            return adb_launch(
+                payload.get("serial"),
+                payload.get("package"),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "stop":
+            return adb_stop(
+                payload.get("serial"),
+                payload.get("package"),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "clear_data":
+            return adb_clear_data(
+                payload.get("serial"),
+                payload.get("package"),
+                tools_status=tools_status,
+                runner=runner,
+            )
+        if operation == "uninstall":
+            return adb_uninstall(
+                payload.get("serial"),
+                payload.get("package"),
+                payload.get("keep_data", False),
                 tools_status=tools_status,
                 runner=runner,
             )

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -27,12 +27,18 @@ log = logging.getLogger("vr_hotspotd.devhub_api")
 _GET_OPERATIONS = {
     "/v1/devbridge/adb/version": "version",
     "/v1/devbridge/adb/devices": "devices",
+    "/v1/devbridge/adb/packages": "packages",
 }
 
 _POST_OPERATIONS = {
     "/v1/devbridge/adb/pair": "pair",
     "/v1/devbridge/adb/connect": "connect",
     "/v1/devbridge/adb/disconnect": "disconnect",
+    "/v1/devbridge/adb/install": "install",
+    "/v1/devbridge/adb/launch": "launch",
+    "/v1/devbridge/adb/stop": "stop",
+    "/v1/devbridge/adb/clear-data": "clear_data",
+    "/v1/devbridge/adb/uninstall": "uninstall",
 }
 
 _RESULT_HTTP_STATUS = {
@@ -90,7 +96,7 @@ class DevHubAPIHandler(APIHandler):
 
     def do_GET(self):
         cid = self._cid()
-        path, _qs = self._parse_url()
+        path, qs = self._parse_url()
         operation = _GET_OPERATIONS.get(path)
         if operation is None:
             super().do_GET()
@@ -102,7 +108,14 @@ class DevHubAPIHandler(APIHandler):
         )
         if not self._require_auth(cid):
             return
-        self._respond_adb_operation(cid=cid, operation=operation)
+
+        request: Optional[Mapping[str, Any]] = None
+        if operation == "packages":
+            request = {
+                "serial": qs.get("serial"),
+                "third_party_only": self._qbool(qs, "third_party_only", True),
+            }
+        self._respond_adb_operation(cid=cid, operation=operation, request=request)
 
     def do_POST(self):
         cid = self._cid()

--- a/tests/test_adb_app_operations.py
+++ b/tests/test_adb_app_operations.py
@@ -70,7 +70,7 @@ def test_packages_can_include_system_apps():
     )
 
     assert result["success"] is True
-    assert calls[0][-3:] == ["list", "packages"]
+    assert calls[0][-2:] == ["list", "packages"]
     assert "-3" not in calls[0]
     assert result["data"]["third_party_only"] is False
 

--- a/tests/test_adb_app_operations.py
+++ b/tests/test_adb_app_operations.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import subprocess
+
+from vr_hotspotd.devtools.adb_operations import execute_adb_operation
+
+
+TOOLS = {"adb": {"path": "/opt/vrhotspot/platform-tools/adb"}}
+SERIAL = "192.168.68.24:5555"
+PACKAGE = "com.example.xrtraining"
+
+
+def _completed(argv, *, stdout=b"", stderr=b"", returncode=0, **kwargs):
+    return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr=stderr)
+
+
+def test_packages_lists_third_party_apps_by_default():
+    observed = {}
+
+    def runner(argv, **kwargs):
+        observed["argv"] = argv
+        observed["timeout"] = kwargs["timeout"]
+        return _completed(
+            argv,
+            stdout=(
+                b"package:com.example.xrtraining\n"
+                b"package:com.vendor.utility\n"
+                b"not-a-package-line\n"
+            ),
+        )
+
+    result = execute_adb_operation(
+        "packages",
+        {"serial": SERIAL},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert result["success"] is True
+    assert observed["argv"] == [
+        "/opt/vrhotspot/platform-tools/adb",
+        "-s",
+        SERIAL,
+        "shell",
+        "pm",
+        "list",
+        "packages",
+        "-3",
+    ]
+    assert observed["timeout"] == 60.0
+    assert result["data"]["third_party_only"] is True
+    assert result["data"]["packages"] == [
+        "com.example.xrtraining",
+        "com.vendor.utility",
+    ]
+
+
+def test_packages_can_include_system_apps():
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return _completed(argv, stdout=b"package:android\npackage:com.example.xrtraining\n")
+
+    result = execute_adb_operation(
+        "packages",
+        {"serial": SERIAL, "third_party_only": False},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert result["success"] is True
+    assert calls[0][-3:] == ["list", "packages"]
+    assert "-3" not in calls[0]
+    assert result["data"]["third_party_only"] is False
+
+
+def test_install_builds_reinstall_command_and_uses_long_timeout(tmp_path):
+    apk = tmp_path / "training.apk"
+    apk.write_bytes(b"APK")
+    observed = {}
+
+    def runner(argv, **kwargs):
+        observed["argv"] = argv
+        observed["timeout"] = kwargs["timeout"]
+        return _completed(argv, stdout=b"Success\n")
+
+    result = execute_adb_operation(
+        "install",
+        {"serial": SERIAL, "apk_path": str(apk)},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert result["success"] is True
+    assert observed["argv"] == [
+        "/opt/vrhotspot/platform-tools/adb",
+        "-s",
+        SERIAL,
+        "install",
+        "-r",
+        str(apk),
+    ]
+    assert observed["timeout"] == 300.0
+    assert result["data"]["apk_path"] == str(apk)
+    assert result["data"]["reinstall"] is True
+    assert result["data"]["grant_permissions"] is False
+
+
+def test_install_supports_fresh_install_and_runtime_permission_grants(tmp_path):
+    apk = tmp_path / "training.apk"
+    apk.write_bytes(b"APK")
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return _completed(argv, stdout=b"Success\n")
+
+    result = execute_adb_operation(
+        "install",
+        {
+            "serial": SERIAL,
+            "apk_path": str(apk),
+            "reinstall": False,
+            "grant_permissions": True,
+        },
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert result["success"] is True
+    assert calls[0] == [
+        "/opt/vrhotspot/platform-tools/adb",
+        "-s",
+        SERIAL,
+        "install",
+        "-g",
+        str(apk),
+    ]
+
+
+def test_launch_stop_clear_and_uninstall_build_typed_commands():
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return _completed(argv, stdout=b"Success\n")
+
+    launch = execute_adb_operation(
+        "launch",
+        {"serial": SERIAL, "package": PACKAGE},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    stop = execute_adb_operation(
+        "stop",
+        {"serial": SERIAL, "package": PACKAGE},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    clear = execute_adb_operation(
+        "clear_data",
+        {"serial": SERIAL, "package": PACKAGE},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    uninstall = execute_adb_operation(
+        "uninstall",
+        {"serial": SERIAL, "package": PACKAGE, "keep_data": True},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert all(result["success"] is True for result in (launch, stop, clear, uninstall))
+    assert calls == [
+        [
+            "/opt/vrhotspot/platform-tools/adb",
+            "-s",
+            SERIAL,
+            "shell",
+            "monkey",
+            "-p",
+            PACKAGE,
+            "-c",
+            "android.intent.category.LAUNCHER",
+            "1",
+        ],
+        [
+            "/opt/vrhotspot/platform-tools/adb",
+            "-s",
+            SERIAL,
+            "shell",
+            "am",
+            "force-stop",
+            PACKAGE,
+        ],
+        [
+            "/opt/vrhotspot/platform-tools/adb",
+            "-s",
+            SERIAL,
+            "shell",
+            "pm",
+            "clear",
+            PACKAGE,
+        ],
+        [
+            "/opt/vrhotspot/platform-tools/adb",
+            "-s",
+            SERIAL,
+            "uninstall",
+            "-k",
+            PACKAGE,
+        ],
+    ]
+
+
+def test_invalid_app_requests_are_rejected_before_execution(tmp_path):
+    called = False
+
+    def runner(argv, **kwargs):
+        nonlocal called
+        called = True
+        return _completed(argv)
+
+    relative_apk = execute_adb_operation(
+        "install",
+        {"serial": SERIAL, "apk_path": "relative.apk"},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    missing_apk = execute_adb_operation(
+        "install",
+        {"serial": SERIAL, "apk_path": str(tmp_path / "missing.apk")},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    bad_package = execute_adb_operation(
+        "launch",
+        {"serial": SERIAL, "package": "not a package"},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+    bad_boolean = execute_adb_operation(
+        "uninstall",
+        {"serial": SERIAL, "package": PACKAGE, "keep_data": "yes"},
+        tools_status=TOOLS,
+        runner=runner,
+    )
+
+    assert called is False
+    assert relative_apk["result_code"] == "invalid_request"
+    assert missing_apk["result_code"] == "invalid_request"
+    assert bad_package["result_code"] == "invalid_request"
+    assert bad_boolean["result_code"] == "invalid_request"
+
+
+def test_apk_symlink_is_rejected(tmp_path):
+    target = tmp_path / "target.apk"
+    target.write_bytes(b"APK")
+    symlink = tmp_path / "link.apk"
+    symlink.symlink_to(target)
+
+    result = execute_adb_operation(
+        "install",
+        {"serial": SERIAL, "apk_path": str(symlink)},
+        tools_status=TOOLS,
+        runner=lambda argv, **kwargs: _completed(argv),
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == "invalid_request"
+    assert "non-symlink" in result["stderr"]

--- a/tests/test_api_devhub_apps.py
+++ b/tests/test_api_devhub_apps.py
@@ -1,0 +1,183 @@
+import io
+import json
+from email.message import Message
+
+import vr_hotspotd.devtools.devhub_api as devhub_api
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
+
+
+SERIAL = "192.168.68.24:5555"
+PACKAGE = "com.example.xrtraining"
+
+
+def _make_handler(path: str, *, method: str = "GET", body=None):
+    raw = b"" if body is None else json.dumps(body).encode("utf-8")
+    handler = DevHubAPIHandler.__new__(DevHubAPIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    if raw:
+        handler.headers["Content-Length"] = str(len(raw))
+    handler.command = method
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    handler.send_response = send_response
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _authorize(monkeypatch, handler):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    handler.headers["X-Api-Token"] = "secret"
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _ok_result(operation, **data):
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "success": True,
+        "result_code": "ok",
+        "returncode": 0,
+        "stdout": "",
+        "stderr": "",
+        "data": data,
+    }
+
+
+def test_packages_endpoint_passes_selected_device_and_filter(monkeypatch):
+    seen = {}
+
+    def fake_execute(operation, request=None):
+        seen["operation"] = operation
+        seen["request"] = dict(request or {})
+        return _ok_result(operation, packages=[PACKAGE])
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+    handler = _authorize(
+        monkeypatch,
+        _make_handler(
+            "/v1/devbridge/adb/packages?serial=192.168.68.24%3A5555&third_party_only=0"
+        ),
+    )
+
+    handler.do_GET()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert seen == {
+        "operation": "packages",
+        "request": {"serial": SERIAL, "third_party_only": False},
+    }
+    assert payload["data"]["data"]["packages"] == [PACKAGE]
+
+
+def test_packages_endpoint_defaults_to_third_party_only(monkeypatch):
+    seen = {}
+
+    def fake_execute(operation, request=None):
+        seen.update(dict(request or {}))
+        return _ok_result(operation, packages=[])
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+    handler = _authorize(
+        monkeypatch,
+        _make_handler(f"/v1/devbridge/adb/packages?serial={SERIAL}"),
+    )
+
+    handler.do_GET()
+
+    assert handler._last_code == 200
+    assert seen == {"serial": SERIAL, "third_party_only": True}
+
+
+def test_app_post_routes_pass_structured_bodies(monkeypatch):
+    calls = []
+
+    def fake_execute(operation, request=None):
+        calls.append((operation, dict(request or {})))
+        return _ok_result(operation)
+
+    monkeypatch.setattr(devhub_api, "execute_adb_operation", fake_execute)
+    cases = (
+        (
+            "/v1/devbridge/adb/install",
+            "install",
+            {
+                "serial": SERIAL,
+                "apk_path": "/home/deck/builds/training.apk",
+                "reinstall": True,
+                "grant_permissions": True,
+            },
+        ),
+        (
+            "/v1/devbridge/adb/launch",
+            "launch",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            "/v1/devbridge/adb/stop",
+            "stop",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            "/v1/devbridge/adb/clear-data",
+            "clear_data",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            "/v1/devbridge/adb/uninstall",
+            "uninstall",
+            {"serial": SERIAL, "package": PACKAGE, "keep_data": True},
+        ),
+    )
+
+    for path, _operation, body in cases:
+        handler = _authorize(
+            monkeypatch,
+            _make_handler(path, method="POST", body=body),
+        )
+        handler.do_POST()
+        assert handler._last_code == 200
+
+    assert calls == [(operation, body) for _path, operation, body in cases]
+
+
+def test_app_routes_require_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    monkeypatch.setattr(
+        devhub_api,
+        "execute_adb_operation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unauthorized request executed ADB")
+        ),
+    )
+
+    requests = (
+        ("GET", f"/v1/devbridge/adb/packages?serial={SERIAL}", None),
+        ("POST", "/v1/devbridge/adb/install", {}),
+        ("POST", "/v1/devbridge/adb/launch", {}),
+        ("POST", "/v1/devbridge/adb/stop", {}),
+        ("POST", "/v1/devbridge/adb/clear-data", {}),
+        ("POST", "/v1/devbridge/adb/uninstall", {}),
+    )
+
+    for method, path, body in requests:
+        handler = _make_handler(path, method=method, body=body)
+        if method == "GET":
+            handler.do_GET()
+        else:
+            handler.do_POST()
+        assert handler._last_code == 401, path
+        assert _response_json(handler)["result_code"] == "unauthorized"

--- a/tests/test_devhub_app_cli.py
+++ b/tests/test_devhub_app_cli.py
@@ -1,0 +1,236 @@
+import json
+
+import pytest
+
+from vr_hotspotd import cli as base_cli
+from vr_hotspotd.devtools import adb_cli
+
+
+SERIAL = "192.168.68.24:5555"
+PACKAGE = "com.example.xrtraining"
+
+
+class _FakeResponse:
+    def __init__(self, data, *, status=200, result_code="ok"):
+        self.status = status
+        self._raw = json.dumps(
+            {
+                "correlation_id": "test-cid",
+                "result_code": result_code,
+                "warnings": [],
+                "data": data,
+            }
+        ).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+@pytest.fixture(autouse=True)
+def clear_cli_environment(monkeypatch):
+    for key in (*base_cli._ENV_KEYS, "VR_HOTSPOTD_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _missing_env_args(tmp_path):
+    return ["--env-file", str(tmp_path / "missing-env")]
+
+
+def _mocked_open(monkeypatch, response_data, seen):
+    def open_request(request, *, timeout):
+        seen["method"] = request.get_method()
+        seen["url"] = request.full_url
+        seen["headers"] = {key.lower(): value for key, value in request.header_items()}
+        seen["timeout"] = timeout
+        seen["body"] = (
+            None if request.data is None else json.loads(request.data.decode("utf-8"))
+        )
+        return _FakeResponse(response_data)
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", open_request)
+
+
+def _run(monkeypatch, tmp_path, response_data, argv):
+    seen = {}
+    _mocked_open(monkeypatch, response_data, seen)
+    result = adb_cli.main(
+        [
+            *argv,
+            "--api-url",
+            "http://127.0.0.1:9900",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+    return result, seen
+
+
+def test_packages_targets_selected_device(monkeypatch, tmp_path, capsys):
+    data = {
+        "operation": "packages",
+        "success": True,
+        "data": {"packages": [PACKAGE]},
+    }
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        ["packages", "--serial", SERIAL],
+    )
+
+    assert result == 0
+    assert seen["method"] == "GET"
+    assert seen["url"] == (
+        "http://127.0.0.1:9900/v1/devbridge/adb/packages?"
+        "serial=192.168.68.24%3A5555&third_party_only=1"
+    )
+    assert seen["body"] is None
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_packages_all_includes_system_packages(monkeypatch, tmp_path, capsys):
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        {"operation": "packages", "success": True},
+        ["packages", "--serial", SERIAL, "--all"],
+    )
+
+    assert result == 0
+    assert seen["url"].endswith("third_party_only=0")
+    capsys.readouterr()
+
+
+def test_install_sends_apk_workflow_and_uses_long_http_timeout(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    apk = tmp_path / "training.apk"
+    apk.write_bytes(b"APK")
+    data = {"operation": "install", "success": True}
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        [
+            "install",
+            "--serial",
+            SERIAL,
+            "--apk",
+            str(apk),
+            "--grant-permissions",
+        ],
+    )
+
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/install"
+    assert seen["body"] == {
+        "serial": SERIAL,
+        "apk_path": str(apk),
+        "reinstall": True,
+        "grant_permissions": True,
+    }
+    assert seen["timeout"] == 300.0
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_install_can_disable_reinstall(monkeypatch, tmp_path, capsys):
+    apk = tmp_path / "training.apk"
+    apk.write_bytes(b"APK")
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        {"operation": "install", "success": True},
+        [
+            "install",
+            "--serial",
+            SERIAL,
+            "--apk",
+            str(apk),
+            "--no-reinstall",
+        ],
+    )
+
+    assert result == 0
+    assert seen["body"]["reinstall"] is False
+    assert seen["body"]["grant_permissions"] is False
+    capsys.readouterr()
+
+
+def test_launch_stop_clear_and_uninstall_send_structured_requests(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    cases = (
+        (
+            ["launch", "--serial", SERIAL, "--package", PACKAGE],
+            "/v1/devbridge/adb/launch",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            ["stop", "--serial", SERIAL, "--package", PACKAGE],
+            "/v1/devbridge/adb/stop",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            ["clear-data", "--serial", SERIAL, "--package", PACKAGE],
+            "/v1/devbridge/adb/clear-data",
+            {"serial": SERIAL, "package": PACKAGE},
+        ),
+        (
+            ["uninstall", "--serial", SERIAL, "--package", PACKAGE, "--keep-data"],
+            "/v1/devbridge/adb/uninstall",
+            {"serial": SERIAL, "package": PACKAGE, "keep_data": True},
+        ),
+    )
+
+    for argv, path, body in cases:
+        result, seen = _run(
+            monkeypatch,
+            tmp_path,
+            {"operation": argv[0], "success": True},
+            argv,
+        )
+        assert result == 0
+        assert seen["method"] == "POST"
+        assert seen["url"] == "http://127.0.0.1:9900" + path
+        assert seen["body"] == body
+        capsys.readouterr()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ["packages", "--serial", "bad serial"],
+        ["install", "--serial", SERIAL, "--apk", "relative.apk"],
+        ["launch", "--serial", SERIAL, "--package", "bad package"],
+        ["uninstall", "--serial", SERIAL, "--package", "com..broken"],
+    ),
+)
+def test_invalid_app_arguments_are_rejected_before_request(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    argv,
+):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError(f"request must not run with timeout {timeout}")
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main([*argv, *_missing_env_args(tmp_path)])
+
+    assert excinfo.value.code == 2
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Turn the Developer Hub ADB connection foundation into a usable application-development workflow.

## New capabilities

The shared typed ADB service, authenticated API, and `vr-hotspot-adb` CLI now support:

- List third-party or all installed packages on a selected headset.
- Install or reinstall an APK from an absolute host path.
- Optionally grant requested runtime permissions during installation.
- Launch an installed package.
- Force-stop an installed package.
- Clear an application's local data.
- Uninstall an application, optionally retaining its data.

## CLI

- `vr-hotspot-adb packages --serial SERIAL [--all]`
- `vr-hotspot-adb install --serial SERIAL --apk /absolute/path.apk [--no-reinstall] [--grant-permissions]`
- `vr-hotspot-adb launch --serial SERIAL --package PACKAGE`
- `vr-hotspot-adb stop --serial SERIAL --package PACKAGE`
- `vr-hotspot-adb clear-data --serial SERIAL --package PACKAGE`
- `vr-hotspot-adb uninstall --serial SERIAL --package PACKAGE [--keep-data]`

## API

- `GET /v1/devbridge/adb/packages?serial=...&third_party_only=0|1`
- `POST /v1/devbridge/adb/install`
- `POST /v1/devbridge/adb/launch`
- `POST /v1/devbridge/adb/stop`
- `POST /v1/devbridge/adb/clear-data`
- `POST /v1/devbridge/adb/uninstall`

## Implementation

- Every operation selects an explicit device serial.
- APK installs use a five-minute operation and HTTP timeout.
- APK paths must be absolute, regular, non-symlink `.apk` files within the supported size bound.
- Package, serial, boolean, and APK inputs are validated before ADB execution.
- The daemon constructs every ADB argv itself with no free-form command surface.

## Tests

Adds focused coverage for command construction, package parsing, install options, app lifecycle operations, API routing/authentication, CLI request construction, input rejection, APK symlink refusal, and install timeout behavior.

## Validation

- CI passed on Python 3.11, 3.12, and 3.13.
- Full pytest passed: 1091 passed, 4 subtests passed.
- Ruff passed.
- Shellcheck passed.
- Vendor manifest and deterministic SBOM validation passed.
- Platform-Tools pin validation passed.
- Installer detection matrix passed.