### PR TITLE
Serve Developer Hub console assets

### DIFF
--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -1,16 +1,17 @@
 """Authenticated Developer Hub API routes for typed ADB operations.
 
 The main VRhotspot API remains the base handler. This subclass intercepts only
-Developer Hub ADB routes and delegates every other request to the established
-APIHandler implementation.
+Developer Hub assets and ADB routes and delegates every other request to the
+established APIHandler implementation.
 """
 
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Mapping, Optional
 
-from vr_hotspotd.api import APIHandler
+from vr_hotspotd.api import APIHandler, _resolve_asset_path
 from vr_hotspotd.devtools.adb_operations import (
     RESULT_FAILED,
     RESULT_INVALID_REQUEST,
@@ -23,6 +24,11 @@ from vr_hotspotd.devtools.adb_operations import (
 
 
 log = logging.getLogger("vr_hotspotd.devhub_api")
+
+_DEVHUB_ASSET_TYPES = {
+    "/assets/devhub.css": "text/css; charset=utf-8",
+    "/assets/devhub.js": "application/javascript; charset=utf-8",
+}
 
 _GET_OPERATIONS = {
     "/v1/devbridge/adb/version": "version",
@@ -59,7 +65,24 @@ _BODY_ERROR_WARNINGS = {
 
 
 class DevHubAPIHandler(APIHandler):
-    """Extend the daemon API with executable Developer Hub operations."""
+    """Extend the daemon API with Developer Hub assets and operations."""
+
+    def _serve_devhub_asset(self, path: str) -> bool:
+        content_type = _DEVHUB_ASSET_TYPES.get(path)
+        if content_type is None:
+            return False
+        asset_name = path.rsplit("/", 1)[-1]
+        asset_path = _resolve_asset_path(asset_name)
+        if not asset_path:
+            self._respond_raw(404, b"Not Found", "text/plain; charset=utf-8")
+            return True
+        try:
+            payload = Path(asset_path).read_bytes()
+        except OSError:
+            self._respond_raw(404, b"Not Found", "text/plain; charset=utf-8")
+            return True
+        self._respond_raw(200, payload, content_type)
+        return True
 
     def _respond_adb_operation(
         self,
@@ -97,6 +120,8 @@ class DevHubAPIHandler(APIHandler):
     def do_GET(self):
         cid = self._cid()
         path, qs = self._parse_url()
+        if self._serve_devhub_asset(path):
+            return
         operation = _GET_OPERATIONS.get(path)
         if operation is None:
             super().do_GET()

--- a/tests/test_devhub_asset_serving.py
+++ b/tests/test_devhub_asset_serving.py
@@ -1,0 +1,79 @@
+import io
+from email.message import Message
+
+import pytest
+
+import vr_hotspotd.devtools.devhub_api as devhub_api
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
+
+
+@pytest.mark.parametrize(
+    ("path", "content_type", "payload"),
+    (
+        ("/assets/devhub.js", "application/javascript; charset=utf-8", b"console.log('hub');"),
+        ("/assets/devhub.css", "text/css; charset=utf-8", b".devhub-page{}"),
+    ),
+)
+def test_developer_hub_assets_are_served_without_api_auth(
+    monkeypatch,
+    tmp_path,
+    path,
+    content_type,
+    payload,
+):
+    asset = tmp_path / path.rsplit("/", 1)[-1]
+    asset.write_bytes(payload)
+    monkeypatch.setattr(
+        devhub_api,
+        "_resolve_asset_path",
+        lambda name: str(asset) if name == asset.name else None,
+    )
+
+    handler = DevHubAPIHandler.__new__(DevHubAPIHandler)
+    handler.rfile = io.BytesIO()
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.command = "GET"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"GET {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+    handler._headers = {}
+
+    def send_response(code, _message=None):
+        handler._last_code = code
+
+    def send_header(key, value):
+        handler._headers[key.casefold()] = value
+
+    handler.send_response = send_response
+    handler.send_header = send_header
+    handler.end_headers = lambda: None
+
+    handler.do_GET()
+
+    assert handler._last_code == 200
+    assert handler._headers["content-type"] == content_type
+    assert handler.wfile.getvalue() == payload
+
+
+def test_missing_developer_hub_asset_returns_404(monkeypatch):
+    monkeypatch.setattr(devhub_api, "_resolve_asset_path", lambda _name: None)
+
+    handler = DevHubAPIHandler.__new__(DevHubAPIHandler)
+    handler.rfile = io.BytesIO()
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.command = "GET"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = "GET /assets/devhub.js HTTP/1.1"
+    handler.path = "/assets/devhub.js"
+    handler._last_code = None
+    handler.send_response = lambda code, _message=None: setattr(handler, "_last_code", code)
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+
+    handler.do_GET()
+
+    assert handler._last_code == 404
+    assert handler.wfile.getvalue() == b"Not Found"


### PR DESCRIPTION
## Summary

Fix the installed Developer Hub console by serving its JavaScript and CSS through the active `DevHubAPIHandler`.

## Problem

The Developer Hub module and stylesheet were merged in PR #113, but the legacy static-asset allowlist in `APIHandler` did not recognize `devhub.js` or `devhub.css`. The browser and Flatpak shell would therefore receive 404 responses for both files.

## Fix

- Intercept `/assets/devhub.js` and `/assets/devhub.css` in `DevHubAPIHandler` before delegating to the legacy asset route.
- Resolve files through the existing development/install asset resolver.
- Return the correct JavaScript and CSS content types.
- Keep assets public like the rest of the Web Portal shell; API operations remain authenticated.
- Return 404 when either file is absent.

## Tests

Adds direct handler tests for JavaScript serving, CSS serving, content types, unauthenticated shell access, and missing assets.

## Validation

CI is running. Merge automatically once green.