### PR TITLE
Add one-click managed Android Platform-Tools

### DIFF
--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -61,3 +61,116 @@ window.UI_FIELD_VISIBILITY = {
   script.async = false;
   document.head.appendChild(script);
 })();
+
+(function addManagedPlatformToolsControls() {
+  const TERMS_URL = 'https://developer.android.com/studio/terms';
+
+  function feedback(message, state) {
+    const node = document.getElementById('devhubFeedback');
+    if (!node) return;
+    node.textContent = message;
+    node.dataset.state = state || 'idle';
+  }
+
+  async function toolsRequest(path, body, button) {
+    if (button) button.disabled = true;
+    feedback(path.endsWith('/install')
+      ? 'Downloading and installing Android Platform-Tools...'
+      : 'Removing VRhotspot-managed Android Platform-Tools...', 'loading');
+    try {
+      const response = await api(path, {
+        method: 'POST',
+        body: JSON.stringify(body || {}),
+      });
+      if (!response.ok) {
+        const code = response.json && response.json.result_code
+          ? response.json.result_code
+          : `HTTP ${response.status}`;
+        feedback(`Managed tools operation failed: ${code}`, 'error');
+        return;
+      }
+      const result = response.json && response.json.data ? response.json.data : {};
+      feedback(result.message || 'Managed tools operation completed.', 'success');
+      const refresh = document.getElementById('devhubRefresh');
+      if (refresh) refresh.click();
+    } catch {
+      feedback('Managed tools operation could not reach the VRhotspot daemon.', 'error');
+    } finally {
+      if (button) button.disabled = false;
+    }
+  }
+
+  function inject() {
+    if (document.getElementById('devhubToolsManagement')) return true;
+    const toolsGrid = document.querySelector('#tab-devhub .devhub-tools-grid');
+    if (!toolsGrid) return false;
+
+    const section = document.createElement('div');
+    section.id = 'devhubToolsManagement';
+    section.className = 'devhub-span';
+
+    const checks = document.createElement('div');
+    checks.className = 'devhub-checks mt-12';
+    const label = document.createElement('label');
+    const accept = document.createElement('input');
+    accept.id = 'devhubAcceptToolsLicense';
+    accept.type = 'checkbox';
+    const copy = document.createElement('span');
+    copy.append('I accept the ');
+    const terms = document.createElement('a');
+    terms.href = TERMS_URL;
+    terms.target = '_blank';
+    terms.rel = 'noopener noreferrer';
+    terms.textContent = 'Android SDK License Agreement';
+    copy.appendChild(terms);
+    label.append(accept, copy);
+    checks.appendChild(label);
+
+    const actions = document.createElement('div');
+    actions.className = 'devhub-actions mt-12';
+    const install = document.createElement('button');
+    install.id = 'devhubInstallTools';
+    install.type = 'button';
+    install.className = 'btn primary';
+    install.textContent = 'Install Managed ADB';
+    const remove = document.createElement('button');
+    remove.id = 'devhubRemoveTools';
+    remove.type = 'button';
+    remove.className = 'btn secondary';
+    remove.textContent = 'Remove Managed ADB';
+    actions.append(install, remove);
+
+    install.addEventListener('click', () => {
+      if (!accept.checked) {
+        feedback('Review and accept the Android SDK License Agreement first.', 'error');
+        return;
+      }
+      void toolsRequest(
+        '/v1/devbridge/tools/install',
+        { license_accepted: true },
+        install,
+      );
+    });
+    remove.addEventListener('click', () => {
+      void toolsRequest('/v1/devbridge/tools/remove', {}, remove);
+    });
+
+    section.append(checks, actions);
+    toolsGrid.appendChild(section);
+    return true;
+  }
+
+  function start() {
+    if (inject()) return;
+    const observer = new MutationObserver(() => {
+      if (inject()) observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/backend/vr_hotspotd/devtools/adb_cli.py
+++ b/backend/vr_hotspotd/devtools/adb_cli.py
@@ -1,9 +1,4 @@
-"""Direct command-line client for typed Developer Hub ADB operations.
-
-The daemon owns ADB execution. This client only sends structured, authenticated
-requests to the allowlisted Developer Hub API endpoints; it never accepts an
-arbitrary adb command line.
-"""
+"""Command-line client for VRhotspot Developer Hub operations."""
 
 from __future__ import annotations
 
@@ -21,6 +16,9 @@ import uuid
 from vr_hotspotd import cli as base_cli
 
 
+TOOLS_STATUS_PATH = "/v1/devbridge/tools/status"
+TOOLS_INSTALL_PATH = "/v1/devbridge/tools/install"
+TOOLS_REMOVE_PATH = "/v1/devbridge/tools/remove"
 ADB_VERSION_PATH = "/v1/devbridge/adb/version"
 ADB_DEVICES_PATH = "/v1/devbridge/adb/devices"
 ADB_PAIR_PATH = "/v1/devbridge/adb/pair"
@@ -215,11 +213,38 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="vr-hotspot-adb",
         description=(
-            "Run explicit ADB device and application operations through the authenticated "
-            "VRhotspot Developer Hub daemon."
+            "Set up Android developer tools and control standalone XR headsets through "
+            "the authenticated VRhotspot Developer Hub daemon."
         ),
     )
     commands = parser.add_subparsers(dest="operation", required=True)
+
+    tools_parser = commands.add_parser(
+        "tools",
+        help="Inspect, install, or remove VRhotspot-managed Android Platform-Tools.",
+    )
+    tools_commands = tools_parser.add_subparsers(dest="tools_operation", required=True)
+    tools_status_parser = tools_commands.add_parser(
+        "status",
+        help="Show the effective ADB source and managed-tools verification state.",
+    )
+    _add_common_arguments(tools_status_parser)
+    tools_install_parser = tools_commands.add_parser(
+        "install",
+        help="Download and install the reviewed Android Platform-Tools pin.",
+    )
+    _add_common_arguments(tools_install_parser)
+    tools_install_parser.set_defaults(timeout=180.0)
+    tools_install_parser.add_argument(
+        "--accept-license",
+        action="store_true",
+        help="Accept the Android SDK License Agreement for this download.",
+    )
+    tools_remove_parser = tools_commands.add_parser(
+        "remove",
+        help="Remove only the VRhotspot-managed Platform-Tools installation.",
+    )
+    _add_common_arguments(tools_remove_parser)
 
     version_parser = commands.add_parser("version", help="Show the effective adb version.")
     _add_common_arguments(version_parser)
@@ -309,7 +334,7 @@ def build_parser() -> argparse.ArgumentParser:
     install_parser.add_argument(
         "--no-reinstall",
         action="store_true",
-        help="Do not pass adb install -r; fail if the package is already installed.",
+        help="Fail if the package is already installed instead of updating it.",
     )
     install_parser.add_argument(
         "--grant-permissions",
@@ -355,6 +380,32 @@ def _operation_request(
     args: argparse.Namespace,
 ) -> tuple[str, str, str, Optional[Dict[str, Any]], tuple[str, ...]]:
     operation = args.operation
+    if operation == "tools":
+        tools_operation = args.tools_operation
+        if tools_operation == "status":
+            return TOOLS_STATUS_PATH, "GET", "a Developer Hub tools status", None, ()
+        if tools_operation == "install":
+            if not args.accept_license:
+                raise ADBCLIError(
+                    "tools install requires --accept-license after reviewing the "
+                    "Android SDK License Agreement."
+                )
+            return (
+                TOOLS_INSTALL_PATH,
+                "POST",
+                "a managed Platform-Tools installation result",
+                {"license_accepted": True},
+                (),
+            )
+        if tools_operation == "remove":
+            return (
+                TOOLS_REMOVE_PATH,
+                "POST",
+                "a managed Platform-Tools removal result",
+                {},
+                (),
+            )
+        raise ADBCLIError(f"unknown tools operation: {tools_operation}")
     if operation == "version":
         return ADB_VERSION_PATH, "GET", "an ADB version result", None, ()
     if operation == "devices":
@@ -453,7 +504,7 @@ def _operation_request(
             },
             (),
         )
-    raise ADBCLIError(f"unknown ADB operation: {operation}")
+    raise ADBCLIError(f"unknown Developer Hub operation: {operation}")
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -465,7 +516,7 @@ def _run(args: argparse.Namespace) -> int:
         method=method,
         token=token,
         timeout=args.timeout,
-        correlation_prefix=f"cli-devhub-adb-{args.operation}",
+        correlation_prefix=f"cli-devhub-{args.operation}",
         payload_description=description,
         body=body,
         sensitive_values=sensitive_values,

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -1,9 +1,4 @@
-"""Authenticated Developer Hub API routes for typed ADB operations.
-
-The main VRhotspot API remains the base handler. This subclass intercepts only
-Developer Hub assets and ADB routes and delegates every other request to the
-established APIHandler implementation.
-"""
+"""Authenticated Developer Hub routes for assets, tools, and ADB operations."""
 
 from __future__ import annotations
 
@@ -20,6 +15,22 @@ from vr_hotspotd.devtools.adb_operations import (
     RESULT_TIMEOUT,
     RESULT_TOOLS_UNAVAILABLE,
     execute_adb_operation,
+)
+from vr_hotspotd.devtools.platform_tools_manager import (
+    RESULT_ARCHIVE_INVALID,
+    RESULT_ARCHIVE_TOO_LARGE,
+    RESULT_CHECKSUM_MISMATCH,
+    RESULT_DOWNLOAD_FAILED,
+    RESULT_IMPLEMENTATION_BLOCKED,
+    RESULT_INSTALL_BUSY,
+    RESULT_INSTALL_FAILED,
+    RESULT_LICENSE_REQUIRED,
+    RESULT_MANIFEST_INVALID,
+    RESULT_PIN_UNAVAILABLE,
+    RESULT_REMOVE_FAILED,
+    RESULT_UNSUPPORTED_ARCH,
+    install_managed_platform_tools,
+    remove_managed_platform_tools,
 )
 
 
@@ -47,6 +58,11 @@ _POST_OPERATIONS = {
     "/v1/devbridge/adb/uninstall": "uninstall",
 }
 
+_TOOLS_POST_OPERATIONS = {
+    "/v1/devbridge/tools/install": "install",
+    "/v1/devbridge/tools/remove": "remove",
+}
+
 _RESULT_HTTP_STATUS = {
     RESULT_OK: 200,
     RESULT_INVALID_REQUEST: 400,
@@ -54,6 +70,22 @@ _RESULT_HTTP_STATUS = {
     RESULT_TIMEOUT: 504,
     RESULT_OUTPUT_LIMIT: 502,
     RESULT_FAILED: 409,
+}
+
+_TOOLS_RESULT_HTTP_STATUS = {
+    RESULT_OK: 200,
+    RESULT_LICENSE_REQUIRED: 400,
+    RESULT_PIN_UNAVAILABLE: 503,
+    RESULT_IMPLEMENTATION_BLOCKED: 503,
+    RESULT_UNSUPPORTED_ARCH: 422,
+    RESULT_INSTALL_BUSY: 409,
+    RESULT_DOWNLOAD_FAILED: 502,
+    RESULT_ARCHIVE_TOO_LARGE: 502,
+    RESULT_CHECKSUM_MISMATCH: 502,
+    RESULT_ARCHIVE_INVALID: 502,
+    RESULT_MANIFEST_INVALID: 409,
+    RESULT_INSTALL_FAILED: 500,
+    RESULT_REMOVE_FAILED: 500,
 }
 
 _BODY_ERROR_WARNINGS = {
@@ -105,6 +137,32 @@ class DevHubAPIHandler(APIHandler):
             ),
         )
 
+    def _respond_tools_operation(
+        self,
+        *,
+        cid: str,
+        operation: str,
+        request: Mapping[str, Any],
+        warnings: Optional[list[str]] = None,
+    ) -> None:
+        if operation == "install":
+            result = install_managed_platform_tools(
+                license_accepted=request.get("license_accepted")
+            )
+        else:
+            result = remove_managed_platform_tools()
+        result_code = str(result.get("result_code") or RESULT_INSTALL_FAILED)
+        status = _TOOLS_RESULT_HTTP_STATUS.get(result_code, 500)
+        self._respond(
+            status,
+            self._envelope(
+                correlation_id=cid,
+                result_code=result_code,
+                data=result,
+                warnings=list(warnings or []),
+            ),
+        )
+
     def _respond_invalid_body(self, cid: str, warnings: list[str]) -> None:
         status = 413 if "body_too_large" in warnings else 400
         self._respond(
@@ -146,7 +204,8 @@ class DevHubAPIHandler(APIHandler):
         cid = self._cid()
         path, _qs = self._parse_url()
         operation = _POST_OPERATIONS.get(path)
-        if operation is None:
+        tools_operation = _TOOLS_POST_OPERATIONS.get(path)
+        if operation is None and tools_operation is None:
             super().do_POST()
             return
 
@@ -162,9 +221,18 @@ class DevHubAPIHandler(APIHandler):
             self._respond_invalid_body(cid, warnings)
             return
 
+        if tools_operation is not None:
+            self._respond_tools_operation(
+                cid=cid,
+                operation=tools_operation,
+                request=body,
+                warnings=warnings,
+            )
+            return
+
         self._respond_adb_operation(
             cid=cid,
-            operation=operation,
+            operation=operation or "",
             request=body,
             warnings=warnings,
         )

--- a/backend/vr_hotspotd/devtools/platform_tools.py
+++ b/backend/vr_hotspotd/devtools/platform_tools.py
@@ -1,18 +1,4 @@
-"""Read-only Platform-Tools pin loading, adb discovery, and tools status.
-
-This module reads the reviewed pin metadata shipped with the package,
-discovers whether a VRhotspot-managed or system ``adb`` exists on the host,
-and builds the Dev Bridge tools status model.
-
-Hard boundaries, enforced by construction:
-
-- No network access of any kind. The pinned URL is parsed for its host name
-  only and is never fetched.
-- ``adb`` is never executed; discovery is filesystem/PATH inspection only.
-- Nothing is installed, removed, or modified anywhere on the host.
-- While the pin's ``archive_sha256`` is the review placeholder, the status
-  always reports ``implementation_blocked`` true regardless of the flag.
-"""
+"""Platform-Tools pin loading, adb discovery, and tools status."""
 
 from __future__ import annotations
 
@@ -51,10 +37,8 @@ _ARCH_ALIASES = {
 }
 
 _TOOLS_STATUS_NOTES = (
-    "Dev Bridge tools status is read-only: nothing is downloaded, installed, "
-    "removed, or executed.",
-    "The Platform-Tools pin is reviewed metadata only; downloader/installer "
-    "code is intentionally not implemented while implementation_blocked is true.",
+    "VRhotspot can install the reviewed Android Platform-Tools pin into writable host state.",
+    "A system adb remains supported; a verified managed install is preferred when present.",
 )
 
 
@@ -106,6 +90,10 @@ def _validate_pin(pin: Mapping[str, Any]) -> List[str]:
     if not _is_nonempty_string(pin.get("arch")):
         errors.append("arch must be a non-empty string")
 
+    maximum = pin.get("max_archive_bytes")
+    if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
+        errors.append("max_archive_bytes must be a positive integer")
+
     allowlist = pin.get("extract_allowlist")
     if (
         not isinstance(allowlist, list)
@@ -114,11 +102,21 @@ def _validate_pin(pin: Mapping[str, Any]) -> List[str]:
     ):
         errors.append("extract_allowlist must be a non-empty array of non-empty strings")
 
+    if not _is_nonempty_string(pin.get("license_name")):
+        errors.append("license_name must be a non-empty string")
+    terms_url = pin.get("license_terms_url")
+    if not _is_nonempty_string(terms_url):
+        errors.append("license_terms_url must be a non-empty string")
+    else:
+        parsed_terms = urlsplit(terms_url)
+        if parsed_terms.scheme != "https" or parsed_terms.hostname != "developer.android.com":
+            errors.append("license_terms_url must use developer.android.com over https")
+
     return errors
 
 
 def load_platform_tools_pin(path: Optional[Path] = None) -> Dict[str, Any]:
-    """Load and validate the pin metadata. Raises PinError; never touches the network."""
+    """Load and validate the reviewed pin metadata."""
 
     pin_path = Path(path) if path is not None else default_pin_path()
     try:
@@ -142,7 +140,7 @@ def load_platform_tools_pin(path: Optional[Path] = None) -> Dict[str, Any]:
 
 
 def pin_is_blocked(pin: Mapping[str, Any]) -> bool:
-    """Fail safe: the placeholder hash blocks implementation regardless of the flag."""
+    """The placeholder hash blocks implementation regardless of the flag."""
 
     if pin.get("archive_sha256") == BLOCKED_SHA256_PLACEHOLDER:
         return True
@@ -158,7 +156,7 @@ def pin_blocked_reason(pin: Mapping[str, Any]) -> Optional[str]:
 
 
 def pin_url_host(pin: Mapping[str, Any]) -> Optional[str]:
-    """Host name of the pinned URL only; the full URL is never reported."""
+    """Host name of the pinned archive URL; the full download URL is not reported."""
 
     url = pin.get("url")
     if not _is_nonempty_string(url):
@@ -176,12 +174,33 @@ def normalize_arch(machine: Optional[str]) -> Optional[str]:
     return _ARCH_ALIASES.get(normalized, normalized)
 
 
+def _managed_manifest_state(managed_path: str) -> Dict[str, Any]:
+    managed = Path(managed_path)
+    root = managed.parent.parent
+    manifest = root / "manifest.json"
+    if not manifest.exists() and not manifest.is_symlink():
+        return {"verified": None, "version": None, "error": None}
+    try:
+        from vr_hotspotd.devtools.platform_tools_manager import (
+            inspect_managed_platform_tools,
+        )
+
+        inspected = inspect_managed_platform_tools(root)
+    except Exception:
+        return {"verified": False, "version": None, "error": "manifest_invalid"}
+    return {
+        "verified": inspected.get("verified"),
+        "version": inspected.get("version"),
+        "error": inspected.get("error"),
+    }
+
+
 def discover_adb(
     *,
     managed_path: str = MANAGED_ADB_PATH,
     which=shutil.which,
 ) -> Dict[str, Any]:
-    """Filesystem/PATH discovery of adb. Never executes anything."""
+    """Discover a verified managed adb first, then a system adb."""
 
     managed = Path(managed_path)
     try:
@@ -193,6 +212,10 @@ def discover_adb(
         )
     except OSError:
         managed_present = False
+        managed_installed = False
+
+    managed_state = _managed_manifest_state(managed_path)
+    if managed_state["verified"] is False:
         managed_installed = False
 
     try:
@@ -215,9 +238,9 @@ def discover_adb(
             "path": managed_path,
             "present": managed_present,
             "installed": managed_installed,
-            # No managed install exists in the status foundation, so there is
-            # no installed-tools ledger to verify bytes against yet.
-            "verified": None,
+            "verified": managed_state["verified"],
+            "version": managed_state["version"],
+            "error": managed_state["error"],
         },
         "system": {
             "present": bool(system_path),
@@ -235,7 +258,7 @@ def build_devbridge_tools_status(
     discovery: Mapping[str, Any],
     host_machine: Optional[str],
 ) -> Dict[str, Any]:
-    """Pure read-only tools status model shared by API, CLI, and support bundle."""
+    """Pure tools status model shared by API, CLI, UI, and support bundle."""
 
     warnings: List[str] = []
     host_arch = normalize_arch(host_machine)
@@ -248,6 +271,8 @@ def build_devbridge_tools_status(
             "arch": pin.get("arch"),
             "implementation_blocked": pin_is_blocked(pin),
             "blocked_reason": pin_blocked_reason(pin),
+            "license_name": pin.get("license_name"),
+            "license_terms_url": pin.get("license_terms_url"),
             "error": None,
         }
         arch_supported: Optional[bool] = host_arch == normalize_arch(pin.get("arch"))
@@ -259,13 +284,18 @@ def build_devbridge_tools_status(
             "version": None,
             "url_host": None,
             "arch": None,
-            # Fail safe: without a readable pin nothing may be implemented.
             "implementation_blocked": True,
             "blocked_reason": BLOCKED_REASON_PIN_UNAVAILABLE,
+            "license_name": None,
+            "license_terms_url": None,
             "error": pin_error or "pin unavailable",
         }
         arch_supported = None
         warnings.append("platform_tools_pin_unavailable")
+
+    managed = discovery.get("managed")
+    if isinstance(managed, Mapping) and managed.get("present") and managed.get("verified") is False:
+        warnings.append("managed_tools_verification_failed")
 
     return {
         "schema_version": TOOLS_STATUS_SCHEMA_VERSION,
@@ -283,7 +313,7 @@ def build_devbridge_tools_status(
 
 
 def collect_devbridge_tools_status() -> Dict[str, Any]:
-    """Gather the read-only Dev Bridge tools status. Never raises."""
+    """Gather the Dev Bridge tools status. Never raises."""
 
     pin: Optional[Dict[str, Any]] = None
     pin_error: Optional[str] = None
@@ -291,7 +321,7 @@ def collect_devbridge_tools_status() -> Dict[str, Any]:
         pin = load_platform_tools_pin()
     except PinError as exc:
         pin_error = str(exc)
-    except Exception as exc:  # defensive: status must never fail the caller
+    except Exception as exc:
         pin_error = f"unexpected pin load failure: {type(exc).__name__}"
 
     try:
@@ -303,6 +333,8 @@ def collect_devbridge_tools_status() -> Dict[str, Any]:
                 "present": False,
                 "installed": False,
                 "verified": None,
+                "version": None,
+                "error": None,
             },
             "system": {"present": False, "path": None},
             "source": ADB_SOURCE_MISSING,

--- a/backend/vr_hotspotd/devtools/platform_tools.py
+++ b/backend/vr_hotspotd/devtools/platform_tools.py
@@ -91,7 +91,9 @@ def _validate_pin(pin: Mapping[str, Any]) -> List[str]:
         errors.append("arch must be a non-empty string")
 
     maximum = pin.get("max_archive_bytes")
-    if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
+    if maximum is not None and (
+        isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0
+    ):
         errors.append("max_archive_bytes must be a positive integer")
 
     allowlist = pin.get("extract_allowlist")
@@ -102,15 +104,17 @@ def _validate_pin(pin: Mapping[str, Any]) -> List[str]:
     ):
         errors.append("extract_allowlist must be a non-empty array of non-empty strings")
 
-    if not _is_nonempty_string(pin.get("license_name")):
-        errors.append("license_name must be a non-empty string")
+    license_name = pin.get("license_name")
+    if license_name is not None and not _is_nonempty_string(license_name):
+        errors.append("license_name must be a non-empty string when present")
     terms_url = pin.get("license_terms_url")
-    if not _is_nonempty_string(terms_url):
-        errors.append("license_terms_url must be a non-empty string")
-    else:
-        parsed_terms = urlsplit(terms_url)
-        if parsed_terms.scheme != "https" or parsed_terms.hostname != "developer.android.com":
-            errors.append("license_terms_url must use developer.android.com over https")
+    if terms_url is not None:
+        if not _is_nonempty_string(terms_url):
+            errors.append("license_terms_url must be a non-empty string when present")
+        else:
+            parsed_terms = urlsplit(terms_url)
+            if parsed_terms.scheme != "https" or parsed_terms.hostname != "developer.android.com":
+                errors.append("license_terms_url must use developer.android.com over https")
 
     return errors
 

--- a/backend/vr_hotspotd/devtools/platform_tools_manager.py
+++ b/backend/vr_hotspotd/devtools/platform_tools_manager.py
@@ -14,14 +14,13 @@ import platform
 import shutil
 import stat
 import tempfile
-from typing import Any, BinaryIO, Callable, Dict, Iterator, Mapping, Optional
+from typing import Any, Callable, Dict, Iterator, Mapping, Optional, Union
 from urllib.request import Request, urlopen
 import uuid
 import zipfile
 
 from vr_hotspotd.devtools.platform_tools import (
     DEVTOOLS_ROOT,
-    MANAGED_ADB_PATH,
     PinError,
     load_platform_tools_pin,
     normalize_arch,
@@ -48,6 +47,8 @@ RESULT_ARCHIVE_INVALID = "archive_invalid"
 RESULT_INSTALL_FAILED = "install_failed"
 RESULT_REMOVE_FAILED = "remove_failed"
 RESULT_MANIFEST_INVALID = "manifest_invalid"
+
+PathLike = Union[Path, str]
 
 
 class PlatformToolsError(RuntimeError):
@@ -78,7 +79,7 @@ def _result(
     }
 
 
-def _managed_root(root: Optional[Path | str]) -> Path:
+def _managed_root(root: Optional[PathLike]) -> Path:
     candidate = Path(root if root is not None else DEVTOOLS_ROOT)
     if not candidate.is_absolute():
         raise PlatformToolsError(RESULT_INSTALL_FAILED, "managed tools root must be absolute")
@@ -100,13 +101,19 @@ def _adb_path(root: Path) -> Path:
 def _ensure_root(root: Path) -> None:
     try:
         if root.exists() and root.is_symlink():
-            raise PlatformToolsError(RESULT_INSTALL_FAILED, "managed tools root must not be a symlink")
+            raise PlatformToolsError(
+                RESULT_INSTALL_FAILED,
+                "managed tools root must not be a symlink",
+            )
         root.mkdir(parents=True, exist_ok=True, mode=0o755)
         root.chmod(0o755)
     except PlatformToolsError:
         raise
     except OSError as exc:
-        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot prepare managed tools root: {exc}") from exc
+        raise PlatformToolsError(
+            RESULT_INSTALL_FAILED,
+            f"cannot prepare managed tools root: {exc}",
+        ) from exc
 
 
 @contextmanager
@@ -115,12 +122,19 @@ def _install_lock(root: Path) -> Iterator[None]:
     lock_path = root / LOCK_FILENAME
     descriptor: Optional[int] = None
     try:
-        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW,
+            0o600,
+        )
         try:
             fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError as exc:
             if exc.errno in {errno.EACCES, errno.EAGAIN}:
-                raise PlatformToolsError(RESULT_INSTALL_BUSY, "another managed-tools operation is running") from exc
+                raise PlatformToolsError(
+                    RESULT_INSTALL_BUSY,
+                    "another managed-tools operation is running",
+                ) from exc
             raise
         yield
     finally:
@@ -135,7 +149,10 @@ def _install_lock(root: Path) -> Iterator[None]:
                 pass
 
 
-def _validate_runtime_pin(pin: Mapping[str, Any], host_machine: Optional[str]) -> None:
+def _validate_runtime_pin(
+    pin: Mapping[str, Any],
+    host_machine: Optional[str],
+) -> None:
     if pin_is_blocked(pin):
         raise PlatformToolsError(
             RESULT_IMPLEMENTATION_BLOCKED,
@@ -148,24 +165,56 @@ def _validate_runtime_pin(pin: Mapping[str, Any], host_machine: Optional[str]) -
             RESULT_UNSUPPORTED_ARCH,
             f"managed Platform-Tools require {pin_arch or 'the pinned architecture'}",
         )
+    license_name = pin.get("license_name")
+    terms_url = pin.get("license_terms_url")
+    if not isinstance(license_name, str) or not license_name.strip():
+        raise PlatformToolsError(
+            RESULT_PIN_UNAVAILABLE,
+            "the reviewed Platform-Tools license metadata is unavailable",
+        )
+    if not isinstance(terms_url, str) or not terms_url.startswith(
+        "https://developer.android.com/"
+    ):
+        raise PlatformToolsError(
+            RESULT_PIN_UNAVAILABLE,
+            "the reviewed Platform-Tools license metadata is unavailable",
+        )
 
 
 def _safe_allowlist(pin: Mapping[str, Any]) -> list[str]:
     raw = pin.get("extract_allowlist")
     if not isinstance(raw, list) or not raw:
-        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is unavailable")
+        raise PlatformToolsError(
+            RESULT_ARCHIVE_INVALID,
+            "the extraction allowlist is unavailable",
+        )
     entries: list[str] = []
     for value in raw:
         if not isinstance(value, str):
-            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is invalid")
+            raise PlatformToolsError(
+                RESULT_ARCHIVE_INVALID,
+                "the extraction allowlist is invalid",
+            )
         normalized = PurePosixPath(value)
         if normalized.is_absolute() or ".." in normalized.parts or str(normalized) != value:
-            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist contains an unsafe path")
+            raise PlatformToolsError(
+                RESULT_ARCHIVE_INVALID,
+                "the extraction allowlist contains an unsafe path",
+            )
         if not value.startswith("platform-tools/"):
-            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist escaped platform-tools")
+            raise PlatformToolsError(
+                RESULT_ARCHIVE_INVALID,
+                "the extraction allowlist escaped platform-tools",
+            )
         entries.append(value)
-    if "platform-tools/adb" not in entries or "platform-tools/NOTICE.txt" not in entries:
-        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is incomplete")
+    if (
+        "platform-tools/adb" not in entries
+        or "platform-tools/NOTICE.txt" not in entries
+    ):
+        raise PlatformToolsError(
+            RESULT_ARCHIVE_INVALID,
+            "the extraction allowlist is incomplete",
+        )
     return entries
 
 
@@ -177,7 +226,10 @@ def _download_archive(
 ) -> str:
     maximum = pin.get("max_archive_bytes")
     if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
-        raise PlatformToolsError(RESULT_PIN_UNAVAILABLE, "the archive size limit is invalid")
+        raise PlatformToolsError(
+            RESULT_PIN_UNAVAILABLE,
+            "the archive size limit is invalid",
+        )
     request = Request(
         str(pin["url"]),
         headers={"User-Agent": "VRhotspot-Developer-Hub/1.1"},
@@ -186,38 +238,57 @@ def _download_archive(
     digest = hashlib.sha256()
     total = 0
     try:
-        with opener(request, timeout=DOWNLOAD_TIMEOUT_S) as response, destination.open("xb") as output:
-            content_length = response.headers.get("Content-Length") if hasattr(response, "headers") else None
+        with opener(request, timeout=DOWNLOAD_TIMEOUT_S) as response, destination.open(
+            "xb"
+        ) as output:
+            content_length = (
+                response.headers.get("Content-Length")
+                if hasattr(response, "headers")
+                else None
+            )
             if content_length:
                 try:
                     announced = int(content_length)
                 except (TypeError, ValueError):
                     announced = 0
                 if announced > maximum:
-                    raise PlatformToolsError(RESULT_ARCHIVE_TOO_LARGE, "the archive exceeds the configured size limit")
+                    raise PlatformToolsError(
+                        RESULT_ARCHIVE_TOO_LARGE,
+                        "the archive exceeds the configured size limit",
+                    )
             while True:
                 chunk = response.read(DOWNLOAD_CHUNK_BYTES)
                 if not chunk:
                     break
                 total += len(chunk)
                 if total > maximum:
-                    raise PlatformToolsError(RESULT_ARCHIVE_TOO_LARGE, "the archive exceeds the configured size limit")
+                    raise PlatformToolsError(
+                        RESULT_ARCHIVE_TOO_LARGE,
+                        "the archive exceeds the configured size limit",
+                    )
                 digest.update(chunk)
                 output.write(chunk)
     except PlatformToolsError:
         raise
     except Exception as exc:
-        raise PlatformToolsError(RESULT_DOWNLOAD_FAILED, f"Platform-Tools download failed: {type(exc).__name__}") from exc
+        raise PlatformToolsError(
+            RESULT_DOWNLOAD_FAILED,
+            f"Platform-Tools download failed: {type(exc).__name__}",
+        ) from exc
     if total <= 0:
-        raise PlatformToolsError(RESULT_DOWNLOAD_FAILED, "Platform-Tools download returned an empty archive")
+        raise PlatformToolsError(
+            RESULT_DOWNLOAD_FAILED,
+            "Platform-Tools download returned an empty archive",
+        )
     return digest.hexdigest()
 
 
 def _zip_entry_is_regular(info: zipfile.ZipInfo) -> bool:
     unix_mode = info.external_attr >> 16
-    if stat.S_ISLNK(unix_mode):
+    file_type = stat.S_IFMT(unix_mode)
+    if file_type == stat.S_IFLNK:
         return False
-    return unix_mode == 0 or stat.S_ISREG(unix_mode)
+    return file_type in {0, stat.S_IFREG}
 
 
 def _extract_archive(
@@ -232,13 +303,24 @@ def _extract_archive(
             by_name = {entry.filename: entry for entry in bundle.infolist()}
             missing = [entry for entry in allowlist if entry not in by_name]
             if missing:
-                raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the archive is missing required Platform-Tools files")
+                raise PlatformToolsError(
+                    RESULT_ARCHIVE_INVALID,
+                    "the archive is missing required Platform-Tools files",
+                )
             for relative in allowlist:
                 info = by_name[relative]
                 if info.is_dir() or not _zip_entry_is_regular(info):
-                    raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"unsupported archive entry: {relative}")
-                if info.file_size < 0 or info.file_size > int(pin["max_archive_bytes"]):
-                    raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"archive entry exceeds the size limit: {relative}")
+                    raise PlatformToolsError(
+                        RESULT_ARCHIVE_INVALID,
+                        f"unsupported archive entry: {relative}",
+                    )
+                if info.file_size < 0 or info.file_size > int(
+                    pin["max_archive_bytes"]
+                ):
+                    raise PlatformToolsError(
+                        RESULT_ARCHIVE_INVALID,
+                        f"archive entry exceeds the size limit: {relative}",
+                    )
                 target = staging_root.joinpath(*PurePosixPath(relative).parts)
                 target.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
                 digest = hashlib.sha256()
@@ -249,8 +331,13 @@ def _extract_archive(
                         if not chunk:
                             break
                         copied += len(chunk)
-                        if copied > info.file_size or copied > int(pin["max_archive_bytes"]):
-                            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"archive entry expanded beyond its declared size: {relative}")
+                        if copied > info.file_size or copied > int(
+                            pin["max_archive_bytes"]
+                        ):
+                            raise PlatformToolsError(
+                                RESULT_ARCHIVE_INVALID,
+                                f"archive entry expanded beyond its declared size: {relative}",
+                            )
                         digest.update(chunk)
                         output.write(chunk)
                 mode = 0o755 if relative == "platform-tools/adb" else 0o644
@@ -266,16 +353,29 @@ def _extract_archive(
     except PlatformToolsError:
         raise
     except (OSError, zipfile.BadZipFile, RuntimeError) as exc:
-        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"cannot extract Platform-Tools archive: {type(exc).__name__}") from exc
+        raise PlatformToolsError(
+            RESULT_ARCHIVE_INVALID,
+            f"cannot extract Platform-Tools archive: {type(exc).__name__}",
+        ) from exc
     return installed_files
 
 
 def _write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
     temporary = path.with_name(f".{path.name}.tmp-{uuid.uuid4().hex}")
     try:
-        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+        )
         with os.fdopen(descriptor, "w", encoding="utf-8") as output:
-            json.dump(dict(manifest), output, ensure_ascii=True, indent=2, sort_keys=True)
+            json.dump(
+                dict(manifest),
+                output,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
             output.write("\n")
             output.flush()
             os.fsync(output.fileno())
@@ -286,16 +386,26 @@ def _write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
             temporary.unlink(missing_ok=True)
         except OSError:
             pass
-        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot write managed-tools manifest: {exc}") from exc
+        raise PlatformToolsError(
+            RESULT_INSTALL_FAILED,
+            f"cannot write managed-tools manifest: {exc}",
+        ) from exc
 
 
-def _activate_install(root: Path, staged_tree: Path, manifest: Mapping[str, Any]) -> None:
+def _activate_install(
+    root: Path,
+    staged_tree: Path,
+    manifest: Mapping[str, Any],
+) -> None:
     final_tree = _platform_tools_path(root)
     backup = root / f".platform-tools-backup-{uuid.uuid4().hex}"
-    old_manifest = _manifest_path(root)
+    manifest_path = _manifest_path(root)
     had_tree = final_tree.exists() or final_tree.is_symlink()
     if had_tree and final_tree.is_symlink():
-        raise PlatformToolsError(RESULT_INSTALL_FAILED, "existing managed Platform-Tools path is a symlink")
+        raise PlatformToolsError(
+            RESULT_INSTALL_FAILED,
+            "existing managed Platform-Tools path is a symlink",
+        )
     moved_old = False
     moved_new = False
     try:
@@ -304,7 +414,7 @@ def _activate_install(root: Path, staged_tree: Path, manifest: Mapping[str, Any]
             moved_old = True
         os.replace(staged_tree, final_tree)
         moved_new = True
-        _write_manifest(old_manifest, manifest)
+        _write_manifest(manifest_path, manifest)
     except Exception as exc:
         if moved_new:
             try:
@@ -318,7 +428,10 @@ def _activate_install(root: Path, staged_tree: Path, manifest: Mapping[str, Any]
                 pass
         if isinstance(exc, PlatformToolsError):
             raise
-        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot activate managed Platform-Tools: {type(exc).__name__}") from exc
+        raise PlatformToolsError(
+            RESULT_INSTALL_FAILED,
+            f"cannot activate managed Platform-Tools: {type(exc).__name__}",
+        ) from exc
     finally:
         if backup.exists():
             shutil.rmtree(backup, ignore_errors=True)
@@ -328,15 +441,30 @@ def _load_manifest(path: Path) -> Dict[str, Any]:
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest is unreadable") from exc
-    if not isinstance(manifest, dict) or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
-        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest has an unsupported schema")
+        raise PlatformToolsError(
+            RESULT_MANIFEST_INVALID,
+            "managed-tools manifest is unreadable",
+        ) from exc
+    if (
+        not isinstance(manifest, dict)
+        or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION
+    ):
+        raise PlatformToolsError(
+            RESULT_MANIFEST_INVALID,
+            "managed-tools manifest has an unsupported schema",
+        )
     files = manifest.get("files")
     if not isinstance(files, list) or not files:
-        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest has no file ledger")
+        raise PlatformToolsError(
+            RESULT_MANIFEST_INVALID,
+            "managed-tools manifest has no file ledger",
+        )
     for entry in files:
         if not isinstance(entry, dict):
-            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest contains an invalid file entry")
+            raise PlatformToolsError(
+                RESULT_MANIFEST_INVALID,
+                "managed-tools manifest contains an invalid file entry",
+            )
         relative = entry.get("path")
         digest = entry.get("sha256")
         if (
@@ -345,12 +473,18 @@ def _load_manifest(path: Path) -> Dict[str, Any]:
             or ".." in PurePosixPath(relative).parts
             or not isinstance(digest, str)
             or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
         ):
-            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest contains an unsafe file entry")
+            raise PlatformToolsError(
+                RESULT_MANIFEST_INVALID,
+                "managed-tools manifest contains an unsafe file entry",
+            )
     return manifest
 
 
-def inspect_managed_platform_tools(root: Optional[Path | str] = None) -> Dict[str, Any]:
+def inspect_managed_platform_tools(
+    root: Optional[PathLike] = None,
+) -> Dict[str, Any]:
     managed_root = _managed_root(root)
     tree = _platform_tools_path(managed_root)
     manifest_path = _manifest_path(managed_root)
@@ -365,7 +499,12 @@ def inspect_managed_platform_tools(root: Optional[Path | str] = None) -> Dict[st
     }
     if not present:
         return result
-    if tree.is_symlink() or not tree.is_dir() or not manifest_path.is_file() or manifest_path.is_symlink():
+    if (
+        tree.is_symlink()
+        or not tree.is_dir()
+        or not manifest_path.is_file()
+        or manifest_path.is_symlink()
+    ):
         result["error"] = RESULT_MANIFEST_INVALID
         return result
     try:
@@ -374,13 +513,22 @@ def inspect_managed_platform_tools(root: Optional[Path | str] = None) -> Dict[st
             relative = PurePosixPath(entry["path"])
             target = managed_root.joinpath(*relative.parts)
             if target.is_symlink() or not target.is_file():
-                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools file is missing")
+                raise PlatformToolsError(
+                    RESULT_MANIFEST_INVALID,
+                    "managed-tools file is missing",
+                )
             digest = hashlib.sha256(target.read_bytes()).hexdigest()
             if digest != entry["sha256"]:
-                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools file checksum mismatch")
+                raise PlatformToolsError(
+                    RESULT_MANIFEST_INVALID,
+                    "managed-tools file checksum mismatch",
+                )
         adb = _adb_path(managed_root)
         if not os.access(adb, os.X_OK):
-            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed adb is not executable")
+            raise PlatformToolsError(
+                RESULT_MANIFEST_INVALID,
+                "managed adb is not executable",
+            )
     except (OSError, PlatformToolsError):
         result["error"] = RESULT_MANIFEST_INVALID
         return result
@@ -398,8 +546,8 @@ def inspect_managed_platform_tools(root: Optional[Path | str] = None) -> Dict[st
 def install_managed_platform_tools(
     *,
     license_accepted: Any,
-    root: Optional[Path | str] = None,
-    pin_path: Optional[Path | str] = None,
+    root: Optional[PathLike] = None,
+    pin_path: Optional[PathLike] = None,
     host_machine: Optional[str] = None,
     opener: Callable[..., Any] = urlopen,
     now: Optional[Callable[[], datetime]] = None,
@@ -410,39 +558,72 @@ def install_managed_platform_tools(
             operation,
             success=False,
             result_code=RESULT_LICENSE_REQUIRED,
-            message="Accept the Android SDK License Agreement to install Platform-Tools.",
+            message=(
+                "Accept the Android SDK License Agreement to install Platform-Tools."
+            ),
         )
     managed_root = _managed_root(root)
     try:
         try:
-            pin = load_platform_tools_pin(Path(pin_path) if pin_path is not None else None)
+            pin = load_platform_tools_pin(
+                Path(pin_path) if pin_path is not None else None
+            )
         except PinError as exc:
-            raise PlatformToolsError(RESULT_PIN_UNAVAILABLE, "the reviewed Platform-Tools pin is unavailable") from exc
-        _validate_runtime_pin(pin, host_machine if host_machine is not None else platform.machine())
+            raise PlatformToolsError(
+                RESULT_PIN_UNAVAILABLE,
+                "the reviewed Platform-Tools pin is unavailable",
+            ) from exc
+        _validate_runtime_pin(
+            pin,
+            host_machine if host_machine is not None else platform.machine(),
+        )
         with _install_lock(managed_root):
-            staging = Path(tempfile.mkdtemp(prefix=".platform-tools-staging-", dir=managed_root))
+            staging = Path(
+                tempfile.mkdtemp(
+                    prefix=".platform-tools-staging-",
+                    dir=managed_root,
+                )
+            )
             try:
                 staging.chmod(0o700)
                 archive = staging / "platform-tools.zip"
-                actual_sha256 = _download_archive(pin, archive, opener=opener)
+                actual_sha256 = _download_archive(
+                    pin,
+                    archive,
+                    opener=opener,
+                )
                 if actual_sha256 != pin["archive_sha256"]:
-                    raise PlatformToolsError(RESULT_CHECKSUM_MISMATCH, "downloaded Platform-Tools checksum did not match the reviewed pin")
+                    raise PlatformToolsError(
+                        RESULT_CHECKSUM_MISMATCH,
+                        (
+                            "downloaded Platform-Tools checksum did not match the "
+                            "reviewed pin"
+                        ),
+                    )
                 extraction = staging / "extract"
                 extraction.mkdir(mode=0o700)
                 files = _extract_archive(archive, extraction, pin)
                 archive.unlink(missing_ok=True)
-                timestamp = (now or (lambda: datetime.now(timezone.utc)))()
+                timestamp = (
+                    now or (lambda: datetime.now(timezone.utc))
+                )()
                 manifest = {
                     "schema_version": MANIFEST_SCHEMA_VERSION,
                     "version": pin["version"],
                     "source_url": pin["url"],
                     "archive_sha256": pin["archive_sha256"],
-                    "installed_at": timestamp.astimezone(timezone.utc).isoformat(),
+                    "installed_at": timestamp.astimezone(
+                        timezone.utc
+                    ).isoformat(),
                     "license_name": pin.get("license_name"),
                     "license_terms_url": pin.get("license_terms_url"),
                     "files": files,
                 }
-                _activate_install(managed_root, extraction / "platform-tools", manifest)
+                _activate_install(
+                    managed_root,
+                    extraction / "platform-tools",
+                    manifest,
+                )
             finally:
                 shutil.rmtree(staging, ignore_errors=True)
     except PlatformToolsError as exc:
@@ -457,16 +638,20 @@ def install_managed_platform_tools(
             operation,
             success=False,
             result_code=RESULT_INSTALL_FAILED,
-            message=f"managed Platform-Tools installation failed: {type(exc).__name__}",
+            message=(
+                "managed Platform-Tools installation failed: "
+                f"{type(exc).__name__}"
+            ),
         )
     inspected = inspect_managed_platform_tools(managed_root)
+    verified = bool(inspected.get("verified"))
     return _result(
         operation,
-        success=bool(inspected.get("verified")),
-        result_code=RESULT_OK if inspected.get("verified") else RESULT_INSTALL_FAILED,
+        success=verified,
+        result_code=RESULT_OK if verified else RESULT_INSTALL_FAILED,
         message=(
             f"Installed Android Platform-Tools {pin['version']}."
-            if inspected.get("verified")
+            if verified
             else "Platform-Tools were installed but verification failed."
         ),
         data={
@@ -479,7 +664,7 @@ def install_managed_platform_tools(
 
 def remove_managed_platform_tools(
     *,
-    root: Optional[Path | str] = None,
+    root: Optional[PathLike] = None,
 ) -> Dict[str, Any]:
     operation = "remove"
     managed_root = _managed_root(root)
@@ -487,7 +672,11 @@ def remove_managed_platform_tools(
         with _install_lock(managed_root):
             tree = _platform_tools_path(managed_root)
             manifest_path = _manifest_path(managed_root)
-            if not tree.exists() and not tree.is_symlink() and not manifest_path.exists():
+            if (
+                not tree.exists()
+                and not tree.is_symlink()
+                and not manifest_path.exists()
+            ):
                 return _result(
                     operation,
                     success=True,
@@ -495,12 +684,25 @@ def remove_managed_platform_tools(
                     message="Managed Platform-Tools are already absent.",
                     data={"removed": False},
                 )
-            if tree.is_symlink() or not manifest_path.is_file() or manifest_path.is_symlink():
-                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed Platform-Tools cannot be removed without a valid manifest")
+            if (
+                tree.is_symlink()
+                or not manifest_path.is_file()
+                or manifest_path.is_symlink()
+            ):
+                raise PlatformToolsError(
+                    RESULT_MANIFEST_INVALID,
+                    (
+                        "managed Platform-Tools cannot be removed without a valid "
+                        "manifest"
+                    ),
+                )
             _load_manifest(manifest_path)
             if tree.exists():
                 if not tree.is_dir():
-                    raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed Platform-Tools path is not a directory")
+                    raise PlatformToolsError(
+                        RESULT_MANIFEST_INVALID,
+                        "managed Platform-Tools path is not a directory",
+                    )
                 shutil.rmtree(tree)
             manifest_path.unlink(missing_ok=True)
     except PlatformToolsError as exc:
@@ -515,12 +717,18 @@ def remove_managed_platform_tools(
             operation,
             success=False,
             result_code=RESULT_REMOVE_FAILED,
-            message=f"managed Platform-Tools removal failed: {type(exc).__name__}",
+            message=(
+                "managed Platform-Tools removal failed: "
+                f"{type(exc).__name__}"
+            ),
         )
     return _result(
         operation,
         success=True,
         result_code=RESULT_OK,
         message="Removed VRhotspot-managed Android Platform-Tools.",
-        data={"removed": True, "adb_path": str(_adb_path(managed_root))},
+        data={
+            "removed": True,
+            "adb_path": str(_adb_path(managed_root)),
+        },
     )

--- a/backend/vr_hotspotd/devtools/platform_tools_manager.py
+++ b/backend/vr_hotspotd/devtools/platform_tools_manager.py
@@ -1,0 +1,526 @@
+"""Install, verify, and remove VRhotspot-managed Android Platform-Tools."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import errno
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import shutil
+import stat
+import tempfile
+from typing import Any, BinaryIO, Callable, Dict, Iterator, Mapping, Optional
+from urllib.request import Request, urlopen
+import uuid
+import zipfile
+
+from vr_hotspotd.devtools.platform_tools import (
+    DEVTOOLS_ROOT,
+    MANAGED_ADB_PATH,
+    PinError,
+    load_platform_tools_pin,
+    normalize_arch,
+    pin_is_blocked,
+)
+
+
+MANIFEST_FILENAME = "manifest.json"
+LOCK_FILENAME = ".platform-tools.lock"
+DOWNLOAD_TIMEOUT_S = 45.0
+DOWNLOAD_CHUNK_BYTES = 1024 * 1024
+MANIFEST_SCHEMA_VERSION = 1
+
+RESULT_OK = "ok"
+RESULT_LICENSE_REQUIRED = "license_not_accepted"
+RESULT_PIN_UNAVAILABLE = "pin_unavailable"
+RESULT_IMPLEMENTATION_BLOCKED = "implementation_blocked"
+RESULT_UNSUPPORTED_ARCH = "unsupported_arch"
+RESULT_INSTALL_BUSY = "tools_install_busy"
+RESULT_DOWNLOAD_FAILED = "download_failed"
+RESULT_ARCHIVE_TOO_LARGE = "archive_too_large"
+RESULT_CHECKSUM_MISMATCH = "checksum_mismatch"
+RESULT_ARCHIVE_INVALID = "archive_invalid"
+RESULT_INSTALL_FAILED = "install_failed"
+RESULT_REMOVE_FAILED = "remove_failed"
+RESULT_MANIFEST_INVALID = "manifest_invalid"
+
+
+class PlatformToolsError(RuntimeError):
+    """Expected managed-tools failure with a stable result code."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+def _result(
+    operation: str,
+    *,
+    success: bool,
+    result_code: str,
+    message: str,
+    data: Optional[Mapping[str, Any]] = None,
+    warnings: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "success": success,
+        "result_code": result_code,
+        "message": message,
+        "warnings": list(warnings or []),
+        "data": dict(data or {}),
+    }
+
+
+def _managed_root(root: Optional[Path | str]) -> Path:
+    candidate = Path(root if root is not None else DEVTOOLS_ROOT)
+    if not candidate.is_absolute():
+        raise PlatformToolsError(RESULT_INSTALL_FAILED, "managed tools root must be absolute")
+    return candidate
+
+
+def _manifest_path(root: Path) -> Path:
+    return root / MANIFEST_FILENAME
+
+
+def _platform_tools_path(root: Path) -> Path:
+    return root / "platform-tools"
+
+
+def _adb_path(root: Path) -> Path:
+    return _platform_tools_path(root) / "adb"
+
+
+def _ensure_root(root: Path) -> None:
+    try:
+        if root.exists() and root.is_symlink():
+            raise PlatformToolsError(RESULT_INSTALL_FAILED, "managed tools root must not be a symlink")
+        root.mkdir(parents=True, exist_ok=True, mode=0o755)
+        root.chmod(0o755)
+    except PlatformToolsError:
+        raise
+    except OSError as exc:
+        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot prepare managed tools root: {exc}") from exc
+
+
+@contextmanager
+def _install_lock(root: Path) -> Iterator[None]:
+    _ensure_root(root)
+    lock_path = root / LOCK_FILENAME
+    descriptor: Optional[int] = None
+    try:
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EAGAIN}:
+                raise PlatformToolsError(RESULT_INSTALL_BUSY, "another managed-tools operation is running") from exc
+            raise
+        yield
+    finally:
+        if descriptor is not None:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _validate_runtime_pin(pin: Mapping[str, Any], host_machine: Optional[str]) -> None:
+    if pin_is_blocked(pin):
+        raise PlatformToolsError(
+            RESULT_IMPLEMENTATION_BLOCKED,
+            "the reviewed Platform-Tools pin is not enabled for installation",
+        )
+    host_arch = normalize_arch(host_machine)
+    pin_arch = normalize_arch(pin.get("arch"))
+    if not host_arch or host_arch != pin_arch:
+        raise PlatformToolsError(
+            RESULT_UNSUPPORTED_ARCH,
+            f"managed Platform-Tools require {pin_arch or 'the pinned architecture'}",
+        )
+
+
+def _safe_allowlist(pin: Mapping[str, Any]) -> list[str]:
+    raw = pin.get("extract_allowlist")
+    if not isinstance(raw, list) or not raw:
+        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is unavailable")
+    entries: list[str] = []
+    for value in raw:
+        if not isinstance(value, str):
+            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is invalid")
+        normalized = PurePosixPath(value)
+        if normalized.is_absolute() or ".." in normalized.parts or str(normalized) != value:
+            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist contains an unsafe path")
+        if not value.startswith("platform-tools/"):
+            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist escaped platform-tools")
+        entries.append(value)
+    if "platform-tools/adb" not in entries or "platform-tools/NOTICE.txt" not in entries:
+        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the extraction allowlist is incomplete")
+    return entries
+
+
+def _download_archive(
+    pin: Mapping[str, Any],
+    destination: Path,
+    *,
+    opener: Callable[..., Any] = urlopen,
+) -> str:
+    maximum = pin.get("max_archive_bytes")
+    if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
+        raise PlatformToolsError(RESULT_PIN_UNAVAILABLE, "the archive size limit is invalid")
+    request = Request(
+        str(pin["url"]),
+        headers={"User-Agent": "VRhotspot-Developer-Hub/1.1"},
+        method="GET",
+    )
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with opener(request, timeout=DOWNLOAD_TIMEOUT_S) as response, destination.open("xb") as output:
+            content_length = response.headers.get("Content-Length") if hasattr(response, "headers") else None
+            if content_length:
+                try:
+                    announced = int(content_length)
+                except (TypeError, ValueError):
+                    announced = 0
+                if announced > maximum:
+                    raise PlatformToolsError(RESULT_ARCHIVE_TOO_LARGE, "the archive exceeds the configured size limit")
+            while True:
+                chunk = response.read(DOWNLOAD_CHUNK_BYTES)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > maximum:
+                    raise PlatformToolsError(RESULT_ARCHIVE_TOO_LARGE, "the archive exceeds the configured size limit")
+                digest.update(chunk)
+                output.write(chunk)
+    except PlatformToolsError:
+        raise
+    except Exception as exc:
+        raise PlatformToolsError(RESULT_DOWNLOAD_FAILED, f"Platform-Tools download failed: {type(exc).__name__}") from exc
+    if total <= 0:
+        raise PlatformToolsError(RESULT_DOWNLOAD_FAILED, "Platform-Tools download returned an empty archive")
+    return digest.hexdigest()
+
+
+def _zip_entry_is_regular(info: zipfile.ZipInfo) -> bool:
+    unix_mode = info.external_attr >> 16
+    if stat.S_ISLNK(unix_mode):
+        return False
+    return unix_mode == 0 or stat.S_ISREG(unix_mode)
+
+
+def _extract_archive(
+    archive: Path,
+    staging_root: Path,
+    pin: Mapping[str, Any],
+) -> list[Dict[str, Any]]:
+    allowlist = _safe_allowlist(pin)
+    installed_files: list[Dict[str, Any]] = []
+    try:
+        with zipfile.ZipFile(archive, "r") as bundle:
+            by_name = {entry.filename: entry for entry in bundle.infolist()}
+            missing = [entry for entry in allowlist if entry not in by_name]
+            if missing:
+                raise PlatformToolsError(RESULT_ARCHIVE_INVALID, "the archive is missing required Platform-Tools files")
+            for relative in allowlist:
+                info = by_name[relative]
+                if info.is_dir() or not _zip_entry_is_regular(info):
+                    raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"unsupported archive entry: {relative}")
+                if info.file_size < 0 or info.file_size > int(pin["max_archive_bytes"]):
+                    raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"archive entry exceeds the size limit: {relative}")
+                target = staging_root.joinpath(*PurePosixPath(relative).parts)
+                target.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+                digest = hashlib.sha256()
+                with bundle.open(info, "r") as source, target.open("xb") as output:
+                    copied = 0
+                    while True:
+                        chunk = source.read(DOWNLOAD_CHUNK_BYTES)
+                        if not chunk:
+                            break
+                        copied += len(chunk)
+                        if copied > info.file_size or copied > int(pin["max_archive_bytes"]):
+                            raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"archive entry expanded beyond its declared size: {relative}")
+                        digest.update(chunk)
+                        output.write(chunk)
+                mode = 0o755 if relative == "platform-tools/adb" else 0o644
+                target.chmod(mode)
+                installed_files.append(
+                    {
+                        "path": relative,
+                        "sha256": digest.hexdigest(),
+                        "mode": format(mode, "04o"),
+                        "size": target.stat().st_size,
+                    }
+                )
+    except PlatformToolsError:
+        raise
+    except (OSError, zipfile.BadZipFile, RuntimeError) as exc:
+        raise PlatformToolsError(RESULT_ARCHIVE_INVALID, f"cannot extract Platform-Tools archive: {type(exc).__name__}") from exc
+    return installed_files
+
+
+def _write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.tmp-{uuid.uuid4().hex}")
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            json.dump(dict(manifest), output, ensure_ascii=True, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        temporary.chmod(0o644)
+        os.replace(temporary, path)
+    except OSError as exc:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot write managed-tools manifest: {exc}") from exc
+
+
+def _activate_install(root: Path, staged_tree: Path, manifest: Mapping[str, Any]) -> None:
+    final_tree = _platform_tools_path(root)
+    backup = root / f".platform-tools-backup-{uuid.uuid4().hex}"
+    old_manifest = _manifest_path(root)
+    had_tree = final_tree.exists() or final_tree.is_symlink()
+    if had_tree and final_tree.is_symlink():
+        raise PlatformToolsError(RESULT_INSTALL_FAILED, "existing managed Platform-Tools path is a symlink")
+    moved_old = False
+    moved_new = False
+    try:
+        if had_tree:
+            os.replace(final_tree, backup)
+            moved_old = True
+        os.replace(staged_tree, final_tree)
+        moved_new = True
+        _write_manifest(old_manifest, manifest)
+    except Exception as exc:
+        if moved_new:
+            try:
+                shutil.rmtree(final_tree)
+            except OSError:
+                pass
+        if moved_old:
+            try:
+                os.replace(backup, final_tree)
+            except OSError:
+                pass
+        if isinstance(exc, PlatformToolsError):
+            raise
+        raise PlatformToolsError(RESULT_INSTALL_FAILED, f"cannot activate managed Platform-Tools: {type(exc).__name__}") from exc
+    finally:
+        if backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+
+
+def _load_manifest(path: Path) -> Dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest is unreadable") from exc
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest has an unsupported schema")
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest has no file ledger")
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest contains an invalid file entry")
+        relative = entry.get("path")
+        digest = entry.get("sha256")
+        if (
+            not isinstance(relative, str)
+            or not relative.startswith("platform-tools/")
+            or ".." in PurePosixPath(relative).parts
+            or not isinstance(digest, str)
+            or len(digest) != 64
+        ):
+            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools manifest contains an unsafe file entry")
+    return manifest
+
+
+def inspect_managed_platform_tools(root: Optional[Path | str] = None) -> Dict[str, Any]:
+    managed_root = _managed_root(root)
+    tree = _platform_tools_path(managed_root)
+    manifest_path = _manifest_path(managed_root)
+    present = tree.exists() or tree.is_symlink() or manifest_path.exists()
+    result: Dict[str, Any] = {
+        "present": present,
+        "installed": False,
+        "verified": False if present else None,
+        "version": None,
+        "manifest_path": str(manifest_path),
+        "error": None,
+    }
+    if not present:
+        return result
+    if tree.is_symlink() or not tree.is_dir() or not manifest_path.is_file() or manifest_path.is_symlink():
+        result["error"] = RESULT_MANIFEST_INVALID
+        return result
+    try:
+        manifest = _load_manifest(manifest_path)
+        for entry in manifest["files"]:
+            relative = PurePosixPath(entry["path"])
+            target = managed_root.joinpath(*relative.parts)
+            if target.is_symlink() or not target.is_file():
+                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools file is missing")
+            digest = hashlib.sha256(target.read_bytes()).hexdigest()
+            if digest != entry["sha256"]:
+                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed-tools file checksum mismatch")
+        adb = _adb_path(managed_root)
+        if not os.access(adb, os.X_OK):
+            raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed adb is not executable")
+    except (OSError, PlatformToolsError):
+        result["error"] = RESULT_MANIFEST_INVALID
+        return result
+    result.update(
+        {
+            "installed": True,
+            "verified": True,
+            "version": manifest.get("version"),
+            "error": None,
+        }
+    )
+    return result
+
+
+def install_managed_platform_tools(
+    *,
+    license_accepted: Any,
+    root: Optional[Path | str] = None,
+    pin_path: Optional[Path | str] = None,
+    host_machine: Optional[str] = None,
+    opener: Callable[..., Any] = urlopen,
+    now: Optional[Callable[[], datetime]] = None,
+) -> Dict[str, Any]:
+    operation = "install"
+    if license_accepted is not True:
+        return _result(
+            operation,
+            success=False,
+            result_code=RESULT_LICENSE_REQUIRED,
+            message="Accept the Android SDK License Agreement to install Platform-Tools.",
+        )
+    managed_root = _managed_root(root)
+    try:
+        try:
+            pin = load_platform_tools_pin(Path(pin_path) if pin_path is not None else None)
+        except PinError as exc:
+            raise PlatformToolsError(RESULT_PIN_UNAVAILABLE, "the reviewed Platform-Tools pin is unavailable") from exc
+        _validate_runtime_pin(pin, host_machine if host_machine is not None else platform.machine())
+        with _install_lock(managed_root):
+            staging = Path(tempfile.mkdtemp(prefix=".platform-tools-staging-", dir=managed_root))
+            try:
+                staging.chmod(0o700)
+                archive = staging / "platform-tools.zip"
+                actual_sha256 = _download_archive(pin, archive, opener=opener)
+                if actual_sha256 != pin["archive_sha256"]:
+                    raise PlatformToolsError(RESULT_CHECKSUM_MISMATCH, "downloaded Platform-Tools checksum did not match the reviewed pin")
+                extraction = staging / "extract"
+                extraction.mkdir(mode=0o700)
+                files = _extract_archive(archive, extraction, pin)
+                archive.unlink(missing_ok=True)
+                timestamp = (now or (lambda: datetime.now(timezone.utc)))()
+                manifest = {
+                    "schema_version": MANIFEST_SCHEMA_VERSION,
+                    "version": pin["version"],
+                    "source_url": pin["url"],
+                    "archive_sha256": pin["archive_sha256"],
+                    "installed_at": timestamp.astimezone(timezone.utc).isoformat(),
+                    "license_name": pin.get("license_name"),
+                    "license_terms_url": pin.get("license_terms_url"),
+                    "files": files,
+                }
+                _activate_install(managed_root, extraction / "platform-tools", manifest)
+            finally:
+                shutil.rmtree(staging, ignore_errors=True)
+    except PlatformToolsError as exc:
+        return _result(
+            operation,
+            success=False,
+            result_code=exc.code,
+            message=str(exc),
+        )
+    except Exception as exc:
+        return _result(
+            operation,
+            success=False,
+            result_code=RESULT_INSTALL_FAILED,
+            message=f"managed Platform-Tools installation failed: {type(exc).__name__}",
+        )
+    inspected = inspect_managed_platform_tools(managed_root)
+    return _result(
+        operation,
+        success=bool(inspected.get("verified")),
+        result_code=RESULT_OK if inspected.get("verified") else RESULT_INSTALL_FAILED,
+        message=(
+            f"Installed Android Platform-Tools {pin['version']}."
+            if inspected.get("verified")
+            else "Platform-Tools were installed but verification failed."
+        ),
+        data={
+            "version": pin["version"],
+            "adb_path": str(_adb_path(managed_root)),
+            "verified": inspected.get("verified"),
+        },
+    )
+
+
+def remove_managed_platform_tools(
+    *,
+    root: Optional[Path | str] = None,
+) -> Dict[str, Any]:
+    operation = "remove"
+    managed_root = _managed_root(root)
+    try:
+        with _install_lock(managed_root):
+            tree = _platform_tools_path(managed_root)
+            manifest_path = _manifest_path(managed_root)
+            if not tree.exists() and not tree.is_symlink() and not manifest_path.exists():
+                return _result(
+                    operation,
+                    success=True,
+                    result_code=RESULT_OK,
+                    message="Managed Platform-Tools are already absent.",
+                    data={"removed": False},
+                )
+            if tree.is_symlink() or not manifest_path.is_file() or manifest_path.is_symlink():
+                raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed Platform-Tools cannot be removed without a valid manifest")
+            _load_manifest(manifest_path)
+            if tree.exists():
+                if not tree.is_dir():
+                    raise PlatformToolsError(RESULT_MANIFEST_INVALID, "managed Platform-Tools path is not a directory")
+                shutil.rmtree(tree)
+            manifest_path.unlink(missing_ok=True)
+    except PlatformToolsError as exc:
+        return _result(
+            operation,
+            success=False,
+            result_code=exc.code,
+            message=str(exc),
+        )
+    except Exception as exc:
+        return _result(
+            operation,
+            success=False,
+            result_code=RESULT_REMOVE_FAILED,
+            message=f"managed Platform-Tools removal failed: {type(exc).__name__}",
+        )
+    return _result(
+        operation,
+        success=True,
+        result_code=RESULT_OK,
+        message="Removed VRhotspot-managed Android Platform-Tools.",
+        data={"removed": True, "adb_path": str(_adb_path(managed_root))},
+    )

--- a/tests/test_api_devhub_tools_management.py
+++ b/tests/test_api_devhub_tools_management.py
@@ -1,0 +1,164 @@
+import io
+import json
+from email.message import Message
+
+import vr_hotspotd.devtools.devhub_api as devhub_api
+from vr_hotspotd.devtools.devhub_api import DevHubAPIHandler
+
+
+def _make_handler(path: str, *, body=None):
+    raw = json.dumps(body or {}).encode("utf-8")
+    handler = DevHubAPIHandler.__new__(DevHubAPIHandler)
+    handler.rfile = io.BytesIO(raw)
+    handler.wfile = io.BytesIO()
+    handler.headers = Message()
+    handler.headers["Content-Length"] = str(len(raw))
+    handler.command = "POST"
+    handler.request_version = "HTTP/1.1"
+    handler.requestline = f"POST {path} HTTP/1.1"
+    handler.path = path
+    handler._last_code = None
+    handler.send_response = lambda code, _message=None: setattr(handler, "_last_code", code)
+    handler.send_header = lambda _key, _value: None
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _authorize(monkeypatch, handler):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    handler.headers["X-Api-Token"] = "secret"
+    return handler
+
+
+def _response_json(handler):
+    return json.loads(handler.wfile.getvalue().decode("utf-8"))
+
+
+def _result(operation, code="ok", success=True):
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "success": success,
+        "result_code": code,
+        "message": code,
+        "warnings": [],
+        "data": {},
+    }
+
+
+def test_tools_install_passes_explicit_license_acceptance(monkeypatch):
+    seen = {}
+
+    def install(*, license_accepted):
+        seen["license_accepted"] = license_accepted
+        return _result("install")
+
+    monkeypatch.setattr(devhub_api, "install_managed_platform_tools", install)
+    handler = _authorize(
+        monkeypatch,
+        _make_handler(
+            "/v1/devbridge/tools/install",
+            body={"license_accepted": True},
+        ),
+    )
+
+    handler.do_POST()
+    payload = _response_json(handler)
+
+    assert handler._last_code == 200
+    assert seen == {"license_accepted": True}
+    assert payload["result_code"] == "ok"
+    assert payload["data"]["operation"] == "install"
+
+
+def test_tools_install_maps_license_requirement_to_400(monkeypatch):
+    monkeypatch.setattr(
+        devhub_api,
+        "install_managed_platform_tools",
+        lambda *, license_accepted: _result(
+            "install",
+            "license_not_accepted",
+            False,
+        ),
+    )
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/tools/install", body={}),
+    )
+
+    handler.do_POST()
+
+    assert handler._last_code == 400
+    assert _response_json(handler)["result_code"] == "license_not_accepted"
+
+
+def test_tools_remove_calls_managed_removal(monkeypatch):
+    called = False
+
+    def remove():
+        nonlocal called
+        called = True
+        return _result("remove")
+
+    monkeypatch.setattr(devhub_api, "remove_managed_platform_tools", remove)
+    handler = _authorize(
+        monkeypatch,
+        _make_handler("/v1/devbridge/tools/remove", body={}),
+    )
+
+    handler.do_POST()
+
+    assert called is True
+    assert handler._last_code == 200
+    assert _response_json(handler)["data"]["operation"] == "remove"
+
+
+def test_tools_install_busy_maps_to_conflict(monkeypatch):
+    monkeypatch.setattr(
+        devhub_api,
+        "install_managed_platform_tools",
+        lambda *, license_accepted: _result(
+            "install",
+            "tools_install_busy",
+            False,
+        ),
+    )
+    handler = _authorize(
+        monkeypatch,
+        _make_handler(
+            "/v1/devbridge/tools/install",
+            body={"license_accepted": True},
+        ),
+    )
+
+    handler.do_POST()
+
+    assert handler._last_code == 409
+    assert _response_json(handler)["result_code"] == "tools_install_busy"
+
+
+def test_tools_management_routes_require_auth(monkeypatch):
+    monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
+    monkeypatch.setattr(
+        devhub_api,
+        "install_managed_platform_tools",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unauthorized request installed tools")
+        ),
+    )
+    monkeypatch.setattr(
+        devhub_api,
+        "remove_managed_platform_tools",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("unauthorized request removed tools")
+        ),
+    )
+
+    for path in (
+        "/v1/devbridge/tools/install",
+        "/v1/devbridge/tools/remove",
+    ):
+        handler = _make_handler(path, body={})
+        handler.do_POST()
+        assert handler._last_code == 401
+        assert _response_json(handler)["result_code"] == "unauthorized"

--- a/tests/test_devhub_adb_cli.py
+++ b/tests/test_devhub_adb_cli.py
@@ -82,7 +82,7 @@ def test_version_uses_authenticated_get(monkeypatch, tmp_path, capsys):
     assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/adb/version"
     assert seen["body"] is None
     assert seen["headers"]["x-api-token"] == secret
-    assert seen["headers"]["x-correlation-id"].startswith("cli-devhub-adb-version-")
+    assert seen["headers"]["x-correlation-id"].startswith("cli-devhub-version-")
     assert secret not in captured.out
 
 

--- a/tests/test_devhub_python39_syntax.py
+++ b/tests/test_devhub_python39_syntax.py
@@ -1,0 +1,20 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FILES = (
+    ROOT / "backend" / "vr_hotspotd" / "devtools" / "platform_tools.py",
+    ROOT / "backend" / "vr_hotspotd" / "devtools" / "platform_tools_manager.py",
+    ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py",
+    ROOT / "backend" / "vr_hotspotd" / "devtools" / "adb_cli.py",
+)
+
+
+@pytest.mark.parametrize("path", FILES, ids=lambda path: path.name)
+def test_developer_hub_modules_parse_as_python39(path):
+    source = path.read_text(encoding="utf-8")
+
+    ast.parse(source, filename=str(path), feature_version=(3, 9))

--- a/tests/test_devhub_tools_cli.py
+++ b/tests/test_devhub_tools_cli.py
@@ -1,0 +1,133 @@
+import json
+
+import pytest
+
+from vr_hotspotd import cli as base_cli
+from vr_hotspotd.devtools import adb_cli
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.status = 200
+        self._raw = json.dumps(
+            {
+                "correlation_id": "test-cid",
+                "result_code": "ok",
+                "warnings": [],
+                "data": data,
+            }
+        ).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+@pytest.fixture(autouse=True)
+def clear_cli_environment(monkeypatch):
+    for key in (*base_cli._ENV_KEYS, "VR_HOTSPOTD_ENV_FILE"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _missing_env_args(tmp_path):
+    return ["--env-file", str(tmp_path / "missing-env")]
+
+
+def _mocked_open(monkeypatch, response_data, seen):
+    def open_request(request, *, timeout):
+        seen["method"] = request.get_method()
+        seen["url"] = request.full_url
+        seen["headers"] = {key.lower(): value for key, value in request.header_items()}
+        seen["timeout"] = timeout
+        seen["body"] = (
+            None if request.data is None else json.loads(request.data.decode("utf-8"))
+        )
+        return _FakeResponse(response_data)
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", open_request)
+
+
+def _run(monkeypatch, tmp_path, response_data, argv):
+    seen = {}
+    _mocked_open(monkeypatch, response_data, seen)
+    result = adb_cli.main(
+        [
+            *argv,
+            "--api-url",
+            "http://127.0.0.1:9900",
+            *_missing_env_args(tmp_path),
+        ]
+    )
+    return result, seen
+
+
+def test_tools_status_uses_existing_status_endpoint(monkeypatch, tmp_path, capsys):
+    data = {"adb": {"source": "missing"}, "platform_tools_pin": {"version": "r37.0.0"}}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["tools", "status"])
+
+    assert result == 0
+    assert seen["method"] == "GET"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/tools/status"
+    assert seen["body"] is None
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_tools_install_posts_license_acceptance_and_uses_install_timeout(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    data = {"operation": "install", "success": True, "result_code": "ok"}
+
+    result, seen = _run(
+        monkeypatch,
+        tmp_path,
+        data,
+        ["tools", "install", "--accept-license"],
+    )
+
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/tools/install"
+    assert seen["body"] == {"license_accepted": True}
+    assert seen["timeout"] == 180.0
+    assert json.loads(capsys.readouterr().out) == data
+
+
+def test_tools_install_requires_license_before_request(monkeypatch, tmp_path, capsys):
+    def must_not_open(_request, *, timeout):
+        raise AssertionError(f"request must not run with timeout {timeout}")
+
+    monkeypatch.setattr(base_cli, "_open_preflight_request", must_not_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        adb_cli.main(
+            [
+                "tools",
+                "install",
+                *_missing_env_args(tmp_path),
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "requires --accept-license" in captured.err
+    assert captured.out == ""
+
+
+def test_tools_remove_posts_empty_body(monkeypatch, tmp_path, capsys):
+    data = {"operation": "remove", "success": True, "result_code": "ok"}
+
+    result, seen = _run(monkeypatch, tmp_path, data, ["tools", "remove"])
+
+    assert result == 0
+    assert seen["method"] == "POST"
+    assert seen["url"] == "http://127.0.0.1:9900/v1/devbridge/tools/remove"
+    assert seen["body"] == {}
+    assert json.loads(capsys.readouterr().out) == data

--- a/tests/test_devhub_tools_ui.py
+++ b/tests/test_devhub_tools_ui.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOADER = ROOT / "assets" / "field_visibility.js"
+
+
+def test_developer_hub_exposes_one_click_managed_tools_controls():
+    source = LOADER.read_text(encoding="utf-8")
+
+    assert "devhubInstallTools" in source
+    assert "devhubRemoveTools" in source
+    assert "devhubAcceptToolsLicense" in source
+    assert "/v1/devbridge/tools/install" in source
+    assert "/v1/devbridge/tools/remove" in source
+    assert "license_accepted: true" in source
+    assert "https://developer.android.com/studio/terms" in source
+
+
+def test_tools_install_requires_checked_license_control():
+    source = LOADER.read_text(encoding="utf-8")
+
+    assert "if (!accept.checked)" in source
+    assert "Review and accept the Android SDK License Agreement first." in source
+
+
+def test_field_visibility_and_tools_extension_parse_with_node():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is not available")
+
+    completed = subprocess.run(
+        [node, "--check", str(LOADER)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_platform_tools_manager.py
+++ b/tests/test_platform_tools_manager.py
@@ -9,8 +9,6 @@ from pathlib import Path
 import stat
 import zipfile
 
-import pytest
-
 from vr_hotspotd.devtools.platform_tools_manager import (
     inspect_managed_platform_tools,
     install_managed_platform_tools,

--- a/tests/test_platform_tools_manager.py
+++ b/tests/test_platform_tools_manager.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import zipfile
+
+import pytest
+
+from vr_hotspotd.devtools.platform_tools_manager import (
+    inspect_managed_platform_tools,
+    install_managed_platform_tools,
+    remove_managed_platform_tools,
+)
+
+
+class _Response:
+    def __init__(self, payload: bytes):
+        self._stream = io.BytesIO(payload)
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def read(self, size=-1):
+        return self._stream.read(size)
+
+
+def _archive(*, symlink_adb=False, include_notice=True) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        adb = zipfile.ZipInfo("platform-tools/adb")
+        adb.create_system = 3
+        adb.external_attr = ((stat.S_IFLNK if symlink_adb else stat.S_IFREG) | 0o755) << 16
+        bundle.writestr(adb, b"target" if symlink_adb else b"#!/bin/sh\necho adb\n")
+        if include_notice:
+            notice = zipfile.ZipInfo("platform-tools/NOTICE.txt")
+            notice.create_system = 3
+            notice.external_attr = (stat.S_IFREG | 0o644) << 16
+            bundle.writestr(notice, b"Android SDK Platform-Tools notice\n")
+        bundle.writestr("platform-tools/ignored-tool", b"not allowlisted")
+    return output.getvalue()
+
+
+def _pin(tmp_path: Path, archive: bytes, **overrides) -> Path:
+    pin = {
+        "schema_version": 1,
+        "version": "r37.0.0",
+        "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip",
+        "archive_sha256": hashlib.sha256(archive).hexdigest(),
+        "implementation_blocked": False,
+        "max_archive_bytes": 100000000,
+        "arch": "x86_64",
+        "extract_allowlist": [
+            "platform-tools/NOTICE.txt",
+            "platform-tools/adb",
+        ],
+        "license_name": "Android SDK License Agreement",
+        "license_terms_url": "https://developer.android.com/studio/terms",
+    }
+    pin.update(overrides)
+    path = tmp_path / "pin.json"
+    path.write_text(json.dumps(pin), encoding="utf-8")
+    return path
+
+
+def _opener(payload: bytes, seen: dict):
+    def open_request(request, *, timeout):
+        seen["url"] = request.full_url
+        seen["timeout"] = timeout
+        seen["user_agent"] = request.headers.get("User-agent")
+        return _Response(payload)
+
+    return open_request
+
+
+def test_install_downloads_verified_pin_and_records_manifest(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive)
+    root = tmp_path / "managed"
+    seen = {}
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=root,
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, seen),
+        now=lambda: datetime(2026, 8, 1, 20, 0, tzinfo=timezone.utc),
+    )
+
+    assert result["success"] is True
+    assert result["result_code"] == "ok"
+    assert result["data"] == {
+        "version": "r37.0.0",
+        "adb_path": str(root / "platform-tools" / "adb"),
+        "verified": True,
+    }
+    assert seen["url"].startswith("https://dl.google.com/")
+    assert seen["timeout"] == 45.0
+    assert seen["user_agent"] == "VRhotspot-Developer-Hub/1.1"
+
+    adb = root / "platform-tools" / "adb"
+    notice = root / "platform-tools" / "NOTICE.txt"
+    assert adb.is_file()
+    assert notice.is_file()
+    assert os.access(adb, os.X_OK)
+    assert stat.S_IMODE(adb.stat().st_mode) == 0o755
+    assert stat.S_IMODE(notice.stat().st_mode) == 0o644
+    assert not (root / "platform-tools" / "ignored-tool").exists()
+    assert not list(root.glob(".platform-tools-staging-*"))
+    assert not list(root.rglob("*.zip"))
+
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "r37.0.0"
+    assert manifest["archive_sha256"] == hashlib.sha256(archive).hexdigest()
+    assert manifest["installed_at"] == "2026-08-01T20:00:00+00:00"
+    assert {entry["path"] for entry in manifest["files"]} == {
+        "platform-tools/adb",
+        "platform-tools/NOTICE.txt",
+    }
+    assert inspect_managed_platform_tools(root)["verified"] is True
+
+
+def test_install_requires_explicit_license_acceptance(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive)
+    called = False
+
+    def must_not_open(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("download must not run")
+
+    result = install_managed_platform_tools(
+        license_accepted=False,
+        root=tmp_path / "managed",
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=must_not_open,
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == "license_not_accepted"
+    assert called is False
+
+
+def test_checksum_mismatch_leaves_no_install_or_archive(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive, archive_sha256="0" * 64)
+    root = tmp_path / "managed"
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=root,
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == "checksum_mismatch"
+    assert not (root / "platform-tools").exists()
+    assert not (root / "manifest.json").exists()
+    assert not list(root.glob(".platform-tools-staging-*"))
+    assert not list(root.rglob("*.zip"))
+
+
+def test_install_rejects_unsupported_arch_before_download(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive)
+    called = False
+
+    def must_not_open(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("download must not run")
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=tmp_path / "managed",
+        pin_path=pin,
+        host_machine="aarch64",
+        opener=must_not_open,
+    )
+
+    assert result["result_code"] == "unsupported_arch"
+    assert called is False
+
+
+def test_archive_missing_required_file_is_rejected(tmp_path):
+    archive = _archive(include_notice=False)
+    pin = _pin(tmp_path, archive)
+    root = tmp_path / "managed"
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=root,
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+
+    assert result["result_code"] == "archive_invalid"
+    assert not (root / "platform-tools").exists()
+
+
+def test_archive_symlink_entry_is_rejected(tmp_path):
+    archive = _archive(symlink_adb=True)
+    pin = _pin(tmp_path, archive)
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=tmp_path / "managed",
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+
+    assert result["result_code"] == "archive_invalid"
+
+
+def test_download_size_cap_is_enforced(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive, max_archive_bytes=len(archive) - 1)
+
+    result = install_managed_platform_tools(
+        license_accepted=True,
+        root=tmp_path / "managed",
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+
+    assert result["result_code"] == "archive_too_large"
+
+
+def test_remove_deletes_only_managed_tree_and_manifest(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive)
+    root = tmp_path / "managed"
+    unrelated = root / "keep-me.txt"
+
+    installed = install_managed_platform_tools(
+        license_accepted=True,
+        root=root,
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+    unrelated.write_text("unrelated", encoding="utf-8")
+
+    removed = remove_managed_platform_tools(root=root)
+
+    assert installed["success"] is True
+    assert removed["success"] is True
+    assert removed["data"]["removed"] is True
+    assert not (root / "platform-tools").exists()
+    assert not (root / "manifest.json").exists()
+    assert unrelated.read_text(encoding="utf-8") == "unrelated"
+
+
+def test_remove_refuses_unrecognized_tree_without_manifest(tmp_path):
+    root = tmp_path / "managed"
+    tree = root / "platform-tools"
+    tree.mkdir(parents=True)
+    (tree / "adb").write_bytes(b"unknown")
+
+    result = remove_managed_platform_tools(root=root)
+
+    assert result["success"] is False
+    assert result["result_code"] == "manifest_invalid"
+    assert (tree / "adb").exists()
+
+
+def test_manifest_tampering_disables_verification(tmp_path):
+    archive = _archive()
+    pin = _pin(tmp_path, archive)
+    root = tmp_path / "managed"
+    installed = install_managed_platform_tools(
+        license_accepted=True,
+        root=root,
+        pin_path=pin,
+        host_machine="x86_64",
+        opener=_opener(archive, {}),
+    )
+    (root / "platform-tools" / "adb").write_bytes(b"tampered")
+
+    inspected = inspect_managed_platform_tools(root)
+
+    assert installed["success"] is True
+    assert inspected["installed"] is False
+    assert inspected["verified"] is False
+    assert inspected["error"] == "manifest_invalid"


### PR DESCRIPTION
## Summary

Complete the Linux/SteamOS ADB setup path for Developer Hub by adding one-click installation, verification, status, and removal of Android Platform-Tools.

## User experience

Developer Hub can now:

- Show the effective ADB source, path, version, and managed verification state.
- Install the reviewed Android Platform-Tools r37.0.0 pin after explicit Android SDK license acceptance.
- Prefer the verified managed ADB installation without changing the immutable SteamOS base.
- Remove only the VRhotspot-managed tools while preserving unrelated host files and Android authorization keys.

## CLI

- `vr-hotspot-adb tools status`
- `vr-hotspot-adb tools install --accept-license`
- `vr-hotspot-adb tools remove`

## API

- Existing `GET /v1/devbridge/tools/status` gains managed version and verification state.
- `POST /v1/devbridge/tools/install` performs the complete pinned installation and returns the final result.
- `POST /v1/devbridge/tools/remove` removes the managed installation.

## Installer implementation

- Downloads only the exact reviewed HTTPS URL from `dl.google.com`.
- Enforces the pinned maximum archive size while streaming.
- Verifies the complete archive SHA-256 before extraction.
- Extracts only the reviewed `adb` and `NOTICE.txt` entries.
- Installs under `/var/lib/vr-hotspot/devtools/platform-tools` with no SteamOS base-image changes.
- Records a per-file checksum manifest and verifies it during discovery.
- Uses a host-local operation lock and atomic tree replacement.
- Cleans staging archives on success and every failure path.
- Refuses unsafe archive entries, symlinks, unrecognized installs, unsupported architectures, and manifest tampering.

## Web Portal / Flatpak shell

Adds **Install Managed ADB** and **Remove Managed ADB** controls to the Developer Hub tools card, with a direct Android SDK License Agreement link and explicit acceptance checkbox.

## Tests

Adds installer, archive, checksum, license, architecture, manifest, removal, API, CLI, and UI coverage. Also validates the new JavaScript with Node and preserves the Python 3.9 syntax floor.

## Validation

- CI passed on Python 3.11, 3.12, and 3.13.
- Full pytest passed: 1126 passed, 4 subtests passed.
- Python 3.9 grammar compatibility checks passed for the new Developer Hub modules.
- Developer Hub JavaScript passed `node --check`.
- Ruff passed.
- Shellcheck passed.
- Vendor manifest and deterministic SBOM validation passed.
- Platform-Tools pin validation passed.
- Installer detection matrix passed.