### PR TITLE
Fix Developer Hub APK picker injection

### DIFF
--- a/assets/devhub_upload.js
+++ b/assets/devhub_upload.js
@@ -98,9 +98,9 @@
     const help = document.createElement('div');
     help.className = 'devhub-host-path-help';
     help.textContent = 'Use this only when the APK already exists on the Linux machine running VRhotspot.';
-    advanced.append(summary, pathField, help);
 
     form.insertBefore(uploadField, pathField);
+    advanced.append(summary, pathField, help);
     form.insertBefore(advanced, checks);
     submit.textContent = 'Install on headset';
 

--- a/tests/test_devhub_apk_picker_ui.py
+++ b/tests/test_devhub_apk_picker_ui.py
@@ -43,6 +43,16 @@ def test_host_path_install_is_preserved_as_advanced_fallback():
     assert "pathInput.required = false" in source
 
 
+def test_picker_is_inserted_before_host_path_moves_into_advanced_section():
+    source = UPLOAD_JS.read_text(encoding="utf-8")
+
+    insert_picker = source.index("form.insertBefore(uploadField, pathField)")
+    move_host_path = source.index("advanced.append(summary, pathField, help)")
+    insert_advanced = source.index("form.insertBefore(advanced, checks)")
+
+    assert insert_picker < move_host_path < insert_advanced
+
+
 def test_developer_hub_desktop_layout_uses_available_space():
     source = DEVHUB_CSS.read_text(encoding="utf-8")
     upload_source = UPLOAD_CSS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Fix the post-merge Developer Hub APK picker initialization before live deployment.

## Root cause

The picker script moved the existing daemon-host path field into its Advanced disclosure, then attempted to insert the new picker relative to that field after it was no longer a child of the form. Browsers would throw a DOM `NotFoundError`, preventing the picker from appearing.

## Fix

- Insert the primary APK picker while the original path field is still attached to the form.
- Move the path field into the Advanced section afterward.
- Add a source-order regression test that preserves the required DOM mutation sequence.

## Validation

CI will run the full Python matrix, Node syntax checks, Ruff, Shellcheck, installer matrix, vendor manifest, SBOM, and Platform-Tools pin validation.