### PR TITLE
Make Developer Hub device-centered

### DIFF
--- a/assets/devhub_workspace.css
+++ b/assets/devhub_workspace.css
@@ -1,0 +1,254 @@
+.devhub-heading {
+  display: none !important;
+}
+
+.devhub-workspace {
+  display: grid;
+  gap: 14px;
+}
+
+.devhub-device-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(120deg, rgba(0, 243, 255, .08), transparent 42%),
+    var(--bg-card);
+}
+
+.devhub-device-identity {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  min-width: 0;
+}
+
+.devhub-device-state {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--text-muted);
+  box-shadow: 0 0 12px currentColor;
+}
+
+.devhub-device-state.online {
+  color: var(--success);
+  background: var(--success);
+}
+
+.devhub-device-state.offline,
+.devhub-device-state.unauthorized {
+  color: var(--danger);
+  background: var(--danger);
+}
+
+.devhub-device-copy {
+  min-width: 0;
+}
+
+.devhub-device-name {
+  color: var(--text-main);
+  font-size: 18px;
+  font-weight: 750;
+  line-height: 1.2;
+}
+
+.devhub-device-serial {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.devhub-device-badges {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.devhub-device-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 5px 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .035em;
+  text-transform: uppercase;
+}
+
+.devhub-device-badge.accent {
+  border-color: rgba(0, 243, 255, .38);
+  color: var(--accent-primary);
+}
+
+.devhub-workspace-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  overflow-x: auto;
+}
+
+.devhub-workspace-tab {
+  min-height: 36px;
+  padding: 8px 14px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.devhub-workspace-tab:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, .035);
+}
+
+.devhub-workspace-tab.active {
+  color: var(--accent-primary);
+  background: var(--accent-subtle);
+  box-shadow: inset 0 0 0 1px rgba(0, 243, 255, .24);
+}
+
+.devhub-workspace-panel[hidden] {
+  display: none !important;
+}
+
+.devhub-workspace-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.devhub-workspace-grid > .devhub-span,
+.devhub-workspace-grid > .devhub-full {
+  grid-column: 1 / -1;
+}
+
+.devhub-quick-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.devhub-quick-action {
+  display: grid;
+  gap: 5px;
+  min-height: 82px;
+  padding: 13px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-main);
+  cursor: pointer;
+  text-align: left;
+}
+
+.devhub-quick-action:hover {
+  border-color: rgba(0, 243, 255, .38);
+  box-shadow: 0 0 16px rgba(0, 243, 255, .08);
+}
+
+.devhub-quick-action strong {
+  color: var(--accent-primary);
+  font-size: 13px;
+}
+
+.devhub-quick-action span {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.devhub-activity {
+  display: none;
+  min-height: 38px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.devhub-activity.visible {
+  display: block;
+}
+
+.devhub-activity[data-state="loading"] {
+  border-color: rgba(0, 243, 255, .4);
+  color: var(--accent-primary);
+}
+
+.devhub-activity[data-state="success"] {
+  border-color: rgba(0, 255, 157, .35);
+  color: var(--success);
+}
+
+.devhub-activity[data-state="error"] {
+  border-color: rgba(255, 0, 85, .5);
+  color: var(--danger);
+}
+
+#devhubFeedback.devhub-feedback {
+  display: none !important;
+}
+
+.devhub-workspace-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.devhub-section-note {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (max-width: 1100px) {
+  .devhub-quick-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 920px) {
+  .devhub-device-bar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .devhub-device-badges {
+    justify-content: flex-start;
+  }
+
+  .devhub-workspace-grid,
+  .devhub-quick-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .devhub-workspace-grid > .devhub-span,
+  .devhub-workspace-grid > .devhub-full {
+    grid-column: auto;
+  }
+}

--- a/assets/devhub_workspace.css
+++ b/assets/devhub_workspace.css
@@ -14,7 +14,7 @@
   gap: 18px;
   padding: 16px 18px;
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background:
     linear-gradient(120deg, rgba(0, 243, 255, .08), transparent 42%),
     var(--bg-card);
@@ -99,7 +99,7 @@
   gap: 6px;
   padding: 4px;
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background: var(--bg-card);
   overflow-x: auto;
 }

--- a/assets/devhub_workspace.css
+++ b/assets/devhub_workspace.css
@@ -1,3 +1,7 @@
+.devhub-page {
+  max-width: none;
+}
+
 .devhub-heading {
   display: none !important;
 }

--- a/assets/devhub_workspace.js
+++ b/assets/devhub_workspace.js
@@ -6,8 +6,6 @@
   const VIEW_NAMES = ['device', 'apps', 'connection', 'tools'];
   let refreshTimer = null;
   let activityTimer = null;
-  let observer = null;
-  let currentView = 'device';
   let syncQueued = false;
 
   function el(id) {
@@ -42,7 +40,9 @@
     const state = (meta.split('·')[0] || '').trim().toLowerCase();
     const modelMatch = meta.match(/(?:^|·)\s*model\s+([^·]+)/i);
     const model = normalizedModel(modelMatch ? modelMatch[1] : '');
-    const transport = serial && serial.includes(':') ? 'Wireless ADB' : (serial ? 'USB ADB' : 'No transport');
+    const transport = serial && serial.includes(':')
+      ? 'Wireless ADB'
+      : (serial ? 'USB ADB' : 'No transport');
     const connected = state === 'device';
     return {
       serial: serial && serial !== 'No device selected' ? serial : '',
@@ -50,13 +50,14 @@
       state: state || (serial ? 'unknown' : 'offline'),
       transport,
       connected,
-      meta,
     };
   }
 
   function setText(id, value) {
     const node = el(id);
-    if (node) node.textContent = String(value || '');
+    if (!node) return;
+    const rendered = String(value || '');
+    if (node.textContent !== rendered) node.textContent = rendered;
   }
 
   function updateDeviceBar() {
@@ -70,9 +71,15 @@
     }
 
     setText('devhubWorkspaceDeviceName', device.model);
-    setText('devhubWorkspaceDeviceSerial', device.serial || 'Connect or select a headset to begin');
+    setText(
+      'devhubWorkspaceDeviceSerial',
+      device.serial || 'Connect or select a headset to begin',
+    );
     setText('devhubWorkspaceTransport', device.transport);
-    setText('devhubWorkspaceState', device.connected ? 'Connected' : (device.state || 'Offline'));
+    setText(
+      'devhubWorkspaceState',
+      device.connected ? 'Connected' : (device.state || 'Offline'),
+    );
 
     const source = String((el('devhubToolSource') || {}).textContent || '').trim();
     const runtime = source && source !== '--' ? `${source} ADB` : 'ADB unavailable';
@@ -95,7 +102,7 @@
 
     const message = source.textContent.trim();
     const state = source.dataset.state || 'idle';
-    activity.textContent = message;
+    if (activity.textContent !== message) activity.textContent = message;
     activity.dataset.state = state;
 
     if (shouldSuppressActivity(message)) {
@@ -106,7 +113,10 @@
     activity.classList.add('visible');
     if (activityTimer) window.clearTimeout(activityTimer);
     if (state === 'success') {
-      activityTimer = window.setTimeout(() => activity.classList.remove('visible'), 4500);
+      activityTimer = window.setTimeout(
+        () => activity.classList.remove('visible'),
+        4500,
+      );
     }
   }
 
@@ -140,7 +150,6 @@
 
   function setView(name, options = {}) {
     const next = VIEW_NAMES.includes(name) ? name : 'device';
-    currentView = next;
     saveView(next);
 
     document.querySelectorAll('.devhub-workspace-tab').forEach((button) => {
@@ -201,10 +210,26 @@
     const actions = document.createElement('div');
     actions.className = 'devhub-quick-actions';
     actions.append(
-      quickAction('Install APK', 'Choose a local build and send it directly to the selected headset.', () => setView('apps', { focusPicker: true })),
-      quickAction('Manage Apps', 'Inspect installed packages, launch builds, stop them, or uninstall them.', () => setView('apps')),
-      quickAction('Connection', 'Manage wireless ADB, pairing, discovery, and connected devices.', () => setView('connection')),
-      quickAction('Developer Tools', 'Inspect the ADB runtime and managed Android Platform-Tools.', () => setView('tools')),
+      quickAction(
+        'Install APK',
+        'Choose a local build and send it directly to the selected headset.',
+        () => setView('apps', { focusPicker: true }),
+      ),
+      quickAction(
+        'Manage Apps',
+        'Inspect installed packages, launch builds, stop them, or uninstall them.',
+        () => setView('apps'),
+      ),
+      quickAction(
+        'Connection',
+        'Manage wireless ADB, pairing, discovery, and connected devices.',
+        () => setView('connection'),
+      ),
+      quickAction(
+        'Developer Tools',
+        'Inspect the ADB runtime and managed Android Platform-Tools.',
+        () => setView('tools'),
+      ),
     );
     body.appendChild(actions);
     section.append(header, body);
@@ -220,6 +245,36 @@
     grid.className = 'devhub-workspace-grid';
     node.appendChild(grid);
     return { node, grid };
+  }
+
+  function scheduleSourceSync() {
+    if (syncQueued) return;
+    syncQueued = true;
+    window.requestAnimationFrame(() => {
+      syncQueued = false;
+      updateDeviceBar();
+      syncActivity();
+    });
+  }
+
+  function observeSources(feedback) {
+    const observer = new MutationObserver(scheduleSourceSync);
+    const sources = [
+      el('devhubSelectedDevice'),
+      el('devhubDeviceList'),
+      el('devhubToolSource'),
+      feedback,
+    ].filter(Boolean);
+
+    for (const source of sources) {
+      observer.observe(source, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['class', 'data-state'],
+      });
+    }
   }
 
   function inject() {
@@ -331,27 +386,10 @@
       refreshButton.tabIndex = -1;
     }
 
-    currentView = readView();
-    setView(currentView);
+    setView(readView());
     updateDeviceBar();
     syncActivity();
-
-    observer = new MutationObserver(() => {
-      if (syncQueued) return;
-      syncQueued = true;
-      window.requestAnimationFrame(() => {
-        syncQueued = false;
-        updateDeviceBar();
-        syncActivity();
-      });
-    });
-    observer.observe(page, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-      attributes: true,
-      attributeFilter: ['class', 'data-state'],
-    });
+    observeSources(feedback);
 
     if (refreshTimer) window.clearInterval(refreshTimer);
     refreshTimer = window.setInterval(requestRefresh, AUTO_REFRESH_MS);

--- a/assets/devhub_workspace.js
+++ b/assets/devhub_workspace.js
@@ -1,0 +1,379 @@
+(function addDeveloperHubWorkspace() {
+  'use strict';
+
+  const AUTO_REFRESH_MS = 5000;
+  const VIEW_KEY = 'vrhs_devhub_workspace_view';
+  const VIEW_NAMES = ['device', 'apps', 'connection', 'tools'];
+  let refreshTimer = null;
+  let activityTimer = null;
+  let observer = null;
+  let currentView = 'device';
+  let syncQueued = false;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function hubIsActive() {
+    const pane = el('tab-devhub');
+    return !!(pane && pane.classList.contains('active') && !document.hidden);
+  }
+
+  function cardByTitle(grid, title) {
+    return Array.from(grid.children).find((node) => {
+      const heading = node.querySelector('.card-header h2');
+      return heading && heading.textContent.trim() === title;
+    }) || null;
+  }
+
+  function normalizedModel(value) {
+    return String(value || '')
+      .replace(/_/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function selectedDeviceSnapshot() {
+    const serial = String((el('devhubSelectedDevice') || {}).textContent || '').trim();
+    const selectedRow = document.querySelector('#devhubDeviceList .devhub-list-item.selected');
+    const meta = selectedRow
+      ? String((selectedRow.querySelector('.devhub-list-meta') || {}).textContent || '').trim()
+      : '';
+    const state = (meta.split('·')[0] || '').trim().toLowerCase();
+    const modelMatch = meta.match(/(?:^|·)\s*model\s+([^·]+)/i);
+    const model = normalizedModel(modelMatch ? modelMatch[1] : '');
+    const transport = serial && serial.includes(':') ? 'Wireless ADB' : (serial ? 'USB ADB' : 'No transport');
+    const connected = state === 'device';
+    return {
+      serial: serial && serial !== 'No device selected' ? serial : '',
+      model: model || (serial ? 'Android XR headset' : 'No headset selected'),
+      state: state || (serial ? 'unknown' : 'offline'),
+      transport,
+      connected,
+      meta,
+    };
+  }
+
+  function setText(id, value) {
+    const node = el(id);
+    if (node) node.textContent = String(value || '');
+  }
+
+  function updateDeviceBar() {
+    const device = selectedDeviceSnapshot();
+    const stateDot = el('devhubWorkspaceDeviceState');
+    if (stateDot) {
+      stateDot.classList.remove('online', 'offline', 'unauthorized');
+      if (device.connected) stateDot.classList.add('online');
+      else if (device.state === 'unauthorized') stateDot.classList.add('unauthorized');
+      else stateDot.classList.add('offline');
+    }
+
+    setText('devhubWorkspaceDeviceName', device.model);
+    setText('devhubWorkspaceDeviceSerial', device.serial || 'Connect or select a headset to begin');
+    setText('devhubWorkspaceTransport', device.transport);
+    setText('devhubWorkspaceState', device.connected ? 'Connected' : (device.state || 'Offline'));
+
+    const source = String((el('devhubToolSource') || {}).textContent || '').trim();
+    const runtime = source && source !== '--' ? `${source} ADB` : 'ADB unavailable';
+    setText('devhubWorkspaceRuntime', runtime);
+    setText('devhubWorkspaceUpdated', `Updated ${new Date().toLocaleTimeString()}`);
+  }
+
+  function shouldSuppressActivity(message) {
+    const value = String(message || '').trim();
+    return !value
+      || value.startsWith('Ready.')
+      || value.startsWith('Refreshing Developer Hub state')
+      || value.startsWith('Open the Hub or refresh');
+  }
+
+  function syncActivity() {
+    const source = el('devhubFeedback');
+    const activity = el('devhubWorkspaceActivity');
+    if (!source || !activity) return;
+
+    const message = source.textContent.trim();
+    const state = source.dataset.state || 'idle';
+    activity.textContent = message;
+    activity.dataset.state = state;
+
+    if (shouldSuppressActivity(message)) {
+      activity.classList.remove('visible');
+      return;
+    }
+
+    activity.classList.add('visible');
+    if (activityTimer) window.clearTimeout(activityTimer);
+    if (state === 'success') {
+      activityTimer = window.setTimeout(() => activity.classList.remove('visible'), 4500);
+    }
+  }
+
+  function requestRefresh() {
+    if (!hubIsActive()) return;
+    const refresh = el('devhubRefresh');
+    if (refresh && !refresh.disabled) refresh.click();
+  }
+
+  function loadPackagesWhenUseful() {
+    const serial = selectedDeviceSnapshot().serial;
+    const list = el('devhubPackageList');
+    const load = el('devhubLoadPackages');
+    if (!serial || !list || !load || load.disabled) return;
+    if (list.querySelector('.devhub-list-item')) return;
+    load.click();
+  }
+
+  function saveView(name) {
+    try { sessionStorage.setItem(VIEW_KEY, name); } catch { }
+  }
+
+  function readView() {
+    try {
+      const value = sessionStorage.getItem(VIEW_KEY);
+      return VIEW_NAMES.includes(value) ? value : 'device';
+    } catch {
+      return 'device';
+    }
+  }
+
+  function setView(name, options = {}) {
+    const next = VIEW_NAMES.includes(name) ? name : 'device';
+    currentView = next;
+    saveView(next);
+
+    document.querySelectorAll('.devhub-workspace-tab').forEach((button) => {
+      const active = button.dataset.view === next;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-selected', active ? 'true' : 'false');
+      button.tabIndex = active ? 0 : -1;
+    });
+
+    document.querySelectorAll('.devhub-workspace-panel').forEach((panel) => {
+      panel.hidden = panel.dataset.view !== next;
+    });
+
+    if (next === 'apps') loadPackagesWhenUseful();
+    if (options.focusPicker) {
+      window.setTimeout(() => {
+        const choose = document.querySelector('#devhubApkPicker .btn');
+        if (choose) choose.focus();
+      }, 0);
+    }
+  }
+
+  function workspaceTab(name, label) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'devhub-workspace-tab';
+    button.dataset.view = name;
+    button.setAttribute('role', 'tab');
+    button.textContent = label;
+    button.addEventListener('click', () => setView(name));
+    return button;
+  }
+
+  function quickAction(title, detail, action) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'devhub-quick-action';
+    const heading = document.createElement('strong');
+    heading.textContent = title;
+    const copy = document.createElement('span');
+    copy.textContent = detail;
+    button.append(heading, copy);
+    button.addEventListener('click', action);
+    return button;
+  }
+
+  function buildOverviewCard() {
+    const section = document.createElement('section');
+    section.className = 'card';
+    const header = document.createElement('div');
+    header.className = 'card-header';
+    const title = document.createElement('h2');
+    title.textContent = 'Quick Actions';
+    header.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    const actions = document.createElement('div');
+    actions.className = 'devhub-quick-actions';
+    actions.append(
+      quickAction('Install APK', 'Choose a local build and send it directly to the selected headset.', () => setView('apps', { focusPicker: true })),
+      quickAction('Manage Apps', 'Inspect installed packages, launch builds, stop them, or uninstall them.', () => setView('apps')),
+      quickAction('Connection', 'Manage wireless ADB, pairing, discovery, and connected devices.', () => setView('connection')),
+      quickAction('Developer Tools', 'Inspect the ADB runtime and managed Android Platform-Tools.', () => setView('tools')),
+    );
+    body.appendChild(actions);
+    section.append(header, body);
+    return section;
+  }
+
+  function panel(name) {
+    const node = document.createElement('div');
+    node.className = 'devhub-workspace-panel';
+    node.dataset.view = name;
+    node.setAttribute('role', 'tabpanel');
+    const grid = document.createElement('div');
+    grid.className = 'devhub-workspace-grid';
+    node.appendChild(grid);
+    return { node, grid };
+  }
+
+  function inject() {
+    if (el('devhubWorkspace')) return true;
+
+    const page = document.querySelector('#tab-devhub .devhub-page');
+    const originalGrid = page && page.querySelector('.devhub-grid');
+    const feedback = el('devhubFeedback');
+    if (!page || !originalGrid || !feedback) return false;
+
+    const cards = {
+      tools: cardByTitle(originalGrid, 'Development Tools'),
+      discovery: cardByTitle(originalGrid, 'Network Discovery'),
+      devices: cardByTitle(originalGrid, 'ADB Devices'),
+      pairing: cardByTitle(originalGrid, 'Wireless Pairing'),
+      connect: cardByTitle(originalGrid, 'Connect Headset'),
+      apk: cardByTitle(originalGrid, 'APK Deployment'),
+      installed: cardByTitle(originalGrid, 'Installed Applications'),
+      control: cardByTitle(originalGrid, 'Application Control'),
+    };
+    if (Object.values(cards).some((card) => !card)) return false;
+
+    const workspace = document.createElement('div');
+    workspace.id = 'devhubWorkspace';
+    workspace.className = 'devhub-workspace';
+
+    const deviceBar = document.createElement('div');
+    deviceBar.className = 'devhub-device-bar';
+    const identity = document.createElement('div');
+    identity.className = 'devhub-device-identity';
+    const state = document.createElement('span');
+    state.id = 'devhubWorkspaceDeviceState';
+    state.className = 'devhub-device-state offline';
+    const copy = document.createElement('div');
+    copy.className = 'devhub-device-copy';
+    const name = document.createElement('div');
+    name.id = 'devhubWorkspaceDeviceName';
+    name.className = 'devhub-device-name';
+    name.textContent = 'No headset selected';
+    const serial = document.createElement('div');
+    serial.id = 'devhubWorkspaceDeviceSerial';
+    serial.className = 'devhub-device-serial';
+    serial.textContent = 'Connect or select a headset to begin';
+    copy.append(name, serial);
+    identity.append(state, copy);
+
+    const badges = document.createElement('div');
+    badges.className = 'devhub-device-badges';
+    badges.innerHTML = `
+      <span id="devhubWorkspaceState" class="devhub-device-badge accent">Offline</span>
+      <span id="devhubWorkspaceTransport" class="devhub-device-badge">No transport</span>
+      <span id="devhubWorkspaceRuntime" class="devhub-device-badge">ADB unavailable</span>`;
+    deviceBar.append(identity, badges);
+
+    const tabs = document.createElement('div');
+    tabs.className = 'devhub-workspace-tabs';
+    tabs.setAttribute('role', 'tablist');
+    tabs.append(
+      workspaceTab('device', 'Device'),
+      workspaceTab('apps', 'Apps'),
+      workspaceTab('connection', 'Connection'),
+      workspaceTab('tools', 'Tools'),
+    );
+
+    const activity = document.createElement('div');
+    activity.id = 'devhubWorkspaceActivity';
+    activity.className = 'devhub-activity';
+    activity.setAttribute('role', 'status');
+    activity.setAttribute('aria-live', 'polite');
+
+    const panels = {
+      device: panel('device'),
+      apps: panel('apps'),
+      connection: panel('connection'),
+      tools: panel('tools'),
+    };
+
+    panels.device.grid.append(buildOverviewCard(), cards.devices);
+    panels.apps.grid.append(cards.apk, cards.installed, cards.control);
+    panels.connection.grid.append(cards.discovery, cards.pairing, cards.connect);
+    panels.tools.grid.append(cards.tools);
+
+    const meta = document.createElement('div');
+    meta.className = 'devhub-workspace-meta';
+    const refreshNote = document.createElement('span');
+    refreshNote.textContent = 'Device state refreshes automatically while this tab is open.';
+    const updated = document.createElement('span');
+    updated.id = 'devhubWorkspaceUpdated';
+    updated.textContent = 'Waiting for device state';
+    meta.append(refreshNote, updated);
+
+    workspace.append(
+      deviceBar,
+      tabs,
+      activity,
+      panels.device.node,
+      panels.apps.node,
+      panels.connection.node,
+      panels.tools.node,
+      meta,
+    );
+
+    page.insertBefore(workspace, feedback);
+    originalGrid.remove();
+    const refreshButton = el('devhubRefresh');
+    if (refreshButton) {
+      refreshButton.hidden = true;
+      refreshButton.setAttribute('aria-hidden', 'true');
+      refreshButton.tabIndex = -1;
+    }
+
+    currentView = readView();
+    setView(currentView);
+    updateDeviceBar();
+    syncActivity();
+
+    observer = new MutationObserver(() => {
+      if (syncQueued) return;
+      syncQueued = true;
+      window.requestAnimationFrame(() => {
+        syncQueued = false;
+        updateDeviceBar();
+        syncActivity();
+      });
+    });
+    observer.observe(page, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['class', 'data-state'],
+    });
+
+    if (refreshTimer) window.clearInterval(refreshTimer);
+    refreshTimer = window.setInterval(requestRefresh, AUTO_REFRESH_MS);
+    window.addEventListener('focus', requestRefresh);
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) requestRefresh();
+    });
+
+    return true;
+  }
+
+  function start() {
+    if (inject()) return;
+    const startupObserver = new MutationObserver(() => {
+      if (inject()) startupObserver.disconnect();
+    });
+    startupObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -61,6 +61,11 @@ window.UI_FIELD_VISIBILITY = {
   uploadStylesheet.href = '/assets/devhub_upload.css';
   document.head.appendChild(uploadStylesheet);
 
+  const workspaceStylesheet = document.createElement('link');
+  workspaceStylesheet.rel = 'stylesheet';
+  workspaceStylesheet.href = '/assets/devhub_workspace.css';
+  document.head.appendChild(workspaceStylesheet);
+
   const script = document.createElement('script');
   script.src = '/assets/devhub.js';
   script.async = false;
@@ -70,6 +75,11 @@ window.UI_FIELD_VISIBILITY = {
   uploadScript.src = '/assets/devhub_upload.js';
   uploadScript.async = false;
   document.head.appendChild(uploadScript);
+
+  const workspaceScript = document.createElement('script');
+  workspaceScript.src = '/assets/devhub_workspace.js';
+  workspaceScript.async = false;
+  document.head.appendChild(workspaceScript);
 })();
 
 (function addManagedPlatformToolsControls() {

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -42,6 +42,8 @@ _DEVHUB_ASSET_TYPES = {
     "/assets/devhub.js": "application/javascript; charset=utf-8",
     "/assets/devhub_upload.css": "text/css; charset=utf-8",
     "/assets/devhub_upload.js": "application/javascript; charset=utf-8",
+    "/assets/devhub_workspace.css": "text/css; charset=utf-8",
+    "/assets/devhub_workspace.js": "application/javascript; charset=utf-8",
 }
 
 _GET_OPERATIONS = {

--- a/tests/test_devhub_workspace_ui.py
+++ b/tests/test_devhub_workspace_ui.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOADER = ROOT / "assets" / "field_visibility.js"
+WORKSPACE_JS = ROOT / "assets" / "devhub_workspace.js"
+WORKSPACE_CSS = ROOT / "assets" / "devhub_workspace.css"
+DEVHUB_API = ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py"
+
+
+def test_workspace_assets_are_loaded_after_core_developer_hub_assets():
+    source = LOADER.read_text(encoding="utf-8")
+
+    assert "'/assets/devhub_workspace.css'" in source
+    assert "'/assets/devhub_workspace.js'" in source
+    assert source.index("'/assets/devhub_upload.js'") < source.index(
+        "'/assets/devhub_workspace.js'"
+    )
+
+
+def test_workspace_assets_are_served_by_developer_hub_handler():
+    source = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert '"/assets/devhub_workspace.css": "text/css; charset=utf-8"' in source
+    assert (
+        '"/assets/devhub_workspace.js": "application/javascript; charset=utf-8"'
+        in source
+    )
+
+
+def test_workspace_is_device_first_and_removes_manual_refresh_ui():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    assert "devhub-device-bar" in source
+    assert "No headset selected" in source
+    assert "Device state refreshes automatically while this tab is open." in source
+    assert "refreshButton.hidden = true" in source
+    assert "window.setInterval(requestRefresh, AUTO_REFRESH_MS)" in source
+    assert "document.addEventListener('visibilitychange'" in source
+    assert "window.addEventListener('focus', requestRefresh)" in source
+
+
+def test_workspace_groups_existing_features_into_clear_views():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    for view in ("device", "apps", "connection", "tools"):
+        assert f"workspaceTab('{view}'" in source
+        assert f"panel('{view}')" in source
+
+    assert "Install APK" in source
+    assert "Manage Apps" in source
+    assert "Connection" in source
+    assert "Developer Tools" in source
+    assert "cards.apk" in source
+    assert "cards.installed" in source
+    assert "cards.control" in source
+
+
+def test_workspace_suppresses_polling_noise_but_preserves_operation_feedback():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    assert "value.startsWith('Ready.')" in source
+    assert "value.startsWith('Refreshing Developer Hub state')" in source
+    assert "activity.classList.add('visible')" in source
+    assert "state === 'success'" in source
+
+
+def test_workspace_styles_are_responsive_and_use_device_status_chips():
+    source = WORKSPACE_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-device-bar" in source
+    assert ".devhub-workspace-tabs" in source
+    assert ".devhub-device-state.online" in source
+    assert ".devhub-workspace-panel[hidden]" in source
+    assert "@media (max-width: 920px)" in source
+
+
+@pytest.mark.parametrize("asset", [LOADER, WORKSPACE_JS])
+def test_workspace_javascript_parses_with_node(asset):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is not available")
+
+    completed = subprocess.run(
+        [node, "--check", str(asset)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_devhub_workspace_ui.py
+++ b/tests/test_devhub_workspace_ui.py
@@ -69,9 +69,21 @@ def test_workspace_suppresses_polling_noise_but_preserves_operation_feedback():
     assert "state === 'success'" in source
 
 
+def test_workspace_observes_source_fields_without_observing_its_own_summary():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    assert "observeSources(feedback)" in source
+    assert "el('devhubSelectedDevice')" in source
+    assert "el('devhubDeviceList')" in source
+    assert "el('devhubToolSource')" in source
+    assert "observer.observe(page" not in source
+
+
 def test_workspace_styles_are_responsive_and_use_device_status_chips():
     source = WORKSPACE_CSS.read_text(encoding="utf-8")
 
+    assert ".devhub-page" in source
+    assert "max-width: none" in source
     assert ".devhub-device-bar" in source
     assert ".devhub-workspace-tabs" in source
     assert ".devhub-device-state.online" in source


### PR DESCRIPTION
## Summary

Replace the current long-form Developer Hub control page with a device-centered workspace that makes the selected headset the primary context.

## What changes

- Removes the visible **Refresh Hub** button.
- Refreshes device state every five seconds while the Developer Hub tab is visible, and again when the browser regains focus.
- Suppresses routine `Ready` / polling messages instead of displaying a full-width green status bar.
- Preserves operation progress, success, and failure feedback in a compact activity message.
- Adds a selected-headset bar showing model, serial, connection state, USB/wireless transport, and ADB runtime.
- Organizes the existing interface into **Device**, **Apps**, **Connection**, and **Tools** views.
- Adds quick actions for APK deployment, application management, connection management, and Android developer tools.
- Keeps all existing typed ADB and managed-tools operations; this is a workspace reorganization, not a capability removal.
- Remembers the selected workspace view for the current browser session.

## Feature direction

Issue #118 records the concrete follow-up roadmap for richer device facts, Quest wireless bootstrap, logs, capture/casting, performance analysis, and scoped file transfer.

## Validation

- New asset-loader and asset-serving contracts.
- Device-first workspace and auto-refresh contracts.
- Polling-noise suppression and operation-feedback contracts.
- Responsive layout contracts.
- Node syntax validation for the loader and workspace module.
- Full repository CI matrix.