### PR TITLE
Replace Developer Hub status lights with info tips

### DIFF
--- a/assets/devhub_workspace.css
+++ b/assets/devhub_workspace.css
@@ -25,33 +25,17 @@
 }
 
 .devhub-device-identity {
-  display: flex;
-  align-items: center;
-  gap: 13px;
   min-width: 0;
 }
 
-.devhub-device-state {
-  width: 12px;
-  height: 12px;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: var(--text-muted);
-  box-shadow: 0 0 12px currentColor;
-}
-
-.devhub-device-state.online {
-  color: var(--success);
-  background: var(--success);
-}
-
-.devhub-device-state.offline,
-.devhub-device-state.unauthorized {
-  color: var(--danger);
-  background: var(--danger);
-}
-
 .devhub-device-copy {
+  min-width: 0;
+}
+
+.devhub-device-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
 }
 
@@ -78,6 +62,10 @@
   flex-wrap: wrap;
 }
 
+.devhub-device-badges[hidden] {
+  display: none !important;
+}
+
 .devhub-device-badge {
   display: inline-flex;
   align-items: center;
@@ -96,6 +84,10 @@
 .devhub-device-badge.accent {
   border-color: rgba(0, 243, 255, .38);
   color: var(--accent-primary);
+}
+
+.devhub-info-tip {
+  flex: 0 0 auto;
 }
 
 .devhub-workspace-tabs {
@@ -155,32 +147,41 @@
 }
 
 .devhub-quick-action {
-  display: grid;
-  gap: 5px;
-  min-height: 82px;
-  padding: 13px;
+  display: flex;
+  align-items: center;
+  min-height: 58px;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text-main);
-  cursor: pointer;
-  text-align: left;
 }
 
-.devhub-quick-action:hover {
+.devhub-quick-action:hover,
+.devhub-quick-action:focus-within {
   border-color: rgba(0, 243, 255, .38);
   box-shadow: 0 0 16px rgba(0, 243, 255, .08);
 }
 
-.devhub-quick-action strong {
+.devhub-quick-action-button {
+  min-width: 0;
+  min-height: 56px;
+  flex: 1 1 auto;
+  padding: 13px;
+  border: 0;
+  background: transparent;
+  color: var(--text-main);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.devhub-quick-action-button strong {
   color: var(--accent-primary);
   font-size: 13px;
 }
 
-.devhub-quick-action span {
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.4;
+.devhub-quick-action-tip {
+  margin: 0 13px 0 6px;
 }
 
 .devhub-activity {
@@ -219,10 +220,15 @@
 
 .devhub-workspace-meta {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
+  align-items: center;
   gap: 12px;
   color: var(--text-muted);
   font-size: 11px;
+}
+
+.devhub-refresh-help {
+  margin-right: auto;
 }
 
 .devhub-section-note {

--- a/assets/devhub_workspace.js
+++ b/assets/devhub_workspace.js
@@ -4,6 +4,12 @@
   const AUTO_REFRESH_MS = 5000;
   const VIEW_KEY = 'vrhs_devhub_workspace_view';
   const VIEW_NAMES = ['device', 'apps', 'connection', 'tools'];
+  const EMPTY_DEVICE_LABELS = new Set([
+    '',
+    '--',
+    'no device selected',
+    'no headset selected',
+  ]);
   let refreshTimer = null;
   let activityTimer = null;
   let syncQueued = false;
@@ -31,8 +37,23 @@
       .trim();
   }
 
+  function normalizedSerial(value) {
+    const serial = String(value || '').trim();
+    return EMPTY_DEVICE_LABELS.has(serial.toLowerCase()) ? '' : serial;
+  }
+
+  function infoTip(text, extraClass = '') {
+    const tip = document.createElement('span');
+    tip.className = ['tip', 'devhub-info-tip', extraClass].filter(Boolean).join(' ');
+    tip.textContent = 'ⓘ';
+    tip.setAttribute('data-tip', text);
+    tip.setAttribute('aria-label', text);
+    tip.setAttribute('tabindex', '0');
+    return tip;
+  }
+
   function selectedDeviceSnapshot() {
-    const serial = String((el('devhubSelectedDevice') || {}).textContent || '').trim();
+    const serial = normalizedSerial((el('devhubSelectedDevice') || {}).textContent);
     const selectedRow = document.querySelector('#devhubDeviceList .devhub-list-item.selected');
     const meta = selectedRow
       ? String((selectedRow.querySelector('.devhub-list-meta') || {}).textContent || '').trim()
@@ -43,9 +64,9 @@
     const transport = serial && serial.includes(':')
       ? 'Wireless ADB'
       : (serial ? 'USB ADB' : 'No transport');
-    const connected = state === 'device';
+    const connected = !!serial && state === 'device';
     return {
-      serial: serial && serial !== 'No device selected' ? serial : '',
+      serial,
       model: model || (serial ? 'Android XR headset' : 'No headset selected'),
       state: state || (serial ? 'unknown' : 'offline'),
       transport,
@@ -62,19 +83,8 @@
 
   function updateDeviceBar() {
     const device = selectedDeviceSnapshot();
-    const stateDot = el('devhubWorkspaceDeviceState');
-    if (stateDot) {
-      stateDot.classList.remove('online', 'offline', 'unauthorized');
-      if (device.connected) stateDot.classList.add('online');
-      else if (device.state === 'unauthorized') stateDot.classList.add('unauthorized');
-      else stateDot.classList.add('offline');
-    }
-
     setText('devhubWorkspaceDeviceName', device.model);
-    setText(
-      'devhubWorkspaceDeviceSerial',
-      device.serial || 'Connect or select a headset to begin',
-    );
+    setText('devhubWorkspaceDeviceSerial', device.serial || 'No device selected');
     setText('devhubWorkspaceTransport', device.transport);
     setText(
       'devhubWorkspaceState',
@@ -84,6 +94,9 @@
     const source = String((el('devhubToolSource') || {}).textContent || '').trim();
     const runtime = source && source !== '--' ? `${source} ADB` : 'ADB unavailable';
     setText('devhubWorkspaceRuntime', runtime);
+
+    const badges = el('devhubWorkspaceBadges');
+    if (badges) badges.hidden = !device.serial;
     setText('devhubWorkspaceUpdated', `Updated ${new Date().toLocaleTimeString()}`);
   }
 
@@ -184,16 +197,19 @@
   }
 
   function quickAction(title, detail, action) {
+    const item = document.createElement('div');
+    item.className = 'devhub-quick-action';
+
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'devhub-quick-action';
+    button.className = 'devhub-quick-action-button';
     const heading = document.createElement('strong');
     heading.textContent = title;
-    const copy = document.createElement('span');
-    copy.textContent = detail;
-    button.append(heading, copy);
+    button.appendChild(heading);
     button.addEventListener('click', action);
-    return button;
+
+    item.append(button, infoTip(detail, 'devhub-quick-action-tip'));
+    return item;
   }
 
   function buildOverviewCard() {
@@ -305,24 +321,30 @@
     deviceBar.className = 'devhub-device-bar';
     const identity = document.createElement('div');
     identity.className = 'devhub-device-identity';
-    const state = document.createElement('span');
-    state.id = 'devhubWorkspaceDeviceState';
-    state.className = 'devhub-device-state offline';
     const copy = document.createElement('div');
     copy.className = 'devhub-device-copy';
+    const nameRow = document.createElement('div');
+    nameRow.className = 'devhub-device-name-row';
     const name = document.createElement('div');
     name.id = 'devhubWorkspaceDeviceName';
     name.className = 'devhub-device-name';
     name.textContent = 'No headset selected';
+    const deviceHelp = infoTip(
+      'This workspace follows the selected ADB headset and refreshes its state automatically.',
+      'devhub-device-help',
+    );
+    nameRow.append(name, deviceHelp);
     const serial = document.createElement('div');
     serial.id = 'devhubWorkspaceDeviceSerial';
     serial.className = 'devhub-device-serial';
-    serial.textContent = 'Connect or select a headset to begin';
-    copy.append(name, serial);
-    identity.append(state, copy);
+    serial.textContent = 'No device selected';
+    copy.append(nameRow, serial);
+    identity.appendChild(copy);
 
     const badges = document.createElement('div');
+    badges.id = 'devhubWorkspaceBadges';
     badges.className = 'devhub-device-badges';
+    badges.hidden = true;
     badges.innerHTML = `
       <span id="devhubWorkspaceState" class="devhub-device-badge accent">Offline</span>
       <span id="devhubWorkspaceTransport" class="devhub-device-badge">No transport</span>
@@ -359,12 +381,14 @@
 
     const meta = document.createElement('div');
     meta.className = 'devhub-workspace-meta';
-    const refreshNote = document.createElement('span');
-    refreshNote.textContent = 'Device state refreshes automatically while this tab is open.';
+    const refreshHelp = infoTip(
+      'Device state refreshes automatically every five seconds while this tab is open.',
+      'devhub-refresh-help',
+    );
     const updated = document.createElement('span');
     updated.id = 'devhubWorkspaceUpdated';
     updated.textContent = 'Waiting for device state';
-    meta.append(refreshNote, updated);
+    meta.append(refreshHelp, updated);
 
     workspace.append(
       deviceBar,

--- a/tests/test_devhub_workspace_ui.py
+++ b/tests/test_devhub_workspace_ui.py
@@ -37,7 +37,6 @@ def test_workspace_is_device_first_and_removes_manual_refresh_ui():
 
     assert "devhub-device-bar" in source
     assert "No headset selected" in source
-    assert "Device state refreshes automatically while this tab is open." in source
     assert "refreshButton.hidden = true" in source
     assert "window.setInterval(requestRefresh, AUTO_REFRESH_MS)" in source
     assert "document.addEventListener('visibilitychange'" in source
@@ -60,6 +59,38 @@ def test_workspace_groups_existing_features_into_clear_views():
     assert "cards.control" in source
 
 
+def test_workspace_uses_shared_info_tips_instead_of_visible_subtext():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    assert "function infoTip(" in source
+    assert "tip.className = ['tip', 'devhub-info-tip'" in source
+    assert "tip.textContent = 'ⓘ'" in source
+    assert "tip.setAttribute('data-tip', text)" in source
+    assert "devhub-quick-action-tip" in source
+    assert "devhub-device-help" in source
+    assert "devhub-refresh-help" in source
+    assert "copy.textContent = detail" not in source
+    assert "refreshNote.textContent" not in source
+
+
+def test_workspace_has_no_decorative_device_status_light():
+    javascript = WORKSPACE_JS.read_text(encoding="utf-8")
+    stylesheet = WORKSPACE_CSS.read_text(encoding="utf-8")
+
+    assert "devhubWorkspaceDeviceState" not in javascript
+    assert "devhub-device-state" not in javascript
+    assert ".devhub-device-state" not in stylesheet
+
+
+def test_workspace_handles_empty_device_labels_without_fake_usb_status():
+    source = WORKSPACE_JS.read_text(encoding="utf-8")
+
+    assert "EMPTY_DEVICE_LABELS" in source
+    assert "'no device selected'" in source
+    assert "normalizedSerial" in source
+    assert "badges.hidden = !device.serial" in source
+
+
 def test_workspace_suppresses_polling_noise_but_preserves_operation_feedback():
     source = WORKSPACE_JS.read_text(encoding="utf-8")
 
@@ -79,14 +110,15 @@ def test_workspace_observes_source_fields_without_observing_its_own_summary():
     assert "observer.observe(page" not in source
 
 
-def test_workspace_styles_are_responsive_and_use_device_status_chips():
+def test_workspace_styles_are_responsive_and_compact():
     source = WORKSPACE_CSS.read_text(encoding="utf-8")
 
     assert ".devhub-page" in source
     assert "max-width: none" in source
     assert ".devhub-device-bar" in source
     assert ".devhub-workspace-tabs" in source
-    assert ".devhub-device-state.online" in source
+    assert ".devhub-quick-action-button" in source
+    assert ".devhub-info-tip" in source
     assert ".devhub-workspace-panel[hidden]" in source
     assert "@media (max-width: 920px)" in source
 


### PR DESCRIPTION
## Summary

Refine the new device-centered Developer Hub after live visual review.

## Changes

- Removes the decorative device status light entirely.
- Reuses the existing Basic-mode `ⓘ` floating-tip system for Developer Hub explanations.
- Replaces permanent Quick Action descriptions with compact info tips.
- Moves the automatic-refresh explanation behind an info tip.
- Keeps actual device serial data visible, while avoiding instructional subtext in the main device header.
- Treats `No device selected`, `No headset selected`, and placeholder values as empty selections.
- Hides connection/runtime badges when no real headset is selected, preventing false `UNKNOWN / USB ADB` presentation.
- Compacts Quick Action cards now that explanatory paragraphs are no longer always visible.

## Validation

- Regression coverage for shared info-tip markup.
- Regression coverage proving the decorative status-light code and CSS are absent.
- Empty-device normalization and badge-hiding coverage.
- Node syntax validation and the full repository CI matrix.