### PR TITLE
Replace quick actions with live headset overview

### DIFF
--- a/assets/devhub_device_overview.css
+++ b/assets/devhub_device_overview.css
@@ -1,0 +1,163 @@
+.devhub-overview-card .card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.devhub-overview-help {
+  margin-left: auto;
+}
+
+.devhub-overview-empty {
+  min-height: 168px;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.devhub-overview-content {
+  display: grid;
+  gap: 16px;
+}
+
+.devhub-overview-content[hidden],
+.devhub-overview-empty[hidden] {
+  display: none !important;
+}
+
+.devhub-overview-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.devhub-overview-metric {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+}
+
+.devhub-overview-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+
+.devhub-overview-label .tip {
+  font-size: 11px;
+}
+
+.devhub-overview-value {
+  margin-top: 7px;
+  color: var(--text-main);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.devhub-overview-controllers {
+  display: grid;
+  gap: 10px;
+}
+
+.devhub-overview-section-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.devhub-overview-section-title h3 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.devhub-controller-list {
+  display: grid;
+  gap: 8px;
+}
+
+.devhub-controller-row {
+  display: grid;
+  grid-template-columns: minmax(150px, .8fr) minmax(0, 1.2fr);
+  align-items: center;
+  gap: 14px;
+  padding: 11px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+}
+
+.devhub-controller-identity {
+  display: grid;
+  gap: 3px;
+}
+
+.devhub-controller-identity strong {
+  color: var(--text-main);
+  font-size: 13px;
+}
+
+.devhub-controller-identity span {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.devhub-controller-facts {
+  display: flex;
+  justify-content: flex-end;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.devhub-controller-facts span {
+  display: inline-flex;
+  min-height: 26px;
+  align-items: center;
+  padding: 4px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.devhub-overview-inline-empty {
+  padding: 12px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+@media (max-width: 1180px) {
+  .devhub-controller-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .devhub-controller-facts {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .devhub-overview-metrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/assets/devhub_device_overview.js
+++ b/assets/devhub_device_overview.js
@@ -1,0 +1,365 @@
+(function addDeveloperHubDeviceOverview() {
+  'use strict';
+
+  const ENDPOINT = '/v1/devbridge/adb/device-overview';
+  const REFRESH_MS = 15000;
+  const EMPTY_SERIALS = new Set(['', '--', 'no device selected', 'no headset selected']);
+  let refreshTimer = null;
+  let selectedObserver = null;
+  let loading = false;
+  let activeSerial = '';
+  let lastLoadedAt = 0;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function normalizedSerial(value) {
+    const serial = String(value || '').trim();
+    return EMPTY_SERIALS.has(serial.toLowerCase()) ? '' : serial;
+  }
+
+  function selectedSerial() {
+    return normalizedSerial((el('devhubSelectedDevice') || {}).textContent);
+  }
+
+  function hubIsVisible() {
+    const tab = el('tab-devhub');
+    return !!(tab && tab.classList.contains('active') && !document.hidden);
+  }
+
+  function infoTip(text, extraClass = '') {
+    const tip = document.createElement('span');
+    tip.className = ['tip', 'devhub-info-tip', extraClass].filter(Boolean).join(' ');
+    tip.textContent = 'ⓘ';
+    tip.setAttribute('data-tip', text);
+    tip.setAttribute('aria-label', text);
+    tip.setAttribute('tabindex', '0');
+    return tip;
+  }
+
+  function metric(label, id, helpText) {
+    const item = document.createElement('div');
+    item.className = 'devhub-overview-metric';
+    const labelRow = document.createElement('div');
+    labelRow.className = 'devhub-overview-label';
+    const labelText = document.createElement('span');
+    labelText.textContent = label;
+    labelRow.appendChild(labelText);
+    if (helpText) labelRow.appendChild(infoTip(helpText));
+    const value = document.createElement('div');
+    value.id = id;
+    value.className = 'devhub-overview-value';
+    value.textContent = '--';
+    item.append(labelRow, value);
+    return item;
+  }
+
+  function findQuickActionsCard() {
+    const cards = document.querySelectorAll(
+      '#devhubWorkspace .devhub-workspace-panel[data-view="device"] .card',
+    );
+    return Array.from(cards).find((card) => {
+      const title = card.querySelector('.card-header h2');
+      return title && title.textContent.trim() === 'Quick Actions';
+    }) || null;
+  }
+
+  function buildOverview(card) {
+    if (!card || card.dataset.overviewReady === '1') return true;
+    const header = card.querySelector('.card-header');
+    const title = header && header.querySelector('h2');
+    const body = card.querySelector('.card-body');
+    if (!header || !title || !body) return false;
+
+    card.dataset.overviewReady = '1';
+    card.classList.add('devhub-overview-card');
+    title.textContent = 'Headset Overview';
+    header.appendChild(infoTip(
+      'Live read-only details from the selected headset. Values refresh automatically while Developer Hub is open.',
+      'devhub-overview-help',
+    ));
+
+    const empty = document.createElement('div');
+    empty.id = 'devhubOverviewEmpty';
+    empty.className = 'devhub-overview-empty';
+    empty.textContent = 'Select a connected headset to view device information.';
+
+    const content = document.createElement('div');
+    content.id = 'devhubOverviewContent';
+    content.className = 'devhub-overview-content';
+    content.hidden = true;
+
+    const metrics = document.createElement('div');
+    metrics.className = 'devhub-overview-metrics';
+    metrics.append(
+      metric('Headset battery', 'devhubOverviewBattery', 'Current battery level and charging state.'),
+      metric('Storage', 'devhubOverviewStorage', 'Free space on the headset data partition.'),
+      metric('Wi-Fi', 'devhubOverviewWifi', 'The network currently reported by Android.'),
+      metric('Network quality', 'devhubOverviewSignal', 'Wi-Fi signal strength and negotiated link speed when available.'),
+      metric('IP address', 'devhubOverviewIp', 'The current IPv4 address reported by the headset route table.'),
+      metric('System', 'devhubOverviewSystem', 'Android release and SDK level.'),
+      metric('Build', 'devhubOverviewBuild', 'The headset firmware build identifier.'),
+      metric('Uptime', 'devhubOverviewUptime', 'Time since the headset last restarted.'),
+    );
+
+    const controllers = document.createElement('section');
+    controllers.className = 'devhub-overview-controllers';
+    const controllerHeader = document.createElement('div');
+    controllerHeader.className = 'devhub-overview-section-title';
+    const controllerTitle = document.createElement('h3');
+    controllerTitle.textContent = 'Controllers';
+    controllerHeader.append(
+      controllerTitle,
+      infoTip('Controller battery and tracking data is shown when the headset exposes it through ADB.'),
+    );
+    const controllerList = document.createElement('div');
+    controllerList.id = 'devhubOverviewControllers';
+    controllerList.className = 'devhub-controller-list';
+    controllers.append(controllerHeader, controllerList);
+
+    content.append(metrics, controllers);
+    body.replaceChildren(empty, content);
+    return true;
+  }
+
+  function setValue(id, value, fallback = 'Not reported') {
+    const node = el(id);
+    if (!node) return;
+    const rendered = value === null || value === undefined || value === ''
+      ? fallback
+      : String(value);
+    node.textContent = rendered;
+  }
+
+  function formatBytes(value) {
+    const bytes = Number(value);
+    if (!Number.isFinite(bytes) || bytes < 0) return null;
+    const gib = bytes / (1024 ** 3);
+    if (gib >= 10) return `${gib.toFixed(0)} GB`;
+    return `${gib.toFixed(1)} GB`;
+  }
+
+  function formatUptime(value) {
+    let seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    seconds = Math.floor(seconds);
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (days) return `${days}d ${hours}h`;
+    if (hours) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  }
+
+  function renderControllers(data) {
+    const container = el('devhubOverviewControllers');
+    if (!container) return;
+    container.replaceChildren();
+
+    if (!data.controller_service_available) {
+      const unavailable = document.createElement('div');
+      unavailable.className = 'devhub-overview-inline-empty';
+      unavailable.textContent = 'Controller telemetry is not reported by this headset.';
+      container.appendChild(unavailable);
+      return;
+    }
+
+    const controllers = Array.isArray(data.controllers) ? data.controllers : [];
+    if (!controllers.length) {
+      const empty = document.createElement('div');
+      empty.className = 'devhub-overview-inline-empty';
+      empty.textContent = 'No paired controllers were reported.';
+      container.appendChild(empty);
+      return;
+    }
+
+    for (const controller of controllers) {
+      const row = document.createElement('div');
+      row.className = 'devhub-controller-row';
+
+      const identity = document.createElement('div');
+      identity.className = 'devhub-controller-identity';
+      const name = document.createElement('strong');
+      name.textContent = `${controller.side || 'Unknown'} controller`;
+      const firmware = document.createElement('span');
+      firmware.textContent = controller.firmware
+        ? `Firmware ${controller.firmware}`
+        : 'Firmware not reported';
+      identity.append(name, firmware);
+
+      const facts = document.createElement('div');
+      facts.className = 'devhub-controller-facts';
+      const battery = controller.battery_percent === null
+        || controller.battery_percent === undefined
+        ? 'Battery --'
+        : `Battery ${controller.battery_percent}%`;
+      const tracking = controller.tracking_status
+        ? `Tracking ${controller.tracking_status}`
+        : 'Tracking not reported';
+      const state = controller.external_status || controller.status;
+      facts.append(
+        Object.assign(document.createElement('span'), { textContent: battery }),
+        Object.assign(document.createElement('span'), { textContent: tracking }),
+      );
+      if (state) {
+        facts.appendChild(Object.assign(document.createElement('span'), {
+          textContent: `State ${state}`,
+        }));
+      }
+
+      row.append(identity, facts);
+      container.appendChild(row);
+    }
+  }
+
+  function renderEmpty(message) {
+    const empty = el('devhubOverviewEmpty');
+    const content = el('devhubOverviewContent');
+    if (empty) {
+      empty.textContent = message || 'Select a connected headset to view device information.';
+      empty.hidden = false;
+    }
+    if (content) content.hidden = true;
+  }
+
+  function renderOverview(data) {
+    const empty = el('devhubOverviewEmpty');
+    const content = el('devhubOverviewContent');
+    if (empty) empty.hidden = true;
+    if (content) content.hidden = false;
+
+    const device = data.device || {};
+    const battery = data.battery || {};
+    const storage = data.storage || {};
+    const wifi = data.wifi || {};
+
+    const batteryValue = battery.percent === null || battery.percent === undefined
+      ? null
+      : `${battery.percent}%${battery.charging ? ' · Charging' : ''}`;
+    const free = formatBytes(storage.available_bytes);
+    const total = formatBytes(storage.total_bytes);
+    const storageValue = free && total ? `${free} free of ${total}` : (free || null);
+    const signalParts = [];
+    if (wifi.rssi_dbm !== null && wifi.rssi_dbm !== undefined) {
+      signalParts.push(`${wifi.rssi_dbm} dBm`);
+    }
+    if (wifi.link_speed_mbps !== null && wifi.link_speed_mbps !== undefined) {
+      signalParts.push(`${wifi.link_speed_mbps} Mbps`);
+    }
+    const systemParts = [];
+    if (device.android_release) systemParts.push(`Android ${device.android_release}`);
+    if (device.android_sdk !== null && device.android_sdk !== undefined) {
+      systemParts.push(`SDK ${device.android_sdk}`);
+    }
+
+    setValue('devhubOverviewBattery', batteryValue);
+    setValue('devhubOverviewStorage', storageValue);
+    setValue('devhubOverviewWifi', wifi.ssid || (wifi.enabled === false ? 'Wi-Fi disabled' : null));
+    setValue('devhubOverviewSignal', signalParts.join(' · '));
+    setValue('devhubOverviewIp', wifi.ip_address);
+    setValue('devhubOverviewSystem', systemParts.join(' · '));
+    setValue('devhubOverviewBuild', device.build);
+    setValue('devhubOverviewUptime', formatUptime(data.uptime_seconds));
+    renderControllers(data);
+
+    const workspaceName = el('devhubWorkspaceDeviceName');
+    if (workspaceName && device.model) workspaceName.textContent = String(device.model);
+  }
+
+  function responseCode(response) {
+    if (response && response.json) {
+      const result = response.json.data;
+      if (result && result.result_code) return String(result.result_code);
+      if (response.json.result_code) return String(response.json.result_code);
+    }
+    return response ? `HTTP ${response.status}` : 'request_failed';
+  }
+
+  async function refreshOverview(force = false) {
+    const serial = selectedSerial();
+    if (!serial) {
+      activeSerial = '';
+      renderEmpty();
+      return;
+    }
+    if (!hubIsVisible() || loading) return;
+    const now = Date.now();
+    if (!force && serial === activeSerial && now - lastLoadedAt < REFRESH_MS) return;
+
+    activeSerial = serial;
+    loading = true;
+    const empty = el('devhubOverviewEmpty');
+    if (empty && el('devhubOverviewContent') && el('devhubOverviewContent').hidden) {
+      empty.textContent = 'Loading headset information...';
+    }
+
+    try {
+      if (typeof api !== 'function') {
+        renderEmpty('The Developer Hub API is unavailable.');
+        return;
+      }
+      const query = new URLSearchParams({ serial });
+      const response = await api(`${ENDPOINT}?${query.toString()}`);
+      if (!response.ok) {
+        renderEmpty(`Headset information unavailable: ${responseCode(response)}`);
+        return;
+      }
+      const operation = response.json && response.json.data ? response.json.data : {};
+      const data = operation && operation.data && typeof operation.data === 'object'
+        ? operation.data
+        : {};
+      if (serial !== selectedSerial()) return;
+      renderOverview(data);
+      lastLoadedAt = Date.now();
+    } catch {
+      renderEmpty('Unable to read headset information from the daemon.');
+    } finally {
+      loading = false;
+    }
+  }
+
+  function wireSelectionObserver() {
+    const selected = el('devhubSelectedDevice');
+    if (!selected || selectedObserver) return;
+    selectedObserver = new MutationObserver(() => {
+      lastLoadedAt = 0;
+      void refreshOverview(true);
+    });
+    selectedObserver.observe(selected, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  function inject() {
+    const card = findQuickActionsCard();
+    if (!card) return false;
+    if (!buildOverview(card)) return false;
+    wireSelectionObserver();
+    void refreshOverview(true);
+
+    if (refreshTimer) window.clearInterval(refreshTimer);
+    refreshTimer = window.setInterval(() => void refreshOverview(false), REFRESH_MS);
+    window.addEventListener('focus', () => void refreshOverview(false));
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) void refreshOverview(false);
+    });
+    return true;
+  }
+
+  function start() {
+    if (inject()) return;
+    const observer = new MutationObserver(() => {
+      if (inject()) observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -66,6 +66,11 @@ window.UI_FIELD_VISIBILITY = {
   workspaceStylesheet.href = '/assets/devhub_workspace.css';
   document.head.appendChild(workspaceStylesheet);
 
+  const overviewStylesheet = document.createElement('link');
+  overviewStylesheet.rel = 'stylesheet';
+  overviewStylesheet.href = '/assets/devhub_device_overview.css';
+  document.head.appendChild(overviewStylesheet);
+
   const script = document.createElement('script');
   script.src = '/assets/devhub.js';
   script.async = false;
@@ -80,6 +85,11 @@ window.UI_FIELD_VISIBILITY = {
   workspaceScript.src = '/assets/devhub_workspace.js';
   workspaceScript.async = false;
   document.head.appendChild(workspaceScript);
+
+  const overviewScript = document.createElement('script');
+  overviewScript.src = '/assets/devhub_device_overview.js';
+  overviewScript.async = false;
+  document.head.appendChild(overviewScript);
 })();
 
 (function addManagedPlatformToolsControls() {

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -17,6 +17,7 @@ from vr_hotspotd.devtools.adb_operations import (
     execute_adb_operation,
 )
 from vr_hotspotd.devtools.apk_upload import APK_UPLOAD_PATH, handle_apk_upload
+from vr_hotspotd.devtools.device_overview import collect_device_overview
 from vr_hotspotd.devtools.platform_tools_manager import (
     RESULT_ARCHIVE_INVALID,
     RESULT_ARCHIVE_TOO_LARGE,
@@ -37,6 +38,8 @@ from vr_hotspotd.devtools.platform_tools_manager import (
 
 log = logging.getLogger("vr_hotspotd.devhub_api")
 
+DEVICE_OVERVIEW_PATH = "/v1/devbridge/adb/device-overview"
+
 _DEVHUB_ASSET_TYPES = {
     "/assets/devhub.css": "text/css; charset=utf-8",
     "/assets/devhub.js": "application/javascript; charset=utf-8",
@@ -44,6 +47,8 @@ _DEVHUB_ASSET_TYPES = {
     "/assets/devhub_upload.js": "application/javascript; charset=utf-8",
     "/assets/devhub_workspace.css": "text/css; charset=utf-8",
     "/assets/devhub_workspace.js": "application/javascript; charset=utf-8",
+    "/assets/devhub_device_overview.css": "text/css; charset=utf-8",
+    "/assets/devhub_device_overview.js": "application/javascript; charset=utf-8",
 }
 
 _GET_OPERATIONS = {
@@ -142,6 +147,20 @@ class DevHubAPIHandler(APIHandler):
             ),
         )
 
+    def _respond_device_overview(self, *, cid: str, serial: Any) -> None:
+        result = collect_device_overview(serial)
+        result_code = str(result.get("result_code") or RESULT_FAILED)
+        status = _RESULT_HTTP_STATUS.get(result_code, 500)
+        self._respond(
+            status,
+            self._envelope(
+                correlation_id=cid,
+                result_code=result_code,
+                data=result,
+                warnings=[],
+            ),
+        )
+
     def _respond_tools_operation(
         self,
         *,
@@ -186,7 +205,8 @@ class DevHubAPIHandler(APIHandler):
         if self._serve_devhub_asset(path):
             return
         operation = _GET_OPERATIONS.get(path)
-        if operation is None:
+        is_device_overview = path == DEVICE_OVERVIEW_PATH
+        if operation is None and not is_device_overview:
             super().do_GET()
             return
 
@@ -197,13 +217,17 @@ class DevHubAPIHandler(APIHandler):
         if not self._require_auth(cid):
             return
 
+        if is_device_overview:
+            self._respond_device_overview(cid=cid, serial=qs.get("serial"))
+            return
+
         request: Optional[Mapping[str, Any]] = None
         if operation == "packages":
             request = {
                 "serial": qs.get("serial"),
                 "third_party_only": self._qbool(qs, "third_party_only", True),
             }
-        self._respond_adb_operation(cid=cid, operation=operation, request=request)
+        self._respond_adb_operation(cid=cid, operation=operation or "", request=request)
 
     def do_POST(self):
         cid = self._cid()

--- a/backend/vr_hotspotd/devtools/device_overview.py
+++ b/backend/vr_hotspotd/devtools/device_overview.py
@@ -1,0 +1,343 @@
+"""Collect a bounded, read-only headset overview through typed ADB commands."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+
+from vr_hotspotd.devtools.adb_operations import (
+    RESULT_FAILED,
+    RESULT_INVALID_REQUEST,
+    RESULT_OK,
+    RESULT_OUTPUT_LIMIT,
+    RESULT_TIMEOUT,
+    RESULT_TOOLS_UNAVAILABLE,
+)
+from vr_hotspotd.devtools.platform_tools import collect_devbridge_tools_status
+
+
+ADB_OVERVIEW_TIMEOUT_S = 15.0
+ADB_OUTPUT_LIMIT_BYTES = 256 * 1024
+SERIAL_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
+PROPERTY_RE = re.compile(r"^\[([^]]+)\]: \[(.*)\]$")
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+class DeviceOverviewError(ValueError):
+    """A headset overview request is invalid or cannot be executed."""
+
+
+def _valid_serial(value: Any) -> str:
+    if not isinstance(value, str) or not SERIAL_RE.fullmatch(value):
+        raise DeviceOverviewError("serial contains unsupported characters")
+    return value
+
+
+def _effective_adb_path(tools_status: Optional[Mapping[str, Any]] = None) -> str:
+    status = dict(tools_status or collect_devbridge_tools_status())
+    adb = status.get("adb")
+    if not isinstance(adb, Mapping):
+        raise DeviceOverviewError("ADB tools status is unavailable")
+    path = adb.get("path")
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise DeviceOverviewError("ADB is not installed")
+    return path
+
+
+def _decode_bounded(value: bytes) -> str:
+    if len(value) > ADB_OUTPUT_LIMIT_BYTES:
+        raise DeviceOverviewError("ADB output exceeded the configured limit")
+    return value.decode("utf-8", errors="replace").rstrip()
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> tuple[int, str, str]:
+    completed = runner(
+        list(argv),
+        input=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=ADB_OVERVIEW_TIMEOUT_S,
+        check=False,
+        shell=False,
+        env={"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
+    )
+    return (
+        int(completed.returncode),
+        _decode_bounded(completed.stdout or b""),
+        _decode_bounded(completed.stderr or b""),
+    )
+
+
+def _device_command(adb: str, serial: str, *arguments: str) -> tuple[str, ...]:
+    return (adb, "-s", serial, "shell", *arguments)
+
+
+def _parse_properties(text: str) -> Dict[str, str]:
+    properties: Dict[str, str] = {}
+    for line in text.splitlines():
+        match = PROPERTY_RE.match(line.strip())
+        if match:
+            properties[match.group(1)] = match.group(2)
+    return properties
+
+
+def _parse_int(value: Any) -> Optional[int]:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_battery(text: str) -> Dict[str, Any]:
+    values: Dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        values[key.strip().lower()] = value.strip()
+
+    level = _parse_int(values.get("level"))
+    scale = _parse_int(values.get("scale")) or 100
+    percent = None
+    if level is not None and scale > 0:
+        percent = max(0, min(100, round((level / scale) * 100)))
+
+    status_code = _parse_int(values.get("status"))
+    status_names = {
+        1: "unknown",
+        2: "charging",
+        3: "discharging",
+        4: "not charging",
+        5: "full",
+    }
+    sources = []
+    for key, label in (
+        ("ac powered", "AC"),
+        ("usb powered", "USB"),
+        ("wireless powered", "wireless"),
+    ):
+        if values.get(key, "").lower() == "true":
+            sources.append(label)
+
+    temperature_raw = _parse_int(values.get("temperature"))
+    voltage_mv = _parse_int(values.get("voltage"))
+    return {
+        "percent": percent,
+        "status": status_names.get(status_code, "unknown"),
+        "charging": status_code in {2, 5} or bool(sources),
+        "power_sources": sources,
+        "temperature_c": (
+            round(temperature_raw / 10.0, 1) if temperature_raw is not None else None
+        ),
+        "voltage_mv": voltage_mv,
+    }
+
+
+def _parse_storage(text: str) -> Dict[str, Any]:
+    for line in reversed(text.splitlines()):
+        parts = line.split()
+        if len(parts) < 6 or parts[-1] != "/data":
+            continue
+        total_kib = _parse_int(parts[1])
+        used_kib = _parse_int(parts[2])
+        available_kib = _parse_int(parts[3])
+        if total_kib is None or used_kib is None or available_kib is None:
+            break
+        return {
+            "total_bytes": total_kib * 1024,
+            "used_bytes": used_kib * 1024,
+            "available_bytes": available_kib * 1024,
+            "used_percent": _parse_int(parts[4].rstrip("%")),
+        }
+    return {}
+
+
+def _first_match(pattern: str, text: str, flags: int = re.IGNORECASE) -> Optional[str]:
+    match = re.search(pattern, text, flags)
+    return match.group(1).strip() if match else None
+
+
+def _parse_wifi(status_text: str, route_text: str) -> Dict[str, Any]:
+    enabled_match = re.search(r"Wi-?Fi is (enabled|disabled)", status_text, re.IGNORECASE)
+    ssid = _first_match(r"SSID:\s*(?:\"([^\"]+)\"|([^,\n]+))", status_text)
+    if ssid is None:
+        alternate = re.search(r"SSID:\s*([^,\n]+)", status_text, re.IGNORECASE)
+        ssid = alternate.group(1).strip().strip('"') if alternate else None
+    if ssid and ssid.lower() in {"<unknown ssid>", "unknown ssid", "<none>"}:
+        ssid = None
+
+    rssi = _parse_int(_first_match(r"RSSI:\s*(-?\d+)", status_text))
+    frequency = _parse_int(_first_match(r"Frequency:\s*(\d+)", status_text))
+    link_speed = _parse_int(
+        _first_match(r"(?:Tx )?Link speed:\s*(\d+)\s*Mbps", status_text)
+    )
+    bssid = _first_match(r"BSSID:\s*([0-9A-Fa-f:]{17})", status_text)
+    ip_address = _first_match(r"\bsrc\s+((?:\d{1,3}\.){3}\d{1,3})", route_text)
+    gateway = _first_match(r"\bdefault via\s+((?:\d{1,3}\.){3}\d{1,3})", route_text)
+
+    return {
+        "enabled": enabled_match.group(1).lower() == "enabled" if enabled_match else None,
+        "ssid": ssid,
+        "bssid": bssid,
+        "rssi_dbm": rssi,
+        "frequency_mhz": frequency,
+        "link_speed_mbps": link_speed,
+        "ip_address": ip_address,
+        "gateway": gateway,
+    }
+
+
+def _parse_uptime(text: str) -> Optional[int]:
+    try:
+        return max(0, int(float(text.split()[0])))
+    except (IndexError, TypeError, ValueError):
+        return None
+
+
+def _parse_controllers(text: str) -> list[Dict[str, Any]]:
+    controllers = []
+    for line in text.splitlines():
+        if "Paired device:" not in line:
+            continue
+        fields: Dict[str, str] = {}
+        for part in line.split(","):
+            if ":" not in part:
+                continue
+            key, value = part.split(":", 1)
+            fields[key.strip()] = value.strip()
+        side = fields.get("Type")
+        if not side:
+            continue
+        battery_text = fields.get("Battery", "").rstrip("%")
+        controllers.append(
+            {
+                "side": side,
+                "battery_percent": _parse_int(battery_text),
+                "firmware": fields.get("Firmware"),
+                "status": fields.get("Status"),
+                "external_status": fields.get("ExternalStatus"),
+                "tracking_status": fields.get("TrackingStatus"),
+                "brightness": fields.get("BrightnessLevel"),
+            }
+        )
+    return controllers
+
+
+def _failure(operation: str, result_code: str, message: str) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "operation": operation,
+        "success": False,
+        "result_code": result_code,
+        "returncode": None,
+        "stdout": "",
+        "stderr": message,
+        "data": {},
+    }
+
+
+def collect_device_overview(
+    serial: Any,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> Dict[str, Any]:
+    """Collect a normalized MDM-style snapshot without arbitrary shell input."""
+
+    operation = "device_overview"
+    try:
+        validated_serial = _valid_serial(serial)
+        adb = _effective_adb_path(tools_status)
+
+        getprop_code, getprop_stdout, getprop_stderr = _run(
+            _device_command(adb, validated_serial, "getprop"),
+            runner=runner,
+        )
+        if getprop_code != 0:
+            return {
+                "schema_version": 1,
+                "operation": operation,
+                "success": False,
+                "result_code": RESULT_FAILED,
+                "returncode": getprop_code,
+                "stdout": "",
+                "stderr": getprop_stderr or "Unable to read headset properties",
+                "data": {},
+            }
+
+        unavailable = []
+
+        def optional(name: str, *arguments: str) -> str:
+            code, stdout, _stderr = _run(
+                _device_command(adb, validated_serial, *arguments),
+                runner=runner,
+            )
+            if code != 0:
+                unavailable.append(name)
+                return ""
+            return stdout
+
+        properties = _parse_properties(getprop_stdout)
+        battery_text = optional("battery", "dumpsys", "battery")
+        storage_text = optional("storage", "df", "-k", "/data")
+        wifi_text = optional("wifi", "cmd", "wifi", "status")
+        route_text = optional("network_route", "ip", "route")
+        uptime_text = optional("uptime", "cat", "/proc/uptime")
+        controllers_text = optional(
+            "controllers",
+            "dumpsys",
+            "OVRRemoteService",
+        )
+        controller_service_available = bool(controllers_text) and not re.search(
+            r"(?:can't find|not found|unknown)\s+(?:service\s*)?OVRRemoteService",
+            controllers_text,
+            re.IGNORECASE,
+        )
+
+        data = {
+            "serial": validated_serial,
+            "transport": "wireless" if ":" in validated_serial else "usb",
+            "device": {
+                "manufacturer": properties.get("ro.product.manufacturer"),
+                "model": properties.get("ro.product.model"),
+                "product": properties.get("ro.product.name"),
+                "device": properties.get("ro.product.device"),
+                "android_release": properties.get("ro.build.version.release"),
+                "android_sdk": _parse_int(properties.get("ro.build.version.sdk")),
+                "build": properties.get("ro.build.display.id"),
+                "security_patch": properties.get("ro.build.version.security_patch"),
+            },
+            "battery": _parse_battery(battery_text) if battery_text else {},
+            "storage": _parse_storage(storage_text) if storage_text else {},
+            "wifi": _parse_wifi(wifi_text, route_text),
+            "uptime_seconds": _parse_uptime(uptime_text),
+            "controller_service_available": controller_service_available,
+            "controllers": _parse_controllers(controllers_text),
+            "unavailable": unavailable,
+        }
+        return {
+            "schema_version": 1,
+            "operation": operation,
+            "success": True,
+            "result_code": RESULT_OK,
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "",
+            "data": data,
+        }
+    except subprocess.TimeoutExpired:
+        return _failure(operation, RESULT_TIMEOUT, "ADB device overview timed out")
+    except DeviceOverviewError as exc:
+        message = str(exc)
+        if message in {"ADB is not installed", "ADB tools status is unavailable"}:
+            result_code = RESULT_TOOLS_UNAVAILABLE
+        elif message == "ADB output exceeded the configured limit":
+            result_code = RESULT_OUTPUT_LIMIT
+        else:
+            result_code = RESULT_INVALID_REQUEST
+        return _failure(operation, result_code, message)

--- a/backend/vr_hotspotd/devtools/device_overview.py
+++ b/backend/vr_hotspotd/devtools/device_overview.py
@@ -21,7 +21,6 @@ ADB_OVERVIEW_TIMEOUT_S = 15.0
 ADB_OUTPUT_LIMIT_BYTES = 256 * 1024
 SERIAL_RE = re.compile(r"^[A-Za-z0-9._:-]{1,255}$")
 PROPERTY_RE = re.compile(r"^\[([^]]+)\]: \[(.*)\]$")
-IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 
 
 class DeviceOverviewError(ValueError):
@@ -228,6 +227,17 @@ def _parse_controllers(text: str) -> list[Dict[str, Any]]:
     return controllers
 
 
+def _controller_service_available(text: str) -> bool:
+    if not text:
+        return False
+    missing = re.search(
+        r"(?:can't find|not found|unknown)\s+(?:service\s*:?\s*)?OVRRemoteService",
+        text,
+        re.IGNORECASE,
+    )
+    return missing is None
+
+
 def _failure(operation: str, result_code: str, message: str) -> Dict[str, Any]:
     return {
         "schema_version": 1,
@@ -293,11 +303,6 @@ def collect_device_overview(
             "dumpsys",
             "OVRRemoteService",
         )
-        controller_service_available = bool(controllers_text) and not re.search(
-            r"(?:can't find|not found|unknown)\s+(?:service\s*)?OVRRemoteService",
-            controllers_text,
-            re.IGNORECASE,
-        )
 
         data = {
             "serial": validated_serial,
@@ -316,7 +321,9 @@ def collect_device_overview(
             "storage": _parse_storage(storage_text) if storage_text else {},
             "wifi": _parse_wifi(wifi_text, route_text),
             "uptime_seconds": _parse_uptime(uptime_text),
-            "controller_service_available": controller_service_available,
+            "controller_service_available": _controller_service_available(
+                controllers_text
+            ),
             "controllers": _parse_controllers(controllers_text),
             "unavailable": unavailable,
         }

--- a/tests/test_devhub_device_overview.py
+++ b/tests/test_devhub_device_overview.py
@@ -1,0 +1,219 @@
+import ast
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from vr_hotspotd.devtools.adb_operations import RESULT_INVALID_REQUEST, RESULT_OK
+from vr_hotspotd.devtools.device_overview import collect_device_overview
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERVIEW_PY = ROOT / "backend" / "vr_hotspotd" / "devtools" / "device_overview.py"
+OVERVIEW_JS = ROOT / "assets" / "devhub_device_overview.js"
+OVERVIEW_CSS = ROOT / "assets" / "devhub_device_overview.css"
+LOADER = ROOT / "assets" / "field_visibility.js"
+DEVHUB_API = ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py"
+
+
+TOOLS_STATUS = {"adb": {"path": "/managed/adb"}}
+
+
+class OverviewRunner:
+    def __init__(self, *, controller_service=True):
+        self.controller_service = controller_service
+        self.calls = []
+
+    def __call__(self, argv, **_kwargs):
+        self.calls.append(tuple(argv))
+        command = tuple(argv[4:])
+        outputs = {
+            ("getprop",): "\n".join(
+                [
+                    "[ro.product.manufacturer]: [Meta]",
+                    "[ro.product.model]: [Quest 3S]",
+                    "[ro.product.name]: [panther]",
+                    "[ro.product.device]: [panther]",
+                    "[ro.build.version.release]: [12]",
+                    "[ro.build.version.sdk]: [32]",
+                    "[ro.build.display.id]: [SQ3A.220605.009.A1]",
+                    "[ro.build.version.security_patch]: [2026-07-01]",
+                ]
+            ),
+            ("dumpsys", "battery"): "\n".join(
+                [
+                    "AC powered: false",
+                    "USB powered: true",
+                    "Wireless powered: false",
+                    "status: 2",
+                    "level: 73",
+                    "scale: 100",
+                    "voltage: 4120",
+                    "temperature: 315",
+                ]
+            ),
+            ("df", "-k", "/data"): "\n".join(
+                [
+                    "Filesystem 1K-blocks Used Available Use% Mounted on",
+                    "/dev/block/dm-10 104857600 52428800 52428800 50% /data",
+                ]
+            ),
+            ("cmd", "wifi", "status"): (
+                "Wifi is enabled\n"
+                "WifiInfo: SSID: \"Lab WiFi\", BSSID: aa:bb:cc:dd:ee:ff, "
+                "RSSI: -51, Link speed: 1200Mbps, Frequency: 5180MHz"
+            ),
+            ("ip", "route"): (
+                "default via 192.168.0.1 dev wlan0\n"
+                "192.168.0.0/24 dev wlan0 src 192.168.0.98"
+            ),
+            ("cat", "/proc/uptime"): "93784.25 12000.00",
+        }
+        if command == ("dumpsys", "OVRRemoteService"):
+            if not self.controller_service:
+                output = "Can't find service: OVRRemoteService"
+            else:
+                output = "\n".join(
+                    [
+                        "Paired device: hidden, Type: Right, Firmware: 1.9.0, Battery: 60%, Status: Enabled, ExternalStatus: ENABLED, TrackingStatus: POSITION, BrightnessLevel: GOOD",
+                        "Paired device: hidden, Type: Left, Firmware: 1.9.0, Battery: 80%, Status: Enabled, ExternalStatus: ENABLED, TrackingStatus: POSITION, BrightnessLevel: GOOD",
+                    ]
+                )
+        else:
+            output = outputs.get(command, "")
+        return subprocess.CompletedProcess(argv, 0, stdout=output.encode(), stderr=b"")
+
+
+def test_collect_device_overview_normalizes_headset_health_and_controller_data():
+    runner = OverviewRunner()
+
+    result = collect_device_overview(
+        "192.168.0.98:5555",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+    )
+
+    assert result["result_code"] == RESULT_OK
+    assert result["success"] is True
+    data = result["data"]
+    assert data["transport"] == "wireless"
+    assert data["device"]["manufacturer"] == "Meta"
+    assert data["device"]["model"] == "Quest 3S"
+    assert data["device"]["android_release"] == "12"
+    assert data["device"]["android_sdk"] == 32
+    assert data["battery"] == {
+        "percent": 73,
+        "status": "charging",
+        "charging": True,
+        "power_sources": ["USB"],
+        "temperature_c": 31.5,
+        "voltage_mv": 4120,
+    }
+    assert data["storage"]["available_bytes"] == 52428800 * 1024
+    assert data["wifi"]["ssid"] == "Lab WiFi"
+    assert data["wifi"]["rssi_dbm"] == -51
+    assert data["wifi"]["link_speed_mbps"] == 1200
+    assert data["wifi"]["ip_address"] == "192.168.0.98"
+    assert data["uptime_seconds"] == 93784
+    assert data["controller_service_available"] is True
+    assert [controller["side"] for controller in data["controllers"]] == [
+        "Right",
+        "Left",
+    ]
+    assert [controller["battery_percent"] for controller in data["controllers"]] == [
+        60,
+        80,
+    ]
+    assert all(call[0] == "/managed/adb" for call in runner.calls)
+    assert all("sh" not in call and "bash" not in call for call in runner.calls)
+
+
+def test_collect_device_overview_treats_missing_quest_controller_service_as_optional():
+    result = collect_device_overview(
+        "USB123",
+        tools_status=TOOLS_STATUS,
+        runner=OverviewRunner(controller_service=False),
+    )
+
+    assert result["result_code"] == RESULT_OK
+    assert result["data"]["transport"] == "usb"
+    assert result["data"]["controller_service_available"] is False
+    assert result["data"]["controllers"] == []
+
+
+def test_collect_device_overview_rejects_unstructured_serial_input():
+    result = collect_device_overview(
+        "device; reboot",
+        tools_status=TOOLS_STATUS,
+        runner=OverviewRunner(),
+    )
+
+    assert result["result_code"] == RESULT_INVALID_REQUEST
+    assert result["success"] is False
+
+
+def test_device_overview_route_and_assets_are_registered():
+    api_source = DEVHUB_API.read_text(encoding="utf-8")
+    loader_source = LOADER.read_text(encoding="utf-8")
+
+    assert 'DEVICE_OVERVIEW_PATH = "/v1/devbridge/adb/device-overview"' in api_source
+    assert "collect_device_overview" in api_source
+    assert '"/assets/devhub_device_overview.css": "text/css; charset=utf-8"' in api_source
+    assert (
+        '"/assets/devhub_device_overview.js": "application/javascript; charset=utf-8"'
+        in api_source
+    )
+    assert "'/assets/devhub_device_overview.css'" in loader_source
+    assert "'/assets/devhub_device_overview.js'" in loader_source
+    assert loader_source.index("'/assets/devhub_workspace.js'") < loader_source.index(
+        "'/assets/devhub_device_overview.js'"
+    )
+
+
+def test_device_page_replaces_quick_actions_with_live_headset_information():
+    source = OVERVIEW_JS.read_text(encoding="utf-8")
+
+    assert "title.textContent = 'Headset Overview'" in source
+    assert "body.replaceChildren(empty, content)" in source
+    assert "Headset battery" in source
+    assert "Storage" in source
+    assert "Wi-Fi" in source
+    assert "Network quality" in source
+    assert "IP address" in source
+    assert "System" in source
+    assert "Build" in source
+    assert "Uptime" in source
+    assert "Controllers" in source
+    assert "Quick Actions" in source  # source card lookup only
+    assert "setInterval(() => void refreshOverview(false), REFRESH_MS)" in source
+
+
+def test_device_overview_python_keeps_python39_grammar():
+    ast.parse(OVERVIEW_PY.read_text(encoding="utf-8"), feature_version=(3, 9))
+
+
+@pytest.mark.parametrize("asset", [OVERVIEW_JS, LOADER])
+def test_device_overview_javascript_parses_with_node(asset):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is not available")
+
+    completed = subprocess.run(
+        [node, "--check", str(asset)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_device_overview_styles_are_responsive_and_use_no_status_lights():
+    source = OVERVIEW_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-overview-metrics" in source
+    assert ".devhub-controller-row" in source
+    assert "@media (max-width: 720px)" in source
+    assert "status-light" not in source
+    assert "box-shadow: 0 0" not in source


### PR DESCRIPTION
## Summary

Replace the redundant Developer Hub Quick Actions panel with an MDM-style live headset overview.

## Device overview

- Headset battery and charging state.
- Free and total storage.
- Current Wi-Fi network, RSSI, link speed, IP address, and gateway when Android reports them.
- Android release, SDK level, firmware build, security patch, and uptime.
- USB or wireless ADB transport.
- Meta Quest controller battery, firmware, state, and tracking data when `OVRRemoteService` exposes it.
- Clean empty and unsupported states for devices that do not expose optional telemetry.

## API

Adds authenticated read-only endpoint:

- `GET /v1/devbridge/adb/device-overview?serial=...`

The backend executes only fixed allowlisted ADB argv sequences. It does not accept arbitrary shell commands or arguments.

## Interface

- Replaces Quick Actions at runtime with **Headset Overview**.
- Keeps Apps, Connection, and Tools as the navigation for those workflows.
- Refreshes detailed telemetry every 15 seconds while Developer Hub is visible.
- Reuses the shared `ⓘ` tooltip system.
- Uses no decorative status lights.

## Validation

- Parser and normalization coverage for properties, battery, storage, Wi-Fi, uptime, and Quest controllers.
- Invalid serial rejection and fixed-command coverage.
- Asset loader, route registration, responsive CSS, Python 3.9 grammar, and Node syntax contracts.
- Full repository CI matrix.