### PR TITLE
Use headset model as Developer Hub device identity

### DIFF
--- a/assets/devhub_device_identity.css
+++ b/assets/devhub_device_identity.css
@@ -1,0 +1,61 @@
+#devhubSelectedDevice.devhub-raw-device-serial {
+  display: none !important;
+}
+
+.devhub-selected-device-display {
+  display: grid;
+  gap: 4px;
+  min-height: 44px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--accent-primary);
+  background: var(--accent-subtle);
+}
+
+.devhub-selected-device-display.empty {
+  border-left-color: var(--border-subtle);
+}
+
+.devhub-selected-device-name {
+  color: var(--text-main);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.devhub-selected-device-address {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.devhub-device-model {
+  color: var(--text-main);
+  font-weight: 700;
+}
+
+.devhub-device-identity-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.devhub-device-identity-meta > span + span::before {
+  content: "·";
+  margin-right: 7px;
+  color: var(--text-muted);
+}
+
+.devhub-device-address {
+  font-family: var(--font-mono);
+}
+
+.devhub-privacy-active .devhub-sensitive-identifier {
+  display: none !important;
+}
+
+.devhub-privacy-active .devhub-device-identity-meta > span + span::before {
+  content: none;
+}

--- a/assets/devhub_device_identity.css
+++ b/assets/devhub_device_identity.css
@@ -42,10 +42,8 @@
   flex-wrap: wrap;
 }
 
-.devhub-device-identity-meta > span + span::before {
-  content: "·";
-  margin-right: 7px;
-  color: var(--text-muted);
+.devhub-device-model-source {
+  display: none;
 }
 
 .devhub-device-address {
@@ -54,8 +52,4 @@
 
 .devhub-privacy-active .devhub-sensitive-identifier {
   display: none !important;
-}
-
-.devhub-privacy-active .devhub-device-identity-meta > span + span::before {
-  content: none;
 }

--- a/assets/devhub_device_identity.js
+++ b/assets/devhub_device_identity.js
@@ -55,11 +55,15 @@
         stateNode.className = 'devhub-device-state';
         stateNode.textContent = state;
 
+        const modelSource = document.createElement('span');
+        modelSource.className = 'devhub-device-model-source';
+        modelSource.textContent = ` · model ${model}`;
+
         const addressNode = document.createElement('span');
         addressNode.className = 'devhub-device-address devhub-sensitive-identifier';
-        addressNode.textContent = serial;
+        addressNode.textContent = ` · ${serial}`;
 
-        meta.replaceChildren(stateNode, addressNode);
+        meta.replaceChildren(stateNode, modelSource, addressNode);
         meta.classList.add('devhub-device-identity-meta');
       }
     });

--- a/assets/devhub_device_identity.js
+++ b/assets/devhub_device_identity.js
@@ -1,0 +1,205 @@
+(function addDeveloperHubDeviceIdentityPrivacy() {
+  'use strict';
+
+  const HIDDEN_VALUE = 'Hidden by Privacy Mode';
+  const EMPTY_SERIALS = new Set(['', '--', 'no device selected', 'no headset selected']);
+  let syncQueued = false;
+  let tabObserver = null;
+
+  function el(id) { return document.getElementById(id); }
+
+  function normalized(value) {
+    return String(value || '').replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function normalizedSerial(value) {
+    const serial = String(value || '').trim();
+    return EMPTY_SERIALS.has(serial.toLowerCase()) ? '' : serial;
+  }
+
+  function privacyEnabled() {
+    const privacy = el('privacyMode');
+    return !!(privacy && privacy.checked);
+  }
+
+  function modelFromMeta(metaText) {
+    const match = String(metaText || '').match(/(?:^|·)\s*model\s+([^·]+)/i);
+    return normalized(match ? match[1] : '');
+  }
+
+  function stateFromMeta(metaText) {
+    return normalized(String(metaText || '').split('·')[0]) || 'ADB device';
+  }
+
+  function prepareDeviceRows() {
+    document.querySelectorAll('#devhubDeviceList .devhub-list-item').forEach((row) => {
+      const title = row.querySelector('.devhub-list-title');
+      const meta = row.querySelector('.devhub-list-meta');
+      if (!title || !meta) return;
+
+      if (row.dataset.devhubIdentityReady !== '1') {
+        const serial = normalizedSerial(title.textContent);
+        const originalMeta = meta.textContent || '';
+        const model = modelFromMeta(originalMeta) || 'Android XR headset';
+        const state = stateFromMeta(originalMeta);
+
+        row.dataset.devhubIdentityReady = '1';
+        row.dataset.devhubSerial = serial;
+        row.dataset.devhubModel = model;
+        row.dataset.devhubState = state;
+
+        title.textContent = model;
+        title.classList.add('devhub-device-model');
+
+        const stateNode = document.createElement('span');
+        stateNode.className = 'devhub-device-state';
+        stateNode.textContent = state;
+
+        const addressNode = document.createElement('span');
+        addressNode.className = 'devhub-device-address devhub-sensitive-identifier';
+        addressNode.textContent = serial;
+
+        meta.replaceChildren(stateNode, addressNode);
+        meta.classList.add('devhub-device-identity-meta');
+      }
+    });
+  }
+
+  function selectedRow() {
+    return document.querySelector('#devhubDeviceList .devhub-list-item.selected');
+  }
+
+  function selectedIdentity() {
+    const row = selectedRow();
+    const serial = normalizedSerial((el('devhubSelectedDevice') || {}).textContent);
+    const fallbackModel = normalized((el('devhubWorkspaceDeviceName') || {}).textContent);
+    return {
+      serial,
+      model: normalized(row && row.dataset.devhubModel)
+        || fallbackModel
+        || (serial ? 'Android XR headset' : 'No headset selected'),
+    };
+  }
+
+  function ensureSelectedDisplay() {
+    const raw = el('devhubSelectedDevice');
+    if (!raw || !raw.parentNode) return null;
+
+    raw.classList.add('devhub-raw-device-serial');
+
+    let display = el('devhubSelectedDeviceIdentity');
+    if (!display) {
+      display = document.createElement('div');
+      display.id = 'devhubSelectedDeviceIdentity';
+      display.className = 'devhub-selected-device-display';
+
+      const name = document.createElement('div');
+      name.id = 'devhubSelectedDeviceName';
+      name.className = 'devhub-selected-device-name';
+
+      const address = document.createElement('div');
+      address.id = 'devhubSelectedDeviceAddress';
+      address.className = 'devhub-selected-device-address devhub-sensitive-identifier';
+
+      display.append(name, address);
+      raw.parentNode.insertBefore(display, raw.nextSibling);
+    }
+    return display;
+  }
+
+  function setText(id, value) {
+    const node = el(id);
+    if (node && node.textContent !== value) node.textContent = value;
+  }
+
+  function syncSelectedDisplay() {
+    const display = ensureSelectedDisplay();
+    if (!display) return;
+
+    const identity = selectedIdentity();
+    setText('devhubSelectedDeviceName', identity.model);
+    setText('devhubSelectedDeviceAddress', identity.serial);
+    display.classList.toggle('empty', !identity.serial);
+  }
+
+  function syncTopIdentity(privacy) {
+    const serial = el('devhubWorkspaceDeviceSerial');
+    if (!serial) return;
+    serial.classList.add('devhub-sensitive-identifier');
+    serial.hidden = privacy;
+  }
+
+  function syncOverviewIp(privacy) {
+    const ip = el('devhubOverviewIp');
+    if (!ip) return;
+
+    const value = String(ip.textContent || '').trim();
+    if (privacy) {
+      if (value && value !== HIDDEN_VALUE && value !== 'Not reported' && value !== '--') {
+        ip.dataset.devhubActualValue = value;
+      }
+      if (value !== HIDDEN_VALUE) ip.textContent = HIDDEN_VALUE;
+      return;
+    }
+
+    if (value === HIDDEN_VALUE && ip.dataset.devhubActualValue) {
+      ip.textContent = ip.dataset.devhubActualValue;
+    }
+  }
+
+  function bindPrivacyToggle() {
+    const privacy = el('privacyMode');
+    if (!privacy || privacy.dataset.devhubIdentityBound === '1') return;
+    privacy.dataset.devhubIdentityBound = '1';
+    privacy.addEventListener('change', scheduleSync);
+  }
+
+  function sync() {
+    const privacy = privacyEnabled();
+    document.documentElement.classList.toggle('devhub-privacy-active', privacy);
+    bindPrivacyToggle();
+    prepareDeviceRows();
+    syncSelectedDisplay();
+    syncTopIdentity(privacy);
+    syncOverviewIp(privacy);
+  }
+
+  function scheduleSync() {
+    if (syncQueued) return;
+    syncQueued = true;
+    window.requestAnimationFrame(() => {
+      syncQueued = false;
+      sync();
+    });
+  }
+
+  function observeTab() {
+    const tab = el('tab-devhub');
+    if (!tab || tabObserver) return false;
+
+    tabObserver = new MutationObserver(scheduleSync);
+    tabObserver.observe(tab, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['class', 'hidden'],
+    });
+    scheduleSync();
+    return true;
+  }
+
+  function start() {
+    if (observeTab()) return;
+    const startupObserver = new MutationObserver(() => {
+      if (observeTab()) startupObserver.disconnect();
+    });
+    startupObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -71,6 +71,11 @@ window.UI_FIELD_VISIBILITY = {
   overviewStylesheet.href = '/assets/devhub_device_overview.css';
   document.head.appendChild(overviewStylesheet);
 
+  const identityStylesheet = document.createElement('link');
+  identityStylesheet.rel = 'stylesheet';
+  identityStylesheet.href = '/assets/devhub_device_identity.css';
+  document.head.appendChild(identityStylesheet);
+
   const script = document.createElement('script');
   script.src = '/assets/devhub.js';
   script.async = false;
@@ -90,6 +95,11 @@ window.UI_FIELD_VISIBILITY = {
   overviewScript.src = '/assets/devhub_device_overview.js';
   overviewScript.async = false;
   document.head.appendChild(overviewScript);
+
+  const identityScript = document.createElement('script');
+  identityScript.src = '/assets/devhub_device_identity.js';
+  identityScript.async = false;
+  document.head.appendChild(identityScript);
 })();
 
 (function addManagedPlatformToolsControls() {

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -49,6 +49,8 @@ _DEVHUB_ASSET_TYPES = {
     "/assets/devhub_workspace.js": "application/javascript; charset=utf-8",
     "/assets/devhub_device_overview.css": "text/css; charset=utf-8",
     "/assets/devhub_device_overview.js": "application/javascript; charset=utf-8",
+    "/assets/devhub_device_identity.css": "text/css; charset=utf-8",
+    "/assets/devhub_device_identity.js": "application/javascript; charset=utf-8",
 }
 
 _GET_OPERATIONS = {

--- a/tests/test_devhub_device_identity_privacy.py
+++ b/tests/test_devhub_device_identity_privacy.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSETS = ROOT / "assets"
+IDENTITY_JS = ASSETS / "devhub_device_identity.js"
+IDENTITY_CSS = ASSETS / "devhub_device_identity.css"
+FIELD_VISIBILITY = ASSETS / "field_visibility.js"
+DEVHUB_API = ROOT / "backend/vr_hotspotd/devtools/devhub_api.py"
+INDEX = ASSETS / "index.html"
+
+
+def test_identity_assets_are_loaded_after_device_overview() -> None:
+    loader = FIELD_VISIBILITY.read_text(encoding="utf-8")
+
+    assert "/assets/devhub_device_identity.css" in loader
+    assert "/assets/devhub_device_identity.js" in loader
+    assert loader.index("/assets/devhub_device_identity.css") > loader.index(
+        "/assets/devhub_device_overview.css"
+    )
+    assert loader.index("/assets/devhub_device_identity.js") > loader.index(
+        "/assets/devhub_device_overview.js"
+    )
+
+
+def test_identity_assets_are_served_by_devhub_handler() -> None:
+    source = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert '"/assets/devhub_device_identity.css": "text/css; charset=utf-8"' in source
+    assert (
+        '"/assets/devhub_device_identity.js": '
+        '"application/javascript; charset=utf-8"'
+    ) in source
+
+
+def test_model_first_identity_and_privacy_contract() -> None:
+    source = IDENTITY_JS.read_text(encoding="utf-8")
+    index = INDEX.read_text(encoding="utf-8")
+
+    assert 'el("privacyMode")' in source or "el('privacyMode')" in source
+    assert 'id="privacyMode"' in index
+    assert "modelFromMeta" in source
+    assert "devhubSelectedDeviceName" in source
+    assert "devhubWorkspaceDeviceSerial" in source
+    assert "devhubOverviewIp" in source
+    assert "Hidden by Privacy Mode" in source
+    assert "devhub-sensitive-identifier" in source
+    assert "devhub-device-model-source" in source
+
+
+def test_privacy_css_hides_sensitive_identifiers_only_when_enabled() -> None:
+    source = IDENTITY_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-privacy-active .devhub-sensitive-identifier" in source
+    assert "display: none !important" in source
+    assert ".devhub-device-model-source" in source
+
+
+def test_identity_javascript_syntax() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+
+    subprocess.run(
+        [node, "--check", str(IDENTITY_JS)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

Make the Developer Hub consistently present the headset model as the primary device identity and integrate network-identifier redaction with the existing Privacy Mode.

## Interface

- Show `Quest 3S` (or the reported model) as the ADB device title instead of the IP-based ADB serial.
- Show the model in the selected-headset field while retaining the serial internally for all operations.
- Keep the ADB address as secondary transport metadata when Privacy Mode is off.
- Preserve the hidden model metadata consumed by the existing workspace header.

## Privacy Mode

When Privacy Mode is enabled, hide/redact:

- The address under the main headset title.
- The address in the selected-headset field.
- ADB device-list addresses.
- The IP Address value in Headset Overview.

The actual serial remains unchanged in application state so connect, disconnect, package, APK, and app-control actions continue to target the correct headset.

## Validation

- Asset load order and authenticated asset-serving contracts.
- Model-first identity and privacy-mode DOM contracts.
- Privacy CSS contract.
- Node syntax validation.
- Full repository CI matrix.