### PR TITLE
Replace Connection tab with guided wireless headset setup

### DIFF
--- a/assets/devhub_connection_wizard.css
+++ b/assets/devhub_connection_wizard.css
@@ -1,0 +1,280 @@
+.devhub-headsets-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.devhub-headsets-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.devhub-unified-discovery {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.devhub-unified-discovery[hidden] {
+  display: none !important;
+}
+
+.devhub-unified-section-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 10px;
+}
+
+.devhub-unified-section-title h3 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.devhub-advanced-connection {
+  grid-column: 1 / -1;
+}
+
+.devhub-advanced-connection details {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+}
+
+.devhub-advanced-connection summary {
+  cursor: pointer;
+  padding: 13px 14px;
+  color: var(--text-main);
+  font-weight: 700;
+  user-select: none;
+}
+
+.devhub-advanced-connection details[open] summary {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.devhub-advanced-connection-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 12px;
+}
+
+.devhub-advanced-connection-grid > .card {
+  min-width: 0;
+  margin: 0;
+}
+
+body.devhub-modal-open {
+  overflow: hidden;
+}
+
+.devhub-wizard-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, .72);
+  backdrop-filter: blur(5px);
+}
+
+.devhub-wizard-overlay[hidden] {
+  display: none !important;
+}
+
+.devhub-wizard-dialog {
+  width: min(760px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, .6);
+}
+
+.devhub-wizard-header,
+.devhub-wizard-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 18px;
+}
+
+.devhub-wizard-header {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.devhub-wizard-header h2 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 18px;
+}
+
+.devhub-wizard-header .btn {
+  margin-left: auto;
+}
+
+.devhub-wizard-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 16px 18px 0;
+}
+
+.devhub-wizard-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+}
+
+.devhub-wizard-step > span {
+  display: grid;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.devhub-wizard-step strong {
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.devhub-wizard-step.current {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  background: var(--accent-subtle);
+}
+
+.devhub-wizard-step.complete {
+  color: var(--success);
+}
+
+.devhub-wizard-body {
+  min-height: 250px;
+  display: grid;
+  align-content: center;
+  gap: 12px;
+  padding: 28px 24px;
+  text-align: center;
+}
+
+.devhub-wizard-body h3 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 21px;
+}
+
+.devhub-wizard-body p {
+  max-width: 580px;
+  margin: 0 auto;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.devhub-wizard-device {
+  width: min(520px, 100%);
+  display: grid;
+  gap: 6px;
+  margin: 8px auto 0;
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  text-align: left;
+}
+
+.devhub-wizard-device[hidden] {
+  display: none !important;
+}
+
+.devhub-wizard-device strong {
+  color: var(--text-main);
+}
+
+.devhub-wizard-device > span {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.devhub-wizard-device label {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.devhub-wizard-device select {
+  width: 100%;
+  min-height: 38px;
+}
+
+.devhub-wizard-footer {
+  justify-content: flex-end;
+  border-top: 1px solid var(--border-subtle);
+}
+
+@media (max-width: 900px) {
+  .devhub-advanced-connection-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .devhub-wizard-steps {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .devhub-headsets-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .devhub-headsets-actions {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .devhub-wizard-overlay {
+    padding: 10px;
+  }
+
+  .devhub-wizard-dialog {
+    max-height: calc(100vh - 20px);
+  }
+
+  .devhub-wizard-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .devhub-wizard-header,
+  .devhub-wizard-footer {
+    padding: 14px;
+  }
+
+  .devhub-wizard-body {
+    padding: 24px 16px;
+  }
+}

--- a/assets/devhub_connection_wizard.js
+++ b/assets/devhub_connection_wizard.js
@@ -1,0 +1,606 @@
+(function addDeveloperHubConnectionWizard() {
+  'use strict';
+
+  const DEVICES_PATH = '/v1/devbridge/adb/devices';
+  const CONNECT_PATH = '/v1/devbridge/adb/connect';
+  const ENABLE_WIRELESS_PATH = '/v1/devbridge/adb/enable-wireless';
+  const WORKSPACE_VIEW_KEY = 'vrhs_devhub_workspace_view';
+  const POLL_MS = 1600;
+
+  let pollTimer = null;
+  let selectedUsbSerial = '';
+  let usbDevices = [];
+  let setupComplete = false;
+  let requestRunning = false;
+  let candidateObserver = null;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function infoTip(text) {
+    const tip = document.createElement('span');
+    tip.className = 'tip devhub-info-tip';
+    tip.textContent = 'ⓘ';
+    tip.setAttribute('data-tip', text);
+    tip.setAttribute('aria-label', text);
+    tip.setAttribute('tabindex', '0');
+    return tip;
+  }
+
+  function normalized(value) {
+    return String(value || '').replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  function operationData(response) {
+    return response && response.json && response.json.data
+      ? response.json.data
+      : {};
+  }
+
+  function nestedData(response) {
+    const result = operationData(response);
+    return result && result.data && typeof result.data === 'object'
+      ? result.data
+      : {};
+  }
+
+  function responseMessage(response, fallback) {
+    const result = operationData(response);
+    return String(
+      (result && result.message)
+      || (response && response.json && response.json.message)
+      || fallback,
+    );
+  }
+
+  function feedback(message, state) {
+    const node = el('devhubFeedback');
+    if (!node) return;
+    node.textContent = message;
+    node.dataset.state = state || 'idle';
+  }
+
+  async function getDevices() {
+    if (typeof api !== 'function') return [];
+    const response = await api(DEVICES_PATH);
+    if (!response.ok) throw new Error(responseMessage(response, 'Unable to inspect ADB devices.'));
+    const data = nestedData(response);
+    return Array.isArray(data.devices) ? data.devices : [];
+  }
+
+  function isUsbDevice(device) {
+    const serial = String((device && device.serial) || '').trim();
+    if (!serial || serial.includes(':')) return false;
+    const props = device && device.properties && typeof device.properties === 'object'
+      ? device.properties
+      : {};
+    return !!props.usb || !serial.includes(':');
+  }
+
+  function deviceModel(device) {
+    const props = device && device.properties && typeof device.properties === 'object'
+      ? device.properties
+      : {};
+    return normalized(props.model || props.product || 'Android XR headset');
+  }
+
+  function cardByTitle(panel, title) {
+    return Array.from(panel.querySelectorAll(':scope > .devhub-workspace-grid > .card')).find((card) => {
+      const heading = card.querySelector('.card-header h2');
+      return heading && heading.textContent.trim() === title;
+    }) || null;
+  }
+
+  function setWizardStep(step) {
+    document.querySelectorAll('.devhub-wizard-step').forEach((node) => {
+      const value = Number(node.dataset.step);
+      node.classList.toggle('current', value === step);
+      node.classList.toggle('complete', value < step);
+    });
+  }
+
+  function setWizardCopy(title, detail) {
+    const titleNode = el('devhubWizardTitle');
+    const detailNode = el('devhubWizardDetail');
+    if (titleNode) titleNode.textContent = title;
+    if (detailNode) detailNode.textContent = detail;
+  }
+
+  function renderUsbDevice(device) {
+    const box = el('devhubWizardDevice');
+    if (!box) return;
+    box.replaceChildren();
+
+    if (!device) {
+      box.hidden = true;
+      return;
+    }
+
+    box.hidden = false;
+    const name = document.createElement('strong');
+    name.textContent = deviceModel(device);
+    const serial = document.createElement('span');
+    serial.className = 'devhub-sensitive-identifier';
+    serial.textContent = String(device.serial || '');
+    box.append(name, serial);
+
+    if (usbDevices.length > 1) {
+      const label = document.createElement('label');
+      label.textContent = 'USB headset';
+      const select = document.createElement('select');
+      select.id = 'devhubWizardUsbSelect';
+      for (const candidate of usbDevices) {
+        const option = document.createElement('option');
+        option.value = String(candidate.serial || '');
+        option.textContent = `${deviceModel(candidate)} — ${candidate.state || 'unknown'}`;
+        option.selected = option.value === selectedUsbSerial;
+        select.appendChild(option);
+      }
+      select.addEventListener('change', () => {
+        selectedUsbSerial = select.value;
+        renderWizardState();
+      });
+      label.appendChild(select);
+      box.appendChild(label);
+    }
+  }
+
+  function chosenUsbDevice() {
+    return usbDevices.find((device) => String(device.serial || '') === selectedUsbSerial)
+      || usbDevices.find((device) => device.state === 'device')
+      || usbDevices[0]
+      || null;
+  }
+
+  function renderWizardState() {
+    const action = el('devhubWizardAction');
+    const device = chosenUsbDevice();
+    if (!action) return;
+
+    if (setupComplete) {
+      setWizardStep(4);
+      action.disabled = false;
+      action.textContent = 'Done';
+      renderUsbDevice(device);
+      return;
+    }
+
+    renderUsbDevice(device);
+    action.textContent = 'Enable Wireless ADB';
+
+    if (!device) {
+      setWizardStep(1);
+      setWizardCopy(
+        'Connect the headset by USB',
+        'Use a data-capable USB cable. VRhotspot will detect the headset automatically.',
+      );
+      action.disabled = true;
+      return;
+    }
+
+    if (String(device.state || '').toLowerCase() === 'unauthorized') {
+      setWizardStep(2);
+      setWizardCopy(
+        'Approve USB debugging inside the headset',
+        'Put on the headset, enable “Always allow from this computer,” and select Allow.',
+      );
+      action.disabled = true;
+      return;
+    }
+
+    if (String(device.state || '').toLowerCase() !== 'device') {
+      setWizardStep(1);
+      setWizardCopy(
+        'Waiting for the USB headset',
+        `The headset currently reports “${device.state || 'unknown'}.” Reconnect the cable and keep it awake.`,
+      );
+      action.disabled = true;
+      return;
+    }
+
+    setWizardStep(3);
+    setWizardCopy(
+      `${deviceModel(device)} is ready`,
+      'VRhotspot will read its Wi-Fi address, enable wireless ADB, and connect it automatically.',
+    );
+    action.disabled = requestRunning;
+  }
+
+  async function pollUsbDevices() {
+    if (requestRunning || !el('devhubWirelessWizard') || el('devhubWirelessWizard').hidden) return;
+    try {
+      usbDevices = (await getDevices()).filter(isUsbDevice);
+      if (!usbDevices.some((device) => String(device.serial || '') === selectedUsbSerial)) {
+        const preferred = usbDevices.find((device) => device.state === 'device') || usbDevices[0];
+        selectedUsbSerial = preferred ? String(preferred.serial || '') : '';
+      }
+      renderWizardState();
+    } catch (error) {
+      setWizardCopy('Unable to inspect USB devices', String(error.message || error));
+    }
+  }
+
+  async function selectWirelessTarget(target) {
+    const refresh = el('devhubRefresh');
+    if (refresh) refresh.click();
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      await new Promise((resolve) => window.setTimeout(resolve, 450));
+      const rows = document.querySelectorAll('#devhubDeviceList .devhub-list-item');
+      const row = Array.from(rows).find((candidate) => {
+        if (candidate.dataset.devhubSerial === target) return true;
+        const address = candidate.querySelector('.devhub-device-address');
+        return address && String(address.textContent || '').includes(target);
+      });
+      if (!row) continue;
+      const choose = row.querySelector('button');
+      if (choose) choose.click();
+      return;
+    }
+  }
+
+  async function enableWireless() {
+    if (setupComplete) {
+      closeWizard();
+      return;
+    }
+
+    const device = chosenUsbDevice();
+    if (!device || device.state !== 'device' || requestRunning) return;
+
+    requestRunning = true;
+    renderWizardState();
+    setWizardCopy(
+      'Enabling wireless connection',
+      'Keep the headset awake and connected to Wi-Fi. This usually takes only a few seconds.',
+    );
+
+    try {
+      const response = await api(ENABLE_WIRELESS_PATH, {
+        method: 'POST',
+        body: JSON.stringify({ serial: String(device.serial || ''), port: 5555 }),
+      });
+      const result = operationData(response);
+      if (!response.ok || !result.success) {
+        throw new Error(responseMessage(response, 'Wireless setup failed.'));
+      }
+
+      const data = result.data && typeof result.data === 'object' ? result.data : {};
+      const target = String(data.target || '');
+      setupComplete = true;
+      setWizardCopy(
+        `${normalized(data.model || deviceModel(device))} is connected wirelessly`,
+        'You can disconnect the USB cable. VRhotspot will keep using the wireless connection.',
+      );
+      feedback('Wireless headset setup completed.', 'success');
+      renderWizardState();
+      if (target) await selectWirelessTarget(target);
+    } catch (error) {
+      setWizardStep(3);
+      setWizardCopy('Wireless setup needs attention', String(error.message || error));
+      feedback(String(error.message || error), 'error');
+    } finally {
+      requestRunning = false;
+      renderWizardState();
+    }
+  }
+
+  function startPolling() {
+    if (pollTimer) window.clearInterval(pollTimer);
+    void pollUsbDevices();
+    pollTimer = window.setInterval(pollUsbDevices, POLL_MS);
+  }
+
+  function stopPolling() {
+    if (pollTimer) window.clearInterval(pollTimer);
+    pollTimer = null;
+  }
+
+  function openWizard() {
+    const modal = el('devhubWirelessWizard');
+    if (!modal) return;
+    setupComplete = false;
+    requestRunning = false;
+    usbDevices = [];
+    selectedUsbSerial = '';
+    modal.hidden = false;
+    document.body.classList.add('devhub-modal-open');
+    renderWizardState();
+    startPolling();
+    const close = el('devhubWizardClose');
+    if (close) close.focus();
+  }
+
+  function closeWizard() {
+    const modal = el('devhubWirelessWizard');
+    if (!modal) return;
+    modal.hidden = true;
+    document.body.classList.remove('devhub-modal-open');
+    stopPolling();
+    const trigger = el('devhubWirelessSetup');
+    if (trigger) trigger.focus();
+  }
+
+  function buildWizard() {
+    if (el('devhubWirelessWizard')) return;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'devhubWirelessWizard';
+    overlay.className = 'devhub-wizard-overlay';
+    overlay.hidden = true;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'devhubWizardHeading');
+
+    const dialog = document.createElement('div');
+    dialog.className = 'devhub-wizard-dialog';
+
+    const header = document.createElement('div');
+    header.className = 'devhub-wizard-header';
+    const heading = document.createElement('h2');
+    heading.id = 'devhubWizardHeading';
+    heading.textContent = 'Set up wireless headset';
+    const close = document.createElement('button');
+    close.id = 'devhubWizardClose';
+    close.type = 'button';
+    close.className = 'btn sm secondary';
+    close.textContent = 'Close';
+    close.addEventListener('click', closeWizard);
+    header.append(heading, close);
+
+    const steps = document.createElement('div');
+    steps.className = 'devhub-wizard-steps';
+    ['Connect USB', 'Approve', 'Enable wireless', 'Complete'].forEach((label, index) => {
+      const step = document.createElement('div');
+      step.className = 'devhub-wizard-step';
+      step.dataset.step = String(index + 1);
+      const number = document.createElement('span');
+      number.textContent = String(index + 1);
+      const copy = document.createElement('strong');
+      copy.textContent = label;
+      step.append(number, copy);
+      steps.appendChild(step);
+    });
+
+    const body = document.createElement('div');
+    body.className = 'devhub-wizard-body';
+    const title = document.createElement('h3');
+    title.id = 'devhubWizardTitle';
+    const detail = document.createElement('p');
+    detail.id = 'devhubWizardDetail';
+    const device = document.createElement('div');
+    device.id = 'devhubWizardDevice';
+    device.className = 'devhub-wizard-device';
+    device.hidden = true;
+    body.append(title, detail, device);
+
+    const footer = document.createElement('div');
+    footer.className = 'devhub-wizard-footer';
+    const cancel = document.createElement('button');
+    cancel.type = 'button';
+    cancel.className = 'btn secondary';
+    cancel.textContent = 'Cancel';
+    cancel.addEventListener('click', closeWizard);
+    const action = document.createElement('button');
+    action.id = 'devhubWizardAction';
+    action.type = 'button';
+    action.className = 'btn primary';
+    action.textContent = 'Enable Wireless ADB';
+    action.disabled = true;
+    action.addEventListener('click', () => void enableWireless());
+    footer.append(cancel, action);
+
+    dialog.append(header, steps, body, footer);
+    overlay.appendChild(dialog);
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) closeWizard();
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !overlay.hidden) closeWizard();
+    });
+    document.body.appendChild(overlay);
+  }
+
+  async function connectCandidate(address, button) {
+    if (!address || requestRunning) return;
+    requestRunning = true;
+    button.disabled = true;
+    feedback(`Connecting to discovered headset ${address}...`, 'loading');
+    try {
+      const response = await api(CONNECT_PATH, {
+        method: 'POST',
+        body: JSON.stringify({ ip: address, port: 5555 }),
+      });
+      if (!response.ok) throw new Error(responseMessage(response, 'Connection failed.'));
+      feedback('Discovered headset connected.', 'success');
+      const refresh = el('devhubRefresh');
+      if (refresh) refresh.click();
+    } catch (error) {
+      feedback(String(error.message || error), 'error');
+    } finally {
+      requestRunning = false;
+      button.disabled = false;
+    }
+  }
+
+  function prepareCandidateRows() {
+    const list = el('devhubCandidateList');
+    if (!list) return;
+
+    list.querySelectorAll('.devhub-list-item').forEach((row) => {
+      const title = row.querySelector('.devhub-list-title');
+      const button = row.querySelector('button');
+      if (!title || !button || row.dataset.wizardCandidateReady === '1') return;
+      const address = String(title.textContent || '').trim();
+      row.dataset.wizardCandidateReady = '1';
+      row.dataset.devhubCandidateAddress = address;
+      title.classList.add('devhub-sensitive-identifier');
+      button.textContent = 'Connect';
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void connectCandidate(address, button);
+      }, { capture: true });
+    });
+
+    const section = el('devhubUnifiedDiscovery');
+    if (section) {
+      section.hidden = !list.querySelector('.devhub-list-item');
+    }
+  }
+
+  function mergeDiscoveryIntoDevices(discoveryCard, devicesCard) {
+    const candidateList = el('devhubCandidateList');
+    const deviceBody = devicesCard.querySelector('.card-body');
+    if (!candidateList || !deviceBody) return;
+
+    const heading = devicesCard.querySelector('.card-header h2');
+    if (heading) heading.textContent = 'Headsets';
+
+    const section = document.createElement('section');
+    section.id = 'devhubUnifiedDiscovery';
+    section.className = 'devhub-unified-discovery';
+    section.hidden = true;
+    const titleRow = document.createElement('div');
+    titleRow.className = 'devhub-unified-section-title';
+    const title = document.createElement('h3');
+    title.textContent = 'Available on network';
+    titleRow.append(
+      title,
+      infoTip('Headsets discovered on the VRhotspot network appear here when they are available.'),
+    );
+    section.append(titleRow, candidateList);
+    deviceBody.appendChild(section);
+    discoveryCard.remove();
+
+    candidateObserver = new MutationObserver(prepareCandidateRows);
+    candidateObserver.observe(candidateList, { childList: true, subtree: true });
+    prepareCandidateRows();
+  }
+
+  function addSetupButton(devicesCard) {
+    if (el('devhubWirelessSetup')) return;
+    const header = devicesCard.querySelector('.card-header');
+    if (!header) return;
+    header.classList.add('devhub-headsets-header');
+
+    const actions = document.createElement('div');
+    actions.className = 'devhub-headsets-actions';
+    const setup = document.createElement('button');
+    setup.id = 'devhubWirelessSetup';
+    setup.type = 'button';
+    setup.className = 'btn sm primary';
+    setup.textContent = 'Set up wireless headset';
+    setup.addEventListener('click', openWizard);
+
+    const disconnect = el('devhubDisconnect');
+    if (disconnect && disconnect.parentNode === header) {
+      header.insertBefore(actions, disconnect);
+      actions.append(setup, disconnect);
+    } else {
+      actions.appendChild(setup);
+      header.appendChild(actions);
+    }
+  }
+
+  function moveManualConnectionToTools(pairingCard, connectCard, toolsPanel) {
+    const toolsGrid = toolsPanel.querySelector('.devhub-workspace-grid');
+    if (!toolsGrid || el('devhubAdvancedConnection')) return;
+
+    const card = document.createElement('section');
+    card.id = 'devhubAdvancedConnection';
+    card.className = 'card devhub-advanced-connection';
+    const header = document.createElement('div');
+    header.className = 'card-header';
+    const title = document.createElement('h2');
+    title.textContent = 'Advanced ADB';
+    header.append(title, infoTip('Manual pairing and IP connection are retained for non-standard Android devices and troubleshooting.'));
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = 'Manual pairing and IP connection';
+    const grid = document.createElement('div');
+    grid.className = 'devhub-advanced-connection-grid';
+
+    const pairingTitle = pairingCard.querySelector('.card-header h2');
+    const connectTitle = connectCard.querySelector('.card-header h2');
+    if (pairingTitle) pairingTitle.textContent = 'Pair with code';
+    if (connectTitle) connectTitle.textContent = 'Connect by IP';
+    grid.append(pairingCard, connectCard);
+    details.append(summary, grid);
+    body.appendChild(details);
+    card.append(header, body);
+    toolsGrid.appendChild(card);
+  }
+
+  function normalizeEmptyDeviceCopy() {
+    const list = el('devhubDeviceList');
+    const empty = list && list.querySelector('.devhub-empty');
+    if (empty) {
+      empty.textContent = 'No headsets are connected. Use “Set up wireless headset” to add one.';
+    }
+  }
+
+  function inject() {
+    if (document.documentElement.dataset.devhubConnectionWizardReady === '1') return true;
+    const workspace = el('devhubWorkspace');
+    if (!workspace) return false;
+
+    const devicePanel = workspace.querySelector('.devhub-workspace-panel[data-view="device"]');
+    const connectionPanel = workspace.querySelector('.devhub-workspace-panel[data-view="connection"]');
+    const toolsPanel = workspace.querySelector('.devhub-workspace-panel[data-view="tools"]');
+    if (!devicePanel || !connectionPanel || !toolsPanel) return false;
+
+    const devicesCard = cardByTitle(devicePanel, 'ADB Devices');
+    const discoveryCard = cardByTitle(connectionPanel, 'Network Discovery');
+    const pairingCard = cardByTitle(connectionPanel, 'Wireless Pairing');
+    const connectCard = cardByTitle(connectionPanel, 'Connect Headset');
+    if (!devicesCard || !discoveryCard || !pairingCard || !connectCard) return false;
+
+    document.documentElement.dataset.devhubConnectionWizardReady = '1';
+    buildWizard();
+    addSetupButton(devicesCard);
+    mergeDiscoveryIntoDevices(discoveryCard, devicesCard);
+    moveManualConnectionToTools(pairingCard, connectCard, toolsPanel);
+
+    const connectionTab = workspace.querySelector('.devhub-workspace-tab[data-view="connection"]');
+    const connectionWasActive = connectionTab && connectionTab.classList.contains('active');
+    if (connectionTab) connectionTab.remove();
+    connectionPanel.remove();
+
+    try {
+      if (sessionStorage.getItem(WORKSPACE_VIEW_KEY) === 'connection') {
+        sessionStorage.setItem(WORKSPACE_VIEW_KEY, 'device');
+      }
+    } catch { }
+    if (connectionWasActive) {
+      const deviceTab = workspace.querySelector('.devhub-workspace-tab[data-view="device"]');
+      if (deviceTab) deviceTab.click();
+    }
+
+    const deviceList = el('devhubDeviceList');
+    if (deviceList) {
+      const observer = new MutationObserver(normalizeEmptyDeviceCopy);
+      observer.observe(deviceList, { childList: true, subtree: true });
+    }
+    normalizeEmptyDeviceCopy();
+    return true;
+  }
+
+  function start() {
+    if (inject()) return;
+    const observer = new MutationObserver(() => {
+      if (inject()) observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -76,6 +76,11 @@ window.UI_FIELD_VISIBILITY = {
   identityStylesheet.href = '/assets/devhub_device_identity.css';
   document.head.appendChild(identityStylesheet);
 
+  const connectionStylesheet = document.createElement('link');
+  connectionStylesheet.rel = 'stylesheet';
+  connectionStylesheet.href = '/assets/devhub_connection_wizard.css';
+  document.head.appendChild(connectionStylesheet);
+
   const script = document.createElement('script');
   script.src = '/assets/devhub.js';
   script.async = false;
@@ -100,6 +105,11 @@ window.UI_FIELD_VISIBILITY = {
   identityScript.src = '/assets/devhub_device_identity.js';
   identityScript.async = false;
   document.head.appendChild(identityScript);
+
+  const connectionScript = document.createElement('script');
+  connectionScript.src = '/assets/devhub_connection_wizard.js';
+  connectionScript.async = false;
+  document.head.appendChild(connectionScript);
 })();
 
 (function addManagedPlatformToolsControls() {

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -34,11 +34,13 @@ from vr_hotspotd.devtools.platform_tools_manager import (
     install_managed_platform_tools,
     remove_managed_platform_tools,
 )
+from vr_hotspotd.devtools.wireless_bootstrap import enable_wireless_adb
 
 
 log = logging.getLogger("vr_hotspotd.devhub_api")
 
 DEVICE_OVERVIEW_PATH = "/v1/devbridge/adb/device-overview"
+WIRELESS_BOOTSTRAP_PATH = "/v1/devbridge/adb/enable-wireless"
 
 _DEVHUB_ASSET_TYPES = {
     "/assets/devhub.css": "text/css; charset=utf-8",
@@ -51,6 +53,8 @@ _DEVHUB_ASSET_TYPES = {
     "/assets/devhub_device_overview.js": "application/javascript; charset=utf-8",
     "/assets/devhub_device_identity.css": "text/css; charset=utf-8",
     "/assets/devhub_device_identity.js": "application/javascript; charset=utf-8",
+    "/assets/devhub_connection_wizard.css": "text/css; charset=utf-8",
+    "/assets/devhub_connection_wizard.js": "application/javascript; charset=utf-8",
 }
 
 _GET_OPERATIONS = {
@@ -163,6 +167,29 @@ class DevHubAPIHandler(APIHandler):
             ),
         )
 
+    def _respond_wireless_bootstrap(
+        self,
+        *,
+        cid: str,
+        request: Mapping[str, Any],
+        warnings: Optional[list[str]] = None,
+    ) -> None:
+        result = enable_wireless_adb(
+            request.get("serial"),
+            request.get("port", 5555),
+        )
+        result_code = str(result.get("result_code") or RESULT_FAILED)
+        status = _RESULT_HTTP_STATUS.get(result_code, 500)
+        self._respond(
+            status,
+            self._envelope(
+                correlation_id=cid,
+                result_code=result_code,
+                data=result,
+                warnings=list(warnings or []),
+            ),
+        )
+
     def _respond_tools_operation(
         self,
         *,
@@ -237,7 +264,13 @@ class DevHubAPIHandler(APIHandler):
         operation = _POST_OPERATIONS.get(path)
         tools_operation = _TOOLS_POST_OPERATIONS.get(path)
         is_apk_upload = path == APK_UPLOAD_PATH
-        if operation is None and tools_operation is None and not is_apk_upload:
+        is_wireless_bootstrap = path == WIRELESS_BOOTSTRAP_PATH
+        if (
+            operation is None
+            and tools_operation is None
+            and not is_apk_upload
+            and not is_wireless_bootstrap
+        ):
             super().do_POST()
             return
 
@@ -255,6 +288,14 @@ class DevHubAPIHandler(APIHandler):
         body, warnings = self._read_json_body()
         if any(warning in _BODY_ERROR_WARNINGS for warning in warnings):
             self._respond_invalid_body(cid, warnings)
+            return
+
+        if is_wireless_bootstrap:
+            self._respond_wireless_bootstrap(
+                cid=cid,
+                request=body,
+                warnings=warnings,
+            )
             return
 
         if tools_operation is not None:

--- a/backend/vr_hotspotd/devtools/wireless_bootstrap.py
+++ b/backend/vr_hotspotd/devtools/wireless_bootstrap.py
@@ -1,0 +1,308 @@
+"""Guided USB-to-wireless ADB bootstrap for Developer Hub.
+
+The public API accepts only a validated USB ADB serial and optional TCP port.
+Every subprocess argv is fixed and allowlisted; callers cannot supply shell
+commands or arbitrary adb arguments.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import subprocess
+import time
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+
+from vr_hotspotd.devtools.adb_operations import (
+    ADB_OUTPUT_LIMIT_BYTES,
+    RESULT_FAILED,
+    RESULT_INVALID_REQUEST,
+    RESULT_OK,
+    RESULT_TIMEOUT,
+    RESULT_TOOLS_UNAVAILABLE,
+)
+from vr_hotspotd.devtools.platform_tools import collect_devbridge_tools_status
+
+
+WIRELESS_DEFAULT_PORT = 5555
+WIRELESS_COMMAND_TIMEOUT_S = 15.0
+WIRELESS_CONNECT_ATTEMPTS = 4
+SERIAL_RE = re.compile(r"^[A-Za-z0-9._-]{1,255}$")
+_ROUTE_SRC_RE = re.compile(r"(?:^|\s)src\s+([0-9.]+)(?:\s|$)")
+_INET_RE = re.compile(r"(?:^|\s)inet\s+([0-9.]+)/\d+(?:\s|$)")
+
+
+class WirelessBootstrapError(ValueError):
+    """The guided wireless request is malformed or cannot be prepared."""
+
+
+def _valid_serial(value: Any) -> str:
+    if not isinstance(value, str) or not SERIAL_RE.fullmatch(value.strip()):
+        raise WirelessBootstrapError("serial must be a USB ADB device serial")
+    serial = value.strip()
+    if ":" in serial:
+        raise WirelessBootstrapError("serial must identify a USB-connected headset")
+    return serial
+
+
+def _valid_port(value: Any) -> int:
+    if value is None:
+        return WIRELESS_DEFAULT_PORT
+    if isinstance(value, bool):
+        raise WirelessBootstrapError("port must be an integer between 1 and 65535")
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise WirelessBootstrapError("port must be an integer between 1 and 65535") from exc
+    if not 1 <= port <= 65535:
+        raise WirelessBootstrapError("port must be an integer between 1 and 65535")
+    return port
+
+
+def _adb_path(tools_status: Optional[Mapping[str, Any]] = None) -> str:
+    status = dict(tools_status or collect_devbridge_tools_status())
+    adb = status.get("adb")
+    if not isinstance(adb, Mapping):
+        raise WirelessBootstrapError("ADB tools status is unavailable")
+    path = adb.get("path")
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise WirelessBootstrapError("ADB is not installed")
+    return path
+
+
+def _decode(value: bytes) -> str:
+    if len(value) > ADB_OUTPUT_LIMIT_BYTES:
+        raise WirelessBootstrapError("ADB output exceeded the configured limit")
+    return value.decode("utf-8", errors="replace").rstrip()
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]],
+) -> tuple[int, str, str]:
+    completed = runner(
+        list(argv),
+        input=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=WIRELESS_COMMAND_TIMEOUT_S,
+        check=False,
+        shell=False,
+        env={"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
+    )
+    return (
+        int(completed.returncode),
+        _decode(completed.stdout or b""),
+        _decode(completed.stderr or b""),
+    )
+
+
+def _ipv4_from_output(value: str) -> Optional[str]:
+    for pattern in (_ROUTE_SRC_RE, _INET_RE):
+        match = pattern.search(value)
+        if not match:
+            continue
+        try:
+            address = ipaddress.IPv4Address(match.group(1))
+        except ipaddress.AddressValueError:
+            continue
+        if not address.is_loopback and not address.is_unspecified:
+            return str(address)
+    return None
+
+
+def _result(
+    *,
+    success: bool,
+    result_code: str,
+    stage: str,
+    message: str,
+    data: Optional[Mapping[str, Any]] = None,
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "operation": "enable_wireless",
+        "success": success,
+        "result_code": result_code,
+        "stage": stage,
+        "message": message,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "data": dict(data or {}),
+    }
+
+
+def enable_wireless_adb(
+    serial: Any,
+    port: Any = WIRELESS_DEFAULT_PORT,
+    *,
+    tools_status: Optional[Mapping[str, Any]] = None,
+    runner: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> Dict[str, Any]:
+    """Switch one authorized USB headset to TCP ADB and connect to it."""
+
+    try:
+        validated_serial = _valid_serial(serial)
+        validated_port = _valid_port(port)
+        adb = _adb_path(tools_status)
+    except WirelessBootstrapError as exc:
+        message = str(exc)
+        code = RESULT_TOOLS_UNAVAILABLE if "ADB" in message else RESULT_INVALID_REQUEST
+        return _result(
+            success=False,
+            result_code=code,
+            stage="validate",
+            message=message,
+            returncode=2,
+        )
+
+    base_data: Dict[str, Any] = {
+        "usb_serial": validated_serial,
+        "port": validated_port,
+    }
+
+    try:
+        state_rc, state_out, state_err = _run(
+            (adb, "-s", validated_serial, "get-state"),
+            runner=runner,
+        )
+        if state_rc != 0 or state_out.strip() != "device":
+            return _result(
+                success=False,
+                result_code=RESULT_FAILED,
+                stage="authorize",
+                message=(
+                    "The headset is connected by USB but has not authorized this computer. "
+                    "Put on the headset and approve the USB debugging prompt."
+                ),
+                data=base_data,
+                stdout=state_out,
+                stderr=state_err,
+                returncode=state_rc,
+            )
+
+        model_rc, model_out, _model_err = _run(
+            (adb, "-s", validated_serial, "shell", "getprop", "ro.product.model"),
+            runner=runner,
+        )
+        if model_rc == 0 and model_out.strip():
+            base_data["model"] = model_out.strip().replace("_", " ")
+
+        route_rc, route_out, route_err = _run(
+            (adb, "-s", validated_serial, "shell", "ip", "route"),
+            runner=runner,
+        )
+        address = _ipv4_from_output(route_out) if route_rc == 0 else None
+        if address is None:
+            addr_rc, addr_out, addr_err = _run(
+                (
+                    adb,
+                    "-s",
+                    validated_serial,
+                    "shell",
+                    "ip",
+                    "-f",
+                    "inet",
+                    "addr",
+                    "show",
+                    "wlan0",
+                ),
+                runner=runner,
+            )
+            address = _ipv4_from_output(addr_out) if addr_rc == 0 else None
+            if address is None:
+                return _result(
+                    success=False,
+                    result_code=RESULT_FAILED,
+                    stage="wifi",
+                    message=(
+                        "The headset is authorized, but no Wi-Fi address was found. "
+                        "Connect the headset to Wi-Fi and try again."
+                    ),
+                    data=base_data,
+                    stdout=addr_out or route_out,
+                    stderr=addr_err or route_err,
+                    returncode=addr_rc if addr_rc != 0 else route_rc,
+                )
+
+        base_data["ip"] = address
+        target = f"{address}:{validated_port}"
+        base_data["target"] = target
+
+        tcp_rc, tcp_out, tcp_err = _run(
+            (adb, "-s", validated_serial, "tcpip", str(validated_port)),
+            runner=runner,
+        )
+        if tcp_rc != 0:
+            return _result(
+                success=False,
+                result_code=RESULT_FAILED,
+                stage="enable",
+                message="The headset did not enable wireless ADB.",
+                data=base_data,
+                stdout=tcp_out,
+                stderr=tcp_err,
+                returncode=tcp_rc,
+            )
+
+        last_rc = 1
+        last_out = ""
+        last_err = ""
+        for attempt in range(WIRELESS_CONNECT_ATTEMPTS):
+            if attempt:
+                sleeper(min(0.75 * (attempt + 1), 2.0))
+            else:
+                sleeper(0.75)
+            last_rc, last_out, last_err = _run((adb, "connect", target), runner=runner)
+            normalized = f"{last_out}\n{last_err}".lower()
+            if last_rc == 0 and (
+                "connected to" in normalized or "already connected to" in normalized
+            ):
+                return _result(
+                    success=True,
+                    result_code=RESULT_OK,
+                    stage="complete",
+                    message=f"{base_data.get('model', 'Headset')} is connected wirelessly.",
+                    data=base_data,
+                    stdout=last_out,
+                    stderr=last_err,
+                    returncode=last_rc,
+                )
+
+        return _result(
+            success=False,
+            result_code=RESULT_FAILED,
+            stage="connect",
+            message=(
+                "Wireless ADB was enabled, but the headset did not accept the network "
+                "connection yet. Keep it awake and try connecting again."
+            ),
+            data=base_data,
+            stdout=last_out,
+            stderr=last_err,
+            returncode=last_rc,
+        )
+    except subprocess.TimeoutExpired:
+        return _result(
+            success=False,
+            result_code=RESULT_TIMEOUT,
+            stage="timeout",
+            message="The headset did not respond before the setup timeout.",
+            data=base_data,
+            returncode=1,
+        )
+    except (OSError, WirelessBootstrapError) as exc:
+        return _result(
+            success=False,
+            result_code=RESULT_FAILED,
+            stage="execute",
+            message=f"Wireless setup could not run: {exc}",
+            data=base_data,
+            returncode=1,
+        )

--- a/backend/vr_hotspotd/devtools/wireless_bootstrap.py
+++ b/backend/vr_hotspotd/devtools/wireless_bootstrap.py
@@ -150,15 +150,23 @@ def enable_wireless_adb(
     try:
         validated_serial = _valid_serial(serial)
         validated_port = _valid_port(port)
-        adb = _adb_path(tools_status)
     except WirelessBootstrapError as exc:
-        message = str(exc)
-        code = RESULT_TOOLS_UNAVAILABLE if "ADB" in message else RESULT_INVALID_REQUEST
         return _result(
             success=False,
-            result_code=code,
+            result_code=RESULT_INVALID_REQUEST,
             stage="validate",
-            message=message,
+            message=str(exc),
+            returncode=2,
+        )
+
+    try:
+        adb = _adb_path(tools_status)
+    except WirelessBootstrapError as exc:
+        return _result(
+            success=False,
+            result_code=RESULT_TOOLS_UNAVAILABLE,
+            stage="tools",
+            message=str(exc),
             returncode=2,
         )
 

--- a/tests/test_devhub_connection_wizard_ui.py
+++ b/tests/test_devhub_connection_wizard_ui.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ASSETS = ROOT / "assets"
+WIZARD_JS = ASSETS / "devhub_connection_wizard.js"
+WIZARD_CSS = ASSETS / "devhub_connection_wizard.css"
+FIELD_VISIBILITY = ASSETS / "field_visibility.js"
+DEVHUB_API = ROOT / "backend/vr_hotspotd/devtools/devhub_api.py"
+
+
+def test_connection_wizard_assets_load_after_identity_layer() -> None:
+    loader = FIELD_VISIBILITY.read_text(encoding="utf-8")
+
+    assert "/assets/devhub_connection_wizard.css" in loader
+    assert "/assets/devhub_connection_wizard.js" in loader
+    assert loader.index("/assets/devhub_connection_wizard.css") > loader.index(
+        "/assets/devhub_device_identity.css"
+    )
+    assert loader.index("/assets/devhub_connection_wizard.js") > loader.index(
+        "/assets/devhub_device_identity.js"
+    )
+
+
+def test_connection_wizard_assets_and_endpoint_are_served() -> None:
+    source = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert (
+        '"/assets/devhub_connection_wizard.css": "text/css; charset=utf-8"'
+        in source
+    )
+    assert (
+        '"/assets/devhub_connection_wizard.js": '
+        '"application/javascript; charset=utf-8"'
+        in source
+    )
+    assert 'WIRELESS_BOOTSTRAP_PATH = "/v1/devbridge/adb/enable-wireless"' in source
+    assert "enable_wireless_adb" in source
+    assert "is_wireless_bootstrap" in source
+
+
+def test_normal_connection_tab_is_replaced_by_guided_workflow() -> None:
+    source = WIZARD_JS.read_text(encoding="utf-8")
+
+    assert "Set up wireless headset" in source
+    assert "Connect the headset by USB" in source
+    assert "Approve USB debugging inside the headset" in source
+    assert "Enable Wireless ADB" in source
+    assert "connectionTab.remove()" in source
+    assert "connectionPanel.remove()" in source
+    assert "mergeDiscoveryIntoDevices" in source
+    assert "moveManualConnectionToTools" in source
+    assert "Advanced ADB" in source
+    assert "Manual pairing and IP connection" in source
+
+
+def test_wizard_preserves_privacy_and_internal_serial_state() -> None:
+    source = WIZARD_JS.read_text(encoding="utf-8")
+
+    assert "devhub-sensitive-identifier" in source
+    assert "dataset.devhubSerial" in source
+    assert "serial: String(device.serial || '')" in source
+    assert "target" in source
+
+
+def test_wizard_css_is_modal_responsive_and_has_no_status_lights() -> None:
+    source = WIZARD_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-wizard-overlay" in source
+    assert ".devhub-wizard-dialog" in source
+    assert ".devhub-wizard-step.current" in source
+    assert "@media (max-width: 620px)" in source
+    assert "status-dot" not in source
+
+
+def test_connection_wizard_javascript_syntax() -> None:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not installed")
+
+    subprocess.run(
+        [node, "--check", str(WIZARD_JS)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_devhub_python39_syntax.py
+++ b/tests/test_devhub_python39_syntax.py
@@ -11,6 +11,7 @@ FILES = (
     ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py",
     ROOT / "backend" / "vr_hotspotd" / "devtools" / "apk_upload.py",
     ROOT / "backend" / "vr_hotspotd" / "devtools" / "adb_cli.py",
+    ROOT / "backend" / "vr_hotspotd" / "devtools" / "wireless_bootstrap.py",
 )
 
 

--- a/tests/test_devhub_wireless_bootstrap.py
+++ b/tests/test_devhub_wireless_bootstrap.py
@@ -203,4 +203,4 @@ def test_enable_wireless_adb_reports_missing_tools() -> None:
 
     assert result["success"] is False
     assert result["result_code"] == RESULT_TOOLS_UNAVAILABLE
-    assert result["stage"] == "validate"
+    assert result["stage"] == "tools"

--- a/tests/test_devhub_wireless_bootstrap.py
+++ b/tests/test_devhub_wireless_bootstrap.py
@@ -50,7 +50,7 @@ class BootstrapRunner:
         if command[-2:] == ("ip", "route"):
             return subprocess.CompletedProcess(argv, 0, self.route.encode(), b"")
 
-        if command[-7:] == ("ip", "-f", "inet", "addr", "show", "wlan0"):
+        if command[-6:] == ("ip", "-f", "inet", "addr", "show", "wlan0"):
             return subprocess.CompletedProcess(argv, 0, self.fallback_address.encode(), b"")
 
         if len(command) >= 2 and command[-2] == "tcpip":

--- a/tests/test_devhub_wireless_bootstrap.py
+++ b/tests/test_devhub_wireless_bootstrap.py
@@ -44,7 +44,7 @@ class BootstrapRunner:
                 return subprocess.CompletedProcess(argv, 0, b"device\n", b"")
             return subprocess.CompletedProcess(argv, 1, b"", b"error: device unauthorized\n")
 
-        if command[-3:] == ("getprop", "ro.product.model"):
+        if command[-2:] == ("getprop", "ro.product.model"):
             return subprocess.CompletedProcess(argv, 0, b"Quest_3S\n", b"")
 
         if command[-2:] == ("ip", "route"):

--- a/tests/test_devhub_wireless_bootstrap.py
+++ b/tests/test_devhub_wireless_bootstrap.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import subprocess
+
+from vr_hotspotd.devtools.adb_operations import (
+    RESULT_FAILED,
+    RESULT_INVALID_REQUEST,
+    RESULT_OK,
+    RESULT_TOOLS_UNAVAILABLE,
+)
+from vr_hotspotd.devtools.wireless_bootstrap import enable_wireless_adb
+
+
+ADB = "/var/lib/vr-hotspot/devtools/platform-tools/adb"
+TOOLS_STATUS = {"adb": {"path": ADB}}
+
+
+class BootstrapRunner:
+    def __init__(
+        self,
+        *,
+        authorized: bool = True,
+        route: str = "default via 192.168.0.1 dev wlan0 src 192.168.0.98 metric 303",
+        fallback_address: str = "",
+        tcpip_ok: bool = True,
+        connect_failures: int = 0,
+    ) -> None:
+        self.authorized = authorized
+        self.route = route
+        self.fallback_address = fallback_address
+        self.tcpip_ok = tcpip_ok
+        self.connect_failures = connect_failures
+        self.connect_calls = 0
+        self.calls: list[tuple[str, ...]] = []
+        self.kwargs: list[dict] = []
+
+    def __call__(self, argv, **kwargs):
+        command = tuple(argv)
+        self.calls.append(command)
+        self.kwargs.append(kwargs)
+
+        if command[-1] == "get-state":
+            if self.authorized:
+                return subprocess.CompletedProcess(argv, 0, b"device\n", b"")
+            return subprocess.CompletedProcess(argv, 1, b"", b"error: device unauthorized\n")
+
+        if command[-3:] == ("getprop", "ro.product.model"):
+            return subprocess.CompletedProcess(argv, 0, b"Quest_3S\n", b"")
+
+        if command[-2:] == ("ip", "route"):
+            return subprocess.CompletedProcess(argv, 0, self.route.encode(), b"")
+
+        if command[-7:] == ("ip", "-f", "inet", "addr", "show", "wlan0"):
+            return subprocess.CompletedProcess(argv, 0, self.fallback_address.encode(), b"")
+
+        if len(command) >= 2 and command[-2] == "tcpip":
+            if self.tcpip_ok:
+                return subprocess.CompletedProcess(
+                    argv,
+                    0,
+                    b"restarting in TCP mode port: 5555\n",
+                    b"",
+                )
+            return subprocess.CompletedProcess(argv, 1, b"", b"tcpip failed\n")
+
+        if len(command) >= 2 and command[-2] == "connect":
+            self.connect_calls += 1
+            if self.connect_calls <= self.connect_failures:
+                return subprocess.CompletedProcess(
+                    argv,
+                    1,
+                    b"",
+                    b"failed to connect: Connection refused\n",
+                )
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                b"connected to 192.168.0.98:5555\n",
+                b"",
+            )
+
+        raise AssertionError(f"unexpected argv: {command!r}")
+
+
+def test_enable_wireless_adb_runs_fixed_usb_to_tcp_sequence() -> None:
+    runner = BootstrapRunner()
+
+    result = enable_wireless_adb(
+        "3487C10J3C0CBP",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is True
+    assert result["result_code"] == RESULT_OK
+    assert result["stage"] == "complete"
+    assert result["data"] == {
+        "usb_serial": "3487C10J3C0CBP",
+        "port": 5555,
+        "model": "Quest 3S",
+        "ip": "192.168.0.98",
+        "target": "192.168.0.98:5555",
+    }
+    assert runner.calls == [
+        (ADB, "-s", "3487C10J3C0CBP", "get-state"),
+        (ADB, "-s", "3487C10J3C0CBP", "shell", "getprop", "ro.product.model"),
+        (ADB, "-s", "3487C10J3C0CBP", "shell", "ip", "route"),
+        (ADB, "-s", "3487C10J3C0CBP", "tcpip", "5555"),
+        (ADB, "connect", "192.168.0.98:5555"),
+    ]
+    assert all(call["shell"] is False for call in runner.kwargs)
+    assert all(call["input"] is None for call in runner.kwargs)
+
+
+def test_enable_wireless_adb_explains_usb_authorization() -> None:
+    runner = BootstrapRunner(authorized=False)
+
+    result = enable_wireless_adb(
+        "USB123",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == RESULT_FAILED
+    assert result["stage"] == "authorize"
+    assert "approve the USB debugging prompt" in result["message"]
+    assert runner.calls == [(ADB, "-s", "USB123", "get-state")]
+
+
+def test_enable_wireless_adb_uses_wlan_fallback_address() -> None:
+    runner = BootstrapRunner(
+        route="default via 192.168.0.1 dev wlan0",
+        fallback_address="4: wlan0 inet 10.39.107.42/24 brd 10.39.107.255 scope global wlan0",
+    )
+
+    result = enable_wireless_adb(
+        "USB123",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is True
+    assert result["data"]["target"] == "10.39.107.42:5555"
+    assert (ADB, "-s", "USB123", "shell", "ip", "-f", "inet", "addr", "show", "wlan0") in runner.calls
+
+
+def test_enable_wireless_adb_reports_missing_wifi_address() -> None:
+    runner = BootstrapRunner(route="default via 192.168.0.1 dev wlan0")
+
+    result = enable_wireless_adb(
+        "USB123",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is False
+    assert result["stage"] == "wifi"
+    assert "Connect the headset to Wi-Fi" in result["message"]
+    assert not any(call[-2:] == ("tcpip", "5555") for call in runner.calls)
+
+
+def test_enable_wireless_adb_retries_network_connection() -> None:
+    runner = BootstrapRunner(connect_failures=2)
+
+    result = enable_wireless_adb(
+        "USB123",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is True
+    assert runner.connect_calls == 3
+
+
+def test_enable_wireless_adb_rejects_network_serial_without_running_adb() -> None:
+    runner = BootstrapRunner()
+
+    result = enable_wireless_adb(
+        "192.168.0.98:5555",
+        tools_status=TOOLS_STATUS,
+        runner=runner,
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == RESULT_INVALID_REQUEST
+    assert result["stage"] == "validate"
+    assert runner.calls == []
+
+
+def test_enable_wireless_adb_reports_missing_tools() -> None:
+    result = enable_wireless_adb(
+        "USB123",
+        tools_status={"adb": {"path": None}},
+        sleeper=lambda _seconds: None,
+    )
+
+    assert result["success"] is False
+    assert result["result_code"] == RESULT_TOOLS_UNAVAILABLE
+    assert result["stage"] == "validate"


### PR DESCRIPTION
## Summary

Replace the manual Developer Hub Connection tab with a beginner-friendly headset workflow.

## Device page

- Merge connected ADB devices and discovered network headsets into one **Headsets** card.
- Add a primary **Set up wireless headset** action.
- Hide the network-discovery subsection when no candidates are available.
- Let discovered candidates connect directly instead of merely copying an IP into another form.

## Guided setup wizard

The wizard walks a new Linux user through the Quest workflow:

1. Connect a data-capable USB cable.
2. Approve the USB debugging prompt inside the headset.
3. VRhotspot detects the authorized USB headset automatically.
4. VRhotspot reads the headset Wi-Fi address, enables TCP ADB, connects wirelessly, refreshes the Hub, and selects the wireless transport.

Adds authenticated typed endpoint:

- `POST /v1/devbridge/adb/enable-wireless`

The backend accepts only a validated USB serial and port. It runs fixed allowlisted argv sequences for `get-state`, model lookup, route/address inspection, `adb tcpip`, and `adb connect`; no shell or arbitrary command input is exposed.

## Advanced controls

- Remove the normal **Connection** tab.
- Move pairing-code ADB and manual IP connection into **Tools → Advanced ADB** behind a collapsed disclosure.
- Preserve these controls for non-standard Android devices and troubleshooting.

## Validation

- USB authorization, Wi-Fi discovery, fallback address parsing, TCP activation, retry behavior, invalid serials, and missing tools.
- Fixed argv and `shell=False` contracts.
- Wizard asset loading, endpoint registration, DOM reorganization, privacy integration, responsive CSS, Node syntax, and Python 3.9 grammar.
- Full repository CI matrix.