### PR TITLE
Fix Developer Hub browser freeze

### DIFF
--- a/assets/devhub_connection_wizard.js
+++ b/assets/devhub_connection_wizard.js
@@ -539,8 +539,9 @@
   function normalizeEmptyDeviceCopy() {
     const list = el('devhubDeviceList');
     const empty = list && list.querySelector('.devhub-empty');
-    if (empty) {
-      empty.textContent = 'No headsets are connected. Use “Set up wireless headset” to add one.';
+    const message = 'No headsets are connected. Use “Set up wireless headset” to add one.';
+    if (empty && empty.textContent !== message) {
+      empty.textContent = message;
     }
   }
 
@@ -584,7 +585,7 @@
     const deviceList = el('devhubDeviceList');
     if (deviceList) {
       const observer = new MutationObserver(normalizeEmptyDeviceCopy);
-      observer.observe(deviceList, { childList: true, subtree: true });
+      observer.observe(deviceList, { childList: true });
     }
     normalizeEmptyDeviceCopy();
     return true;

--- a/tests/test_devhub_connection_wizard_ui.py
+++ b/tests/test_devhub_connection_wizard_ui.py
@@ -69,6 +69,14 @@ def test_wizard_preserves_privacy_and_internal_serial_state() -> None:
     assert "target" in source
 
 
+def test_empty_state_observer_is_idempotent_and_direct_child_only() -> None:
+    source = WIZARD_JS.read_text(encoding="utf-8")
+
+    assert "empty && empty.textContent !== message" in source
+    assert "observer.observe(deviceList, { childList: true });" in source
+    assert "observer.observe(deviceList, { childList: true, subtree: true });" not in source
+
+
 def test_wizard_css_is_modal_responsive_and_has_no_status_lights() -> None:
     source = WIZARD_CSS.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Fix the browser freeze introduced by the guided wireless setup UI.

## Root cause

The device-list MutationObserver watched the full subtree and unconditionally rewrote the empty-state text. Replacing that text generated another child-list mutation, which invoked the callback again indefinitely. The loop could start before authentication, starving Firefox's main thread and preventing the API-token prompt from becoming interactive.

## Fix

- Only rewrite the empty-state copy when it is actually different.
- Observe direct device-list child replacements only; do not observe mutations inside the empty-state element.
- Add regression coverage for the idempotent text guard and direct-child observer configuration.

## Validation

- JavaScript syntax check.
- Focused observer-loop regression test.
- Full repository CI matrix.