### PR TITLE
Simplify Developer Hub device and app workflows

### DIFF
--- a/assets/devhub_device_identity.css
+++ b/assets/devhub_device_identity.css
@@ -1,8 +1,9 @@
-#devhubSelectedDevice.devhub-raw-device-serial {
+.devhub-raw-device-serial {
   display: none !important;
 }
 
-.devhub-selected-device-display {
+.devhub-selected-device-display,
+.devhub-target-device-display {
   display: grid;
   gap: 4px;
   min-height: 44px;
@@ -11,11 +12,13 @@
   background: var(--accent-subtle);
 }
 
-.devhub-selected-device-display.empty {
+.devhub-selected-device-display.empty,
+.devhub-target-device-display.empty {
   border-left-color: var(--border-subtle);
 }
 
-.devhub-selected-device-name {
+.devhub-selected-device-name,
+.devhub-target-device-display strong {
   color: var(--text-main);
   font-family: var(--font-mono);
   font-size: 14px;
@@ -23,7 +26,8 @@
   overflow-wrap: anywhere;
 }
 
-.devhub-selected-device-address {
+.devhub-selected-device-address,
+.devhub-target-device-display span {
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
@@ -48,6 +52,69 @@
 
 .devhub-device-address {
   font-family: var(--font-mono);
+}
+
+.devhub-apps-device-context {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+}
+
+.devhub-apps-device-context span {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.devhub-apps-device-context strong {
+  color: var(--text-main);
+  font-size: 13px;
+}
+
+.devhub-install-option-hidden,
+.devhub-install-options-empty {
+  display: none !important;
+}
+
+.devhub-advanced-install-options {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 10px;
+}
+
+.devhub-advanced-install-options summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.devhub-advanced-install-body {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+}
+
+.devhub-advanced-install-body label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-main);
+  font-size: 12px;
 }
 
 .devhub-privacy-active .devhub-sensitive-identifier {

--- a/assets/devhub_device_identity.js
+++ b/assets/devhub_device_identity.js
@@ -2,9 +2,11 @@
   'use strict';
 
   const HIDDEN_VALUE = 'Hidden by Privacy Mode';
+  const UPLOAD_PATH = '/v1/devbridge/adb/install-upload';
   const EMPTY_SERIALS = new Set(['', '--', 'no device selected', 'no headset selected']);
   let syncQueued = false;
   let tabObserver = null;
+  let lastDeploymentAction = '';
 
   function el(id) { return document.getElementById(id); }
 
@@ -22,6 +24,18 @@
     return !!(privacy && privacy.checked);
   }
 
+  function transportForSerial(serial) {
+    const value = normalizedSerial(serial);
+    if (!value) return '';
+    return value.includes(':') ? 'Wireless' : 'Wired';
+  }
+
+  function identityLabel(model, serial) {
+    const name = normalized(model) || 'Android XR headset';
+    const transport = transportForSerial(serial);
+    return transport ? `${name} (${transport})` : name;
+  }
+
   function modelFromMeta(metaText) {
     const match = String(metaText || '').match(/(?:^|·)\s*model\s+([^·]+)/i);
     return normalized(match ? match[1] : '');
@@ -29,6 +43,16 @@
 
   function stateFromMeta(metaText) {
     return normalized(String(metaText || '').split('·')[0]) || 'ADB device';
+  }
+
+  function infoTip(text) {
+    const tip = document.createElement('span');
+    tip.className = 'tip devhub-info-tip';
+    tip.textContent = 'ⓘ';
+    tip.setAttribute('data-tip', text);
+    tip.setAttribute('aria-label', text);
+    tip.setAttribute('tabindex', '0');
+    return tip;
   }
 
   function prepareDeviceRows() {
@@ -47,8 +71,8 @@
         row.dataset.devhubSerial = serial;
         row.dataset.devhubModel = model;
         row.dataset.devhubState = state;
+        row.dataset.devhubTransport = transportForSerial(serial);
 
-        title.textContent = model;
         title.classList.add('devhub-device-model');
 
         const stateNode = document.createElement('span');
@@ -66,6 +90,11 @@
         meta.replaceChildren(stateNode, modelSource, addressNode);
         meta.classList.add('devhub-device-identity-meta');
       }
+
+      const serial = normalizedSerial(row.dataset.devhubSerial);
+      const model = normalized(row.dataset.devhubModel) || 'Android XR headset';
+      const label = identityLabel(model, serial);
+      if (title.textContent !== label) title.textContent = label;
     });
   }
 
@@ -77,11 +106,14 @@
     const row = selectedRow();
     const serial = normalizedSerial((el('devhubSelectedDevice') || {}).textContent);
     const fallbackModel = normalized((el('devhubWorkspaceDeviceName') || {}).textContent);
+    const model = normalized(row && row.dataset.devhubModel)
+      || fallbackModel
+      || (serial ? 'Android XR headset' : 'No headset selected');
     return {
       serial,
-      model: normalized(row && row.dataset.devhubModel)
-        || fallbackModel
-        || (serial ? 'Android XR headset' : 'No headset selected'),
+      model,
+      transport: transportForSerial(serial),
+      label: serial ? identityLabel(model, serial) : 'No headset selected',
     };
   }
 
@@ -111,6 +143,32 @@
     return display;
   }
 
+  function ensureTargetDisplay() {
+    const raw = el('devhubPackageSerial');
+    if (!raw || !raw.parentNode) return null;
+
+    raw.classList.add('devhub-raw-device-serial');
+    raw.setAttribute('aria-hidden', 'true');
+    const label = document.querySelector('label[for="devhubPackageSerial"]');
+    if (label && label.textContent !== 'Target headset') label.textContent = 'Target headset';
+
+    let display = el('devhubTargetDeviceIdentity');
+    if (!display) {
+      display = document.createElement('div');
+      display.id = 'devhubTargetDeviceIdentity';
+      display.className = 'devhub-target-device-display';
+
+      const name = document.createElement('strong');
+      name.id = 'devhubTargetDeviceName';
+      const address = document.createElement('span');
+      address.id = 'devhubTargetDeviceAddress';
+      address.className = 'devhub-sensitive-identifier';
+      display.append(name, address);
+      raw.parentNode.insertBefore(display, raw.nextSibling);
+    }
+    return display;
+  }
+
   function setText(id, value) {
     const node = el(id);
     if (node && node.textContent !== value) node.textContent = value;
@@ -121,9 +179,77 @@
     if (!display) return;
 
     const identity = selectedIdentity();
-    setText('devhubSelectedDeviceName', identity.model);
+    setText('devhubSelectedDeviceName', identity.label);
     setText('devhubSelectedDeviceAddress', identity.serial);
     display.classList.toggle('empty', !identity.serial);
+  }
+
+  function syncTargetDisplay() {
+    const display = ensureTargetDisplay();
+    if (!display) return;
+
+    const identity = selectedIdentity();
+    setText('devhubTargetDeviceName', identity.label);
+    setText('devhubTargetDeviceAddress', identity.serial);
+    display.classList.toggle('empty', !identity.serial);
+  }
+
+  function syncAppsContext() {
+    const list = el('devhubPackageList');
+    const body = list && list.closest('.card-body');
+    if (!body) return;
+
+    let context = el('devhubAppsDeviceContext');
+    if (!context) {
+      context = document.createElement('div');
+      context.id = 'devhubAppsDeviceContext';
+      context.className = 'devhub-apps-device-context';
+      const caption = document.createElement('span');
+      caption.textContent = 'Headset';
+      const value = document.createElement('strong');
+      value.id = 'devhubAppsDeviceName';
+      context.append(caption, value);
+      body.insertBefore(context, body.firstChild);
+    }
+    setText('devhubAppsDeviceName', selectedIdentity().label);
+  }
+
+  function syncInstallControls() {
+    const form = el('devhubInstallForm');
+    const reinstall = el('devhubReinstall');
+    const grant = el('devhubGrantPermissions');
+    if (!form || !reinstall || !grant) return;
+
+    reinstall.checked = true;
+    const reinstallLabel = reinstall.closest('label');
+    if (reinstallLabel) reinstallLabel.classList.add('devhub-install-option-hidden');
+
+    const checks = reinstall.closest('.devhub-checks') || grant.closest('.devhub-checks');
+    if (!el('devhubAdvancedInstallOptions')) {
+      const details = document.createElement('details');
+      details.id = 'devhubAdvancedInstallOptions';
+      details.className = 'devhub-wide devhub-advanced-install-options';
+      const summary = document.createElement('summary');
+      summary.append(
+        document.createTextNode('Advanced install options '),
+        infoTip('Normal installs should use Android permission prompts. Automatic permission grants are intended for controlled testing and automation.'),
+      );
+      const body = document.createElement('div');
+      body.className = 'devhub-advanced-install-body';
+      const grantLabel = grant.closest('label');
+      if (grantLabel) body.appendChild(grantLabel);
+      details.append(summary, body);
+      if (checks && checks.parentNode) checks.parentNode.insertBefore(details, checks);
+    }
+
+    if (checks && !checks.querySelector('label:not(.devhub-install-option-hidden)')) {
+      checks.classList.add('devhub-install-options-empty');
+    }
+
+    const submit = form.querySelector('button[type="submit"]');
+    if (submit && !submit.disabled && submit.textContent !== 'Install or update app') {
+      submit.textContent = 'Install or update app';
+    }
   }
 
   function syncTopIdentity(privacy) {
@@ -151,6 +277,73 @@
     }
   }
 
+  function serialIdentityMap() {
+    const identities = new Map();
+    document.querySelectorAll('#devhubDeviceList .devhub-list-item').forEach((row) => {
+      const serial = normalizedSerial(row.dataset.devhubSerial);
+      const model = normalized(row.dataset.devhubModel) || 'Android XR headset';
+      if (serial) identities.set(serial, identityLabel(model, serial));
+    });
+    const selected = selectedIdentity();
+    if (selected.serial) identities.set(selected.serial, selected.label);
+    return identities;
+  }
+
+  function sanitizeFeedback() {
+    const node = el('devhubFeedback');
+    if (!node) return;
+    let message = String(node.textContent || '');
+    const original = message;
+
+    const identities = Array.from(serialIdentityMap().entries())
+      .sort((left, right) => right[0].length - left[0].length);
+    for (const [serial, label] of identities) {
+      if (message.includes(serial)) message = message.split(serial).join(label);
+    }
+
+    message = message
+      .replace(/Loading packages from/gi, 'Loading apps from')
+      .replace(/Loaded (\d+) package\(s\) from/gi, 'Loaded $1 app(s) from')
+      .replace(/Package inventory failed/gi, 'App inventory failed');
+
+    if (lastDeploymentAction && /^Installed\s+/i.test(message)) {
+      if (lastDeploymentAction === 'updated') {
+        message = message.replace(/^Installed/i, 'Updated');
+      } else if (lastDeploymentAction === 'installed_or_updated') {
+        message = message.replace(/^Installed/i, 'Installed or updated');
+      }
+      lastDeploymentAction = '';
+    }
+
+    if (privacyEnabled()) {
+      message = message.replace(
+        /\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b/g,
+        selectedIdentity().serial ? selectedIdentity().label : 'selected headset',
+      );
+    }
+
+    if (message !== original) node.textContent = message;
+  }
+
+  function bindApiCapture() {
+    if (typeof window.api !== 'function' || window.api.devhubDeploymentCapture === true) return;
+    const original = window.api;
+    const wrapped = async function devhubIdentityAwareApi(path, options) {
+      const response = await original(path, options);
+      if (path === UPLOAD_PATH && response && response.ok) {
+        const publicResult = response.json && response.json.data;
+        const details = publicResult && publicResult.data;
+        lastDeploymentAction = details && typeof details.deployment_action === 'string'
+          ? details.deployment_action
+          : '';
+      }
+      return response;
+    };
+    wrapped.devhubDeploymentCapture = true;
+    wrapped.devhubOriginalApi = original;
+    window.api = wrapped;
+  }
+
   function bindPrivacyToggle() {
     const privacy = el('privacyMode');
     if (!privacy || privacy.dataset.devhubIdentityBound === '1') return;
@@ -161,11 +354,16 @@
   function sync() {
     const privacy = privacyEnabled();
     document.documentElement.classList.toggle('devhub-privacy-active', privacy);
+    bindApiCapture();
     bindPrivacyToggle();
     prepareDeviceRows();
     syncSelectedDisplay();
+    syncTargetDisplay();
+    syncAppsContext();
+    syncInstallControls();
     syncTopIdentity(privacy);
     syncOverviewIp(privacy);
+    sanitizeFeedback();
   }
 
   function scheduleSync() {
@@ -187,15 +385,17 @@
       subtree: true,
       characterData: true,
       attributes: true,
-      attributeFilter: ['class', 'hidden'],
+      attributeFilter: ['class', 'hidden', 'value'],
     });
     scheduleSync();
     return true;
   }
 
   function start() {
+    bindApiCapture();
     if (observeTab()) return;
     const startupObserver = new MutationObserver(() => {
+      bindApiCapture();
       if (observeTab()) startupObserver.disconnect();
     });
     startupObserver.observe(document.documentElement, { childList: true, subtree: true });

--- a/assets/devhub_upload.js
+++ b/assets/devhub_upload.js
@@ -33,6 +33,26 @@
     return detail ? `${code}: ${detail}` : code;
   }
 
+  function deploymentData(response) {
+    const publicResult = response && response.json && response.json.data;
+    return publicResult && publicResult.data && typeof publicResult.data === 'object'
+      ? publicResult.data
+      : {};
+  }
+
+  function deploymentVerb(action) {
+    if (action === 'installed') return 'Installed';
+    if (action === 'updated') return 'Updated';
+    return 'Installed or updated';
+  }
+
+  function selectedHeadsetLabel() {
+    const name = document.getElementById('devhubTargetDeviceName');
+    const value = String((name && name.textContent) || '').trim();
+    if (value && value !== 'No headset selected') return value;
+    return 'selected headset';
+  }
+
   function companionBridgeActive() {
     return typeof companionAuthBridgeAvailable === 'function'
       && companionAuthBridgeAvailable();
@@ -102,7 +122,7 @@
     form.insertBefore(uploadField, pathField);
     advanced.append(summary, pathField, help);
     form.insertBefore(advanced, checks);
-    submit.textContent = 'Install on headset';
+    submit.textContent = 'Install or update app';
 
     function selectedFile() {
       return fileInput.files && fileInput.files.length ? fileInput.files[0] : null;
@@ -116,7 +136,7 @@
         return;
       }
       name.textContent = file.name;
-      meta.textContent = `${formatBytes(file.size)} · Ready to install`;
+      meta.textContent = `${formatBytes(file.size)} · Ready to install or update`;
     }
 
     function useFile(file) {
@@ -194,14 +214,17 @@
         return;
       }
 
-      const reinstall = document.getElementById('devhubReinstall');
       const grant = document.getElementById('devhubGrantPermissions');
       const previousLabel = submit.textContent;
+      const headset = selectedHeadsetLabel();
       submit.disabled = true;
       choose.disabled = true;
       fileInput.disabled = true;
       submit.textContent = 'Installing...';
-      feedback(`Uploading ${file.name} (${formatBytes(file.size)}) and installing it...`, 'loading');
+      feedback(
+        `Uploading ${file.name} (${formatBytes(file.size)}) and installing it on ${headset}...`,
+        'loading',
+      );
 
       try {
         const response = await api(UPLOAD_PATH, {
@@ -210,7 +233,7 @@
             'Content-Type': 'application/vnd.android.package-archive',
             'X-VRhotspot-Serial': serial,
             'X-VRhotspot-Apk-Name': encodeURIComponent(file.name),
-            'X-VRhotspot-Reinstall': reinstall && reinstall.checked ? '1' : '0',
+            'X-VRhotspot-Reinstall': '1',
             'X-VRhotspot-Grant-Permissions': grant && grant.checked ? '1' : '0',
           },
           body: file,
@@ -221,7 +244,11 @@
           return;
         }
 
-        feedback(`Installed ${file.name} on ${serial}.`, 'success');
+        const details = deploymentData(response);
+        feedback(
+          `${deploymentVerb(details.deployment_action)} ${file.name} on ${headset}.`,
+          'success',
+        );
         fileInput.value = '';
         updateSelection();
         const loadPackages = document.getElementById('devhubLoadPackages');

--- a/backend/vr_hotspotd/devtools/apk_upload.py
+++ b/backend/vr_hotspotd/devtools/apk_upload.py
@@ -6,7 +6,7 @@ import logging
 import os
 from pathlib import Path
 import tempfile
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional, Set
 from urllib.parse import unquote
 
 from vr_hotspotd.devtools.adb_operations import (
@@ -60,11 +60,54 @@ def _header_bool(handler: Any, name: str, default: bool) -> bool:
     return value in {"1", "true", "yes", "on", "y"}
 
 
+def _package_inventory(serial: str) -> Optional[Set[str]]:
+    """Return the current third-party package set when ADB can report it."""
+
+    result = execute_adb_operation(
+        "packages",
+        {
+            "serial": serial,
+            "third_party_only": True,
+        },
+    )
+    if not result.get("success"):
+        return None
+    raw_data = result.get("data")
+    if not isinstance(raw_data, Mapping):
+        return None
+    packages = raw_data.get("packages")
+    if not isinstance(packages, list):
+        return None
+    return {value for value in packages if isinstance(value, str) and value}
+
+
+def _deployment_details(
+    *,
+    install_succeeded: bool,
+    before_packages: Optional[Set[str]],
+    after_packages: Optional[Set[str]],
+) -> dict[str, Any]:
+    if not install_succeeded:
+        return {}
+    if before_packages is None or after_packages is None:
+        return {"deployment_action": "installed_or_updated"}
+
+    added = sorted(after_packages - before_packages)
+    if added:
+        details: dict[str, Any] = {"deployment_action": "installed"}
+        if len(added) == 1:
+            details["deployment_package"] = added[0]
+        return details
+    return {"deployment_action": "updated"}
+
+
 def _public_result(
     result: Mapping[str, Any],
     *,
     apk_name: str,
     apk_size_bytes: int,
+    before_packages: Optional[Set[str]],
+    after_packages: Optional[Set[str]],
 ) -> dict[str, Any]:
     public = dict(result)
     raw_data = public.get("data")
@@ -72,6 +115,13 @@ def _public_result(
     data.pop("apk_path", None)
     data["apk_name"] = apk_name
     data["apk_size_bytes"] = apk_size_bytes
+    data.update(
+        _deployment_details(
+            install_succeeded=bool(public.get("success")),
+            before_packages=before_packages,
+            after_packages=after_packages,
+        )
+    )
     public["data"] = data
     return public
 
@@ -153,6 +203,7 @@ def handle_apk_upload(handler: Any, cid: str) -> None:
             upload.flush()
             os.fsync(upload.fileno())
 
+        before_packages = _package_inventory(serial)
         result = execute_adb_operation(
             "install",
             {
@@ -162,10 +213,13 @@ def handle_apk_upload(handler: Any, cid: str) -> None:
                 "grant_permissions": grant_permissions,
             },
         )
+        after_packages = _package_inventory(serial) if result.get("success") else None
         public_result = _public_result(
             result,
             apk_name=apk_name,
             apk_size_bytes=length,
+            before_packages=before_packages,
+            after_packages=after_packages,
         )
         result_code = str(public_result.get("result_code") or RESULT_FAILED)
         handler._respond(

--- a/tests/test_api_devhub_apk_upload.py
+++ b/tests/test_api_devhub_apk_upload.py
@@ -43,16 +43,38 @@ def _response_json(handler):
     return json.loads(handler.wfile.getvalue().decode("utf-8"))
 
 
-def test_apk_upload_streams_to_temporary_file_and_installs(monkeypatch, tmp_path):
+def test_apk_upload_streams_to_temporary_file_and_classifies_new_install(
+    monkeypatch, tmp_path
+):
     monkeypatch.setenv("VR_HOTSPOTD_API_TOKEN", "secret")
     monkeypatch.setattr(apk_upload, "APK_UPLOAD_DIR", tmp_path)
     apk_bytes = b"PK\x03\x04test-apk"
-    seen = {}
+    seen = {"operations": [], "package_calls": 0}
 
     def fake_execute(operation, request=None):
         payload = dict(request or {})
+        seen["operations"].append(operation)
+        if operation == "packages":
+            seen["package_calls"] += 1
+            packages = ["com.example.existing"]
+            if seen["package_calls"] == 2:
+                packages.append("com.example.training")
+            return {
+                "schema_version": 1,
+                "operation": operation,
+                "success": True,
+                "result_code": "ok",
+                "returncode": 0,
+                "stdout": "",
+                "stderr": "",
+                "data": {
+                    "serial": payload["serial"],
+                    "third_party_only": True,
+                    "packages": packages,
+                },
+            }
+
         upload_path = Path(payload["apk_path"])
-        seen["operation"] = operation
         seen["request"] = payload
         seen["bytes"] = upload_path.read_bytes()
         seen["temporary_path"] = upload_path
@@ -79,7 +101,7 @@ def test_apk_upload_streams_to_temporary_file_and_installs(monkeypatch, tmp_path
     payload = _response_json(handler)
 
     assert handler._last_code == 200
-    assert seen["operation"] == "install"
+    assert seen["operations"] == ["packages", "install", "packages"]
     assert seen["request"]["serial"] == SERIAL
     assert seen["request"]["reinstall"] is True
     assert seen["request"]["grant_permissions"] is True
@@ -88,6 +110,26 @@ def test_apk_upload_streams_to_temporary_file_and_installs(monkeypatch, tmp_path
     assert "apk_path" not in payload["data"]["data"]
     assert payload["data"]["data"]["apk_name"] == "training.apk"
     assert payload["data"]["data"]["apk_size_bytes"] == len(apk_bytes)
+    assert payload["data"]["data"]["deployment_action"] == "installed"
+    assert payload["data"]["data"]["deployment_package"] == "com.example.training"
+
+
+def test_deployment_details_distinguish_update_and_unknown_inventory() -> None:
+    assert apk_upload._deployment_details(
+        install_succeeded=True,
+        before_packages={"com.example.training"},
+        after_packages={"com.example.training"},
+    ) == {"deployment_action": "updated"}
+    assert apk_upload._deployment_details(
+        install_succeeded=True,
+        before_packages=None,
+        after_packages=None,
+    ) == {"deployment_action": "installed_or_updated"}
+    assert apk_upload._deployment_details(
+        install_succeeded=False,
+        before_packages={"com.example.training"},
+        after_packages={"com.example.training"},
+    ) == {}
 
 
 def test_apk_upload_requires_auth_before_reading_body(monkeypatch):

--- a/tests/test_devhub_apk_picker_ui.py
+++ b/tests/test_devhub_apk_picker_ui.py
@@ -27,12 +27,25 @@ def test_developer_hub_exposes_browser_apk_picker():
     assert "devhubApkPicker" in source
     assert "devhubApkFile" in source
     assert "Choose APK" in source
-    assert "Install on headset" in source
+    assert "Install or update app" in source
     assert "/v1/devbridge/adb/install-upload" in source
     assert "application/vnd.android.package-archive" in source
     assert "X-VRhotspot-Serial" in source
     assert "X-VRhotspot-Apk-Name" in source
     assert "body: file" in source
+
+
+def test_upload_always_allows_update_and_reports_detected_action():
+    source = UPLOAD_JS.read_text(encoding="utf-8")
+
+    assert "'X-VRhotspot-Reinstall': '1'" in source
+    assert "deploymentData" in source
+    assert "deployment_action" in source
+    assert "deploymentVerb" in source
+    assert "Updated" in source
+    assert "Installed or updated" in source
+    assert "selectedHeadsetLabel" in source
+    assert "on ${headset}" in source
 
 
 def test_host_path_install_is_preserved_as_advanced_fallback():

--- a/tests/test_devhub_device_identity_privacy.py
+++ b/tests/test_devhub_device_identity_privacy.py
@@ -39,14 +39,20 @@ def test_identity_assets_are_served_by_devhub_handler() -> None:
     ) in source
 
 
-def test_model_first_identity_and_privacy_contract() -> None:
+def test_model_transport_identity_and_privacy_contract() -> None:
     source = IDENTITY_JS.read_text(encoding="utf-8")
     index = INDEX.read_text(encoding="utf-8")
 
     assert 'el("privacyMode")' in source or "el('privacyMode')" in source
     assert 'id="privacyMode"' in index
     assert "modelFromMeta" in source
+    assert "transportForSerial" in source
+    assert "Wireless" in source
+    assert "Wired" in source
+    assert "identityLabel" in source
     assert "devhubSelectedDeviceName" in source
+    assert "devhubTargetDeviceName" in source
+    assert "devhubAppsDeviceName" in source
     assert "devhubWorkspaceDeviceSerial" in source
     assert "devhubOverviewIp" in source
     assert "Hidden by Privacy Mode" in source
@@ -54,12 +60,30 @@ def test_model_first_identity_and_privacy_contract() -> None:
     assert "devhub-device-model-source" in source
 
 
-def test_privacy_css_hides_sensitive_identifiers_only_when_enabled() -> None:
+def test_app_feedback_and_install_controls_are_novice_friendly() -> None:
+    source = IDENTITY_JS.read_text(encoding="utf-8")
+
+    assert "Loading apps from" in source
+    assert "Loaded $1 app(s) from" in source
+    assert "App inventory failed" in source
+    assert "Target headset" in source
+    assert "Install or update app" in source
+    assert "devhubAdvancedInstallOptions" in source
+    assert "Automatic permission grants are intended for controlled testing" in source
+    assert "reinstall.checked = true" in source
+    assert "devhub-install-option-hidden" in source
+
+
+def test_privacy_css_hides_identifiers_and_raw_serial_fields() -> None:
     source = IDENTITY_CSS.read_text(encoding="utf-8")
 
     assert ".devhub-privacy-active .devhub-sensitive-identifier" in source
+    assert ".devhub-raw-device-serial" in source
     assert "display: none !important" in source
     assert ".devhub-device-model-source" in source
+    assert ".devhub-target-device-display" in source
+    assert ".devhub-apps-device-context" in source
+    assert ".devhub-advanced-install-options" in source
 
 
 def test_identity_javascript_syntax() -> None:


### PR DESCRIPTION
## Summary

Make the Developer Hub Apps workflow understandable to users who are new to Linux and ADB.

## Device identity

- Label every connected headset as `Model (Wired)` or `Model (Wireless)`.
- Use the same transport-aware identity in the selected-headset panel, APK target, and Installed Applications context.
- Keep raw USB serials and IP addresses as secondary metadata only.
- Continue hiding sensitive identifiers when Privacy Mode is enabled.
- Rewrite app inventory feedback to use the headset identity rather than its serial/IP.

## APK deployment

- Replace the visible Target serial field with a read-only Target headset identity.
- Make reinstall/update behavior automatic rather than a checkbox users must understand.
- Rename the primary action to Install or update app.
- Move Grant runtime permissions into Advanced install options, off by default, with an info explanation for automated testing use cases.
- Keep daemon-host path deployment as an advanced fallback.

## Install versus update detection

The upload handler records the third-party package inventory before and after a successful deployment:

- a newly appearing package is reported as installed;
- no package-set change is reported as updated;
- unavailable inventory is reported as installed_or_updated.

The browser presents the detected result without exposing package-management mechanics to the user.

## Validation

- Backend install/update classification tests.
- Transport-aware identity and privacy contracts.
- Novice install controls and target-headset contracts.
- JavaScript syntax checks.
- Full repository CI matrix.