### PR TITLE
Polish Developer Hub privacy, layout, and storage reporting

### DIFF
--- a/assets/devhub_device_identity.css
+++ b/assets/devhub_device_identity.css
@@ -1,4 +1,4 @@
-.devhub-raw-device-serial {
+#devhubSelectedDevice.devhub-raw-device-serial {
   display: none !important;
 }
 
@@ -117,6 +117,121 @@
   font-size: 12px;
 }
 
+/* The selected-headset card already owns device identity and transport state. */
+.devhub-device-bar {
+  display: none !important;
+}
+
+/* Keep automatic-refresh help attached to the timestamp instead of floating left. */
+.devhub-workspace-meta {
+  gap: 6px;
+}
+
+#devhubWorkspaceUpdated {
+  order: 1;
+}
+
+.devhub-refresh-help {
+  order: 2;
+  margin-right: 0 !important;
+}
+
 .devhub-privacy-active .devhub-sensitive-identifier {
   display: none !important;
+}
+
+/* SSIDs are personally identifying network data. */
+.devhub-privacy-active #devhubOverviewWifi {
+  position: relative;
+  color: transparent !important;
+  user-select: none;
+}
+
+.devhub-privacy-active #devhubOverviewWifi::after {
+  content: "Hidden by Privacy Mode";
+  position: absolute;
+  inset: 0 auto auto 0;
+  color: var(--text-main);
+}
+
+/* Keep package identifiers usable internally while masking them on screen. */
+.devhub-privacy-active #devhubPackageList .devhub-list-title {
+  position: relative;
+  color: transparent !important;
+  user-select: none;
+}
+
+.devhub-privacy-active #devhubPackageList .devhub-list-title::after {
+  content: "Installed app";
+  position: absolute;
+  inset: 0 auto auto 0;
+  color: var(--text-main);
+}
+
+.devhub-privacy-active #devhubSelectedPackage {
+  position: relative;
+  color: transparent !important;
+  user-select: none;
+}
+
+.devhub-privacy-active #devhubSelectedPackage::after {
+  content: "Hidden by Privacy Mode";
+  position: absolute;
+  inset: 0 auto auto 0;
+  color: var(--text-main);
+}
+
+.devhub-privacy-active #devhubPackageName {
+  color: transparent !important;
+  caret-color: transparent;
+}
+
+.devhub-privacy-active #devhubPackageName:focus {
+  border-color: var(--border-subtle);
+  box-shadow: none;
+}
+
+.devhub-privacy-active #devhubPackageName.closest {
+  position: relative;
+}
+
+.devhub-privacy-active .devhub-field:has(#devhubPackageName) {
+  position: relative;
+}
+
+.devhub-privacy-active .devhub-field:has(#devhubPackageName)::after {
+  content: "Hidden by Privacy Mode";
+  position: absolute;
+  left: 12px;
+  bottom: 10px;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+/* Operation details can include APK filenames or package identifiers. */
+.devhub-privacy-active .devhub-activity.visible {
+  position: relative;
+  color: transparent !important;
+  user-select: none;
+}
+
+.devhub-privacy-active .devhub-activity.visible::after {
+  position: absolute;
+  inset: 10px 12px auto;
+  color: var(--text-main);
+}
+
+.devhub-privacy-active .devhub-activity.visible[data-state="loading"]::after {
+  content: "Working…";
+  color: var(--accent-primary);
+}
+
+.devhub-privacy-active .devhub-activity.visible[data-state="success"]::after {
+  content: "Operation completed.";
+  color: var(--success);
+}
+
+.devhub-privacy-active .devhub-activity.visible[data-state="error"]::after {
+  content: "Operation failed. Disable Privacy Mode for details.";
+  color: var(--danger);
 }

--- a/backend/vr_hotspotd/devtools/device_overview.py
+++ b/backend/vr_hotspotd/devtools/device_overview.py
@@ -138,22 +138,57 @@ def _parse_battery(text: str) -> Dict[str, Any]:
 
 
 def _parse_storage(text: str) -> Dict[str, Any]:
-    for line in reversed(text.splitlines()):
+    """Parse both normal and wrapped Android toybox ``df -k`` output."""
+
+    candidates = []
+    for line_number, line in enumerate(text.splitlines()):
         parts = line.split()
-        if len(parts) < 6 or parts[-1] != "/data":
+        if len(parts) < 4:
             continue
-        total_kib = _parse_int(parts[1])
-        used_kib = _parse_int(parts[2])
-        available_kib = _parse_int(parts[3])
+
+        # Long Android device-mapper names can wrap onto their own line. In that
+        # case the following row begins directly with the numeric block count.
+        numeric_first = _parse_int(parts[0]) is not None
+        offset = 0 if numeric_first else 1
+        if len(parts) < offset + 4:
+            continue
+
+        total_kib = _parse_int(parts[offset])
+        used_kib = _parse_int(parts[offset + 1])
+        available_kib = _parse_int(parts[offset + 2])
+        used_percent = _parse_int(parts[offset + 3].rstrip("%"))
         if total_kib is None or used_kib is None or available_kib is None:
-            break
-        return {
-            "total_bytes": total_kib * 1024,
-            "used_bytes": used_kib * 1024,
-            "available_bytes": available_kib * 1024,
-            "used_percent": _parse_int(parts[4].rstrip("%")),
-        }
-    return {}
+            continue
+
+        mount = parts[-1] if not parts[-1].endswith("%") else ""
+        if mount == "/data":
+            mount_score = 3
+        elif mount.startswith("/data/"):
+            mount_score = 2
+        elif mount.startswith("/storage/emulated"):
+            mount_score = 1
+        else:
+            mount_score = 0
+
+        candidates.append(
+            (
+                mount_score,
+                line_number,
+                {
+                    "total_bytes": total_kib * 1024,
+                    "used_bytes": used_kib * 1024,
+                    "available_bytes": available_kib * 1024,
+                    "used_percent": used_percent,
+                },
+            )
+        )
+
+    if not candidates:
+        return {}
+
+    # The command is scoped to /data, so an unlabelled wrapped numeric row is a
+    # valid fallback. Prefer an explicitly identified data mount when present.
+    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
 
 
 def _first_match(pattern: str, text: str, flags: int = re.IGNORECASE) -> Optional[str]:

--- a/tests/test_devhub_privacy_layout_storage.py
+++ b/tests/test_devhub_privacy_layout_storage.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from vr_hotspotd.devtools.device_overview import _parse_storage
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IDENTITY_CSS = ROOT / "assets" / "devhub_device_identity.css"
+
+
+def test_android_storage_parser_accepts_standard_data_mount() -> None:
+    result = _parse_storage(
+        "\n".join(
+            [
+                "Filesystem 1K-blocks Used Available Use% Mounted on",
+                "/dev/block/dm-10 104857600 52428800 52428800 50% /data",
+            ]
+        )
+    )
+
+    assert result == {
+        "total_bytes": 104857600 * 1024,
+        "used_bytes": 52428800 * 1024,
+        "available_bytes": 52428800 * 1024,
+        "used_percent": 50,
+    }
+
+
+def test_android_storage_parser_accepts_wrapped_device_mapper_output() -> None:
+    result = _parse_storage(
+        "\n".join(
+            [
+                "Filesystem 1K-blocks Used Available Use% Mounted on",
+                "/dev/block/mapper/userdata-long-device-name",
+                "122070312 42000000 80070312 35% /data/user/0",
+            ]
+        )
+    )
+
+    assert result["total_bytes"] == 122070312 * 1024
+    assert result["available_bytes"] == 80070312 * 1024
+    assert result["used_percent"] == 35
+
+
+def test_device_workspace_removes_redundant_top_bar_and_groups_refresh_help() -> None:
+    source = IDENTITY_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-device-bar" in source
+    assert "display: none !important" in source
+    assert "#devhubWorkspaceUpdated" in source
+    assert ".devhub-refresh-help" in source
+    assert "margin-right: 0 !important" in source
+
+
+def test_privacy_mode_masks_network_app_and_operation_details() -> None:
+    source = IDENTITY_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-privacy-active #devhubOverviewWifi" in source
+    assert ".devhub-privacy-active #devhubPackageList .devhub-list-title" in source
+    assert ".devhub-privacy-active #devhubSelectedPackage" in source
+    assert ".devhub-privacy-active #devhubPackageName" in source
+    assert ".devhub-privacy-active .devhub-activity.visible" in source
+    assert "Hidden by Privacy Mode" in source
+    assert "Operation completed." in source


### PR DESCRIPTION
## Summary

Refine the Developer Hub based on real Quest 3S usage.

## Layout

- Remove the redundant top device/status bar; the Headsets panel already owns selection and transport state.
- Keep the automatic-refresh info icon directly beside the Updated timestamp.

## Privacy Mode

- Hide the Wi-Fi SSID.
- Mask installed application/package names while preserving the underlying values for actions.
- Mask the selected package and manual package field.
- Replace operation details that may contain APK filenames or package identifiers with generic privacy-safe status text.
- Continue hiding IP addresses and device serials.

## Storage

Android toybox can wrap long device-mapper filesystem names onto a separate line or report a more specific data mount. The previous parser required the final column to be exactly `/data`, causing valid Quest storage output to be discarded. The parser now supports standard rows, wrapped numeric rows, `/data/*`, and scoped unlabeled fallback rows.

## Validation

- Standard `/data` storage parsing.
- Wrapped Quest/Android device-mapper storage parsing.
- Redundant top-bar removal contract.
- Timestamp/help placement contract.
- Privacy masking contracts for SSID, apps, selected package, and operation feedback.
- Full repository CI matrix.