### PR TITLE
Clarify app installation and privacy labels

### DIFF
--- a/assets/devhub_device_identity.css
+++ b/assets/devhub_device_identity.css
@@ -1,4 +1,5 @@
-#devhubSelectedDevice.devhub-raw-device-serial {
+#devhubSelectedDevice.devhub-raw-device-serial,
+#devhubPackageSerial.devhub-raw-device-serial {
   display: none !important;
 }
 
@@ -78,6 +79,16 @@
   font-size: 13px;
 }
 
+/* Use plain-language terminology while keeping the original DOM contract. */
+.card:has(#devhubInstallForm) .card-header h2 {
+  font-size: 0;
+}
+
+.card:has(#devhubInstallForm) .card-header h2::after {
+  content: "Install App";
+  font-size: 14px;
+}
+
 .devhub-install-option-hidden,
 .devhub-install-options-empty {
   display: none !important;
@@ -154,6 +165,19 @@
   color: var(--text-main);
 }
 
+/* Explain redaction before masking individual app identifiers. */
+.devhub-privacy-active #devhubPackageList::before {
+  content: "App names hidden by Privacy Mode";
+  display: block;
+  margin-bottom: 10px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 /* Keep package identifiers usable internally while masking them on screen. */
 .devhub-privacy-active #devhubPackageList .devhub-list-title {
   position: relative;
@@ -162,7 +186,7 @@
 }
 
 .devhub-privacy-active #devhubPackageList .devhub-list-title::after {
-  content: "Installed app";
+  content: "App name hidden";
   position: absolute;
   inset: 0 auto auto 0;
   color: var(--text-main);

--- a/tests/test_devhub_privacy_layout_storage.py
+++ b/tests/test_devhub_privacy_layout_storage.py
@@ -61,3 +61,19 @@ def test_privacy_mode_masks_network_app_and_operation_details() -> None:
     assert ".devhub-privacy-active .devhub-activity.visible" in source
     assert "Hidden by Privacy Mode" in source
     assert "Operation completed." in source
+
+
+def test_app_install_uses_plain_language_and_never_shows_raw_target_serial() -> None:
+    source = IDENTITY_CSS.read_text(encoding="utf-8")
+
+    assert "#devhubPackageSerial.devhub-raw-device-serial" in source
+    assert '.card:has(#devhubInstallForm) .card-header h2::after' in source
+    assert 'content: "Install App"' in source
+
+
+def test_privacy_mode_explains_that_app_names_are_intentionally_hidden() -> None:
+    source = IDENTITY_CSS.read_text(encoding="utf-8")
+
+    assert ".devhub-privacy-active #devhubPackageList::before" in source
+    assert 'content: "App names hidden by Privacy Mode"' in source
+    assert 'content: "App name hidden"' in source


### PR DESCRIPTION
## Summary

Polish the Developer Hub Apps view for novice users.

## Changes

- Rename the visible `APK Deployment` heading to `Install App`.
- Hide the raw target serial/IP field again while preserving the underlying value used by install operations.
- Keep the selected headset identity visible as `Model (Wired)` or `Model (Wireless)`.
- Show an explicit `App names hidden by Privacy Mode` notice above the installed-app list.
- Replace each redacted package title with `App name hidden` so Privacy Mode cannot be mistaken for a package-reading failure.

## Validation

- Raw target serial remains hidden.
- Plain-language install heading is present.
- Privacy notice and redacted app labels are covered by focused tests.
- Full repository CI matrix.