### PR TITLE
Stop active services before backend file sync

### DIFF
--- a/backend/scripts/install.sh
+++ b/backend/scripts/install.sh
@@ -264,6 +264,9 @@ install -d -m 755 /etc/vr-hotspot
 touch /etc/vr-hotspot/env
 chmod 600 /etc/vr-hotspot/env || true
 
+log "Stopping active VRhotspot services before file sync"
+systemctl stop "$AUTOSTART_UNIT" "$DAEMON_UNIT" &>/dev/null || true
+
 log "Copying application files -> $INSTALL_DIR"
 # Copy source code
 mkdir -p "$INSTALL_DIR"

--- a/tests/test_backend_installer_update_safety.py
+++ b/tests/test_backend_installer_update_safety.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "backend" / "scripts" / "install.sh"
+
+
+def test_installer_stops_runtime_before_overwriting_bundled_executables() -> None:
+    source = INSTALLER.read_text(encoding="utf-8")
+
+    stop_marker = 'systemctl stop "$AUTOSTART_UNIT" "$DAEMON_UNIT"'
+    copy_marker = 'cp -r "$BACKEND_SRC/../." "$INSTALL_DIR/"'
+
+    assert stop_marker in source
+    assert source.index(stop_marker) < source.index(copy_marker)
+    assert 'Stopping active VRhotspot services before file sync' in source


### PR DESCRIPTION
## Summary

Prevent backend updates from failing with `Text file busy` when bundled `hostapd` or `dnsmasq` is still running from the installed application tree.

## Changes

- Stop `vr-hotspot-autostart.service` and `vr-hotspotd.service` before copying application files.
- Tolerate missing units during fresh installs.
- Preserve the existing post-install daemon restart and autostart-state synchronization.
- Add a regression test requiring the stop step to occur before the copy operation.

## Real-system finding

A CachyOS update to PR #127 failed while copying `/var/lib/vr-hotspot/app/backend/vendor/bin/hostapd` because the installed binary was active. Manually stopping VRhotspot services allowed the same installer to complete successfully.