### PR TITLE
Remove Adapter Readiness from Basic mode

### DIFF
--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -50,6 +50,19 @@ window.UI_FIELD_VISIBILITY = {
   debug: "advanced"
 };
 
+(function removeBasicAdapterReadinessCard() {
+  function removeCard() {
+    const card = document.querySelector('[data-adapter-readiness-card]');
+    if (card) card.remove();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', removeCard, { once: true });
+  } else {
+    removeCard();
+  }
+})();
+
 (function loadDeveloperHubAssets() {
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';

--- a/tests/test_basic_mode_adapter_readiness_visibility.py
+++ b/tests/test_basic_mode_adapter_readiness_visibility.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIELD_VISIBILITY = ROOT / "assets" / "field_visibility.js"
+INDEX_HTML = ROOT / "assets" / "index.html"
+
+
+def test_basic_mode_removes_adapter_readiness_card_from_the_dom() -> None:
+    source = FIELD_VISIBILITY.read_text(encoding="utf-8")
+
+    assert "removeBasicAdapterReadinessCard" in source
+    assert "[data-adapter-readiness-card]" in source
+    assert "card.remove()" in source
+
+
+def test_adapter_readiness_markup_remains_available_to_the_readiness_engine() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert 'data-adapter-readiness-card' in html
+    assert 'data-readiness-field="recommended"' in html


### PR DESCRIPTION
## Summary

Simplify the Basic-mode dashboard by removing the Adapter Readiness card from the rendered interface.

## Changes

- Remove the Basic-mode Adapter Readiness card from the DOM after page initialization.
- Keep the readiness engine, adapter recommendation, and underlying markup/data contracts intact for Pro diagnostics and future troubleshooting.
- Add regression coverage so the Basic-mode card cannot reappear unnoticed.

## Rationale

The recommended adapter is already surfaced directly in Connection Setup. Showing score, capability tags, 6 GHz support, and readiness reasoning in Basic mode duplicates information and adds technical noise for novice users.