### PR TITLE
Restore full-width two-column Basic desktop layout

### DIFF
--- a/assets/basic_layout.css
+++ b/assets/basic_layout.css
@@ -1,0 +1,13 @@
+/*
+ * Basic-mode desktop layout refinement.
+ *
+ * PR #89 introduced a three-column wide-screen grid for Connection Setup,
+ * Status & Control, and Adapter Readiness. Adapter Readiness is no longer
+ * rendered in Basic mode, so preserve the existing responsive grid while
+ * allowing the two remaining cards to use the full desktop container.
+ */
+@media (min-width: 1400px) {
+  body[data-ui-mode="basic"] .basic-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -63,6 +63,13 @@ window.UI_FIELD_VISIBILITY = {
   }
 })();
 
+(function loadBasicModeLayout() {
+  const stylesheet = document.createElement('link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = '/assets/basic_layout.css';
+  document.head.appendChild(stylesheet);
+})();
+
 (function loadDeveloperHubAssets() {
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -43,6 +43,7 @@ DEVICE_OVERVIEW_PATH = "/v1/devbridge/adb/device-overview"
 WIRELESS_BOOTSTRAP_PATH = "/v1/devbridge/adb/enable-wireless"
 
 _DEVHUB_ASSET_TYPES = {
+    "/assets/basic_layout.css": "text/css; charset=utf-8",
     "/assets/devhub.css": "text/css; charset=utf-8",
     "/assets/devhub.js": "application/javascript; charset=utf-8",
     "/assets/devhub_upload.css": "text/css; charset=utf-8",

--- a/tests/test_basic_mode_desktop_layout.py
+++ b/tests/test_basic_mode_desktop_layout.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BASIC_LAYOUT = ROOT / "assets" / "basic_layout.css"
+FIELD_VISIBILITY = ROOT / "assets" / "field_visibility.js"
+CORE_UI = ROOT / "assets" / "ui.css"
+DEVHUB_API = ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py"
+
+
+def test_wide_basic_mode_reuses_two_column_grid_after_readiness_removal() -> None:
+    layout = BASIC_LAYOUT.read_text(encoding="utf-8")
+
+    assert '@media (min-width: 1400px)' in layout
+    assert 'body[data-ui-mode="basic"] .basic-grid' in layout
+    assert 'grid-template-columns: repeat(2, minmax(0, 1fr));' in layout
+    assert ".advanced-layout" not in layout
+    assert ".content-area" not in layout
+
+
+def test_existing_responsive_container_and_mobile_stack_remain_intact() -> None:
+    core = CORE_UI.read_text(encoding="utf-8")
+
+    assert "max-width: 1720px;" in core
+    assert "@media (max-width: 760px)" in core
+    assert "grid-template-columns: minmax(0, 1fr);" in core
+
+
+def test_basic_layout_asset_is_loaded_and_served() -> None:
+    loader = FIELD_VISIBILITY.read_text(encoding="utf-8")
+    api = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert "loadBasicModeLayout" in loader
+    assert "'/assets/basic_layout.css'" in loader
+    assert '"/assets/basic_layout.css": "text/css; charset=utf-8"' in api
+
+
+def test_adapter_readiness_removal_and_pro_layout_contracts_are_unchanged() -> None:
+    loader = FIELD_VISIBILITY.read_text(encoding="utf-8")
+    core = CORE_UI.read_text(encoding="utf-8")
+
+    assert "removeBasicAdapterReadinessCard" in loader
+    assert "card.remove()" in loader
+    assert ".advanced-layout" in core
+    assert ".sidebar" in core
+    assert ".content-area" in core


### PR DESCRIPTION
## Summary

Use the existing Basic-mode responsive layout correctly after removing Adapter Readiness.

## Root cause

PR #89 intentionally switched Basic mode to three equal columns above 1400px so Connection Setup, Status & Control, and Adapter Readiness could share one desktop row. PR #129 removed Adapter Readiness from the rendered Basic interface, but the wide-screen grid continued reserving its third column. On a 2560x1440 display, the two remaining cards therefore occupied only two-thirds of the already-wired 1720px container.

## Changes

- Add a Basic-mode-only wide-screen override that keeps the existing grid at two columns above 1400px.
- Preserve the existing 1720px container, fluid gap, one-column mobile breakpoint, card internals, and all Pro-mode layout rules.
- Load and serve the scoped stylesheet through the existing portal asset path.
- Add regression coverage for the desktop override, mobile stack, asset wiring, Adapter Readiness removal, and unchanged Pro layout contracts.

## Boundaries

- No form, control, card, header, or content changes.
- No JavaScript behavior changes beyond loading the scoped stylesheet.
- No API, daemon, networking, installer, Developer Hub, or Flatpak behavior changes.
- No new layout framework or duplicate DOM structure.