### PR TITLE
Add comfortable desktop density to Basic mode

### DIFF
--- a/assets/basic_layout.css
+++ b/assets/basic_layout.css
@@ -1,10 +1,193 @@
 /*
- * Basic-mode desktop layout refinement.
+ * Basic-mode desktop layout and density refinements.
  *
+ * These rules intentionally apply only to the Basic dashboard on desktop.
+ * They preserve the existing DOM, responsive mobile stack, and Pro layout
+ * while making the 100% browser view feel like the previously preferred
+ * enlarged desktop presentation.
+ */
+@media (min-width: 1200px) {
+  body[data-ui-mode="basic"] .top-header {
+    height: 112px;
+    padding-inline: clamp(28px, 2vw, 44px);
+  }
+
+  body[data-ui-mode="basic"] .brand-logo-small {
+    height: 100px;
+  }
+
+  body[data-ui-mode="basic"] .ui-mode-toggle {
+    gap: 10px;
+    padding: 6px 10px;
+  }
+
+  body[data-ui-mode="basic"] .mode-label {
+    font-size: 14px;
+  }
+
+  body[data-ui-mode="basic"] .slider-toggle {
+    width: 42px;
+    height: 24px;
+  }
+
+  body[data-ui-mode="basic"] .slider-toggle .slider::before {
+    width: 18px;
+    height: 18px;
+  }
+
+  body[data-ui-mode="basic"] .slider-toggle input:checked + .slider::before {
+    transform: translateX(18px);
+  }
+
+  body[data-ui-mode="basic"] .basic-container {
+    max-width: 2480px;
+    padding: clamp(30px, 1.75vw, 44px);
+  }
+
+  body[data-ui-mode="basic"] .basic-grid {
+    gap: clamp(28px, 1.8vw, 40px);
+  }
+
+  body[data-ui-mode="basic"] .basic-card .card-header {
+    padding: 24px 30px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .card-header h2 {
+    font-size: 18px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .card-body {
+    padding: 30px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .form-group {
+    margin-bottom: 22px;
+  }
+
+  body[data-ui-mode="basic"] .basic-connect-inline {
+    padding-top: 22px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card label {
+    margin-bottom: 9px;
+    font-size: 15px !important;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .field-label-with-tip {
+    gap: 8px;
+    margin-bottom: 9px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .field-label-with-tip label,
+  body[data-ui-mode="basic"] .basic-card .tog {
+    margin-bottom: 0;
+  }
+
+  body[data-ui-mode="basic"] .basic-card input:not([type="checkbox"]):not([type="radio"]),
+  body[data-ui-mode="basic"] .basic-card select,
+  body[data-ui-mode="basic"] .basic-card textarea {
+    min-height: 50px;
+    padding: 12px 16px;
+    font-size: 17px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .small {
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .info-banner {
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+
+  body[data-ui-mode="basic"] [data-ui-section="basic"] .btn {
+    height: 48px;
+    padding: 0 22px;
+    font-size: 16px;
+    line-height: 1.2;
+  }
+
+  body[data-ui-mode="basic"] .basic-status-actions {
+    gap: 14px;
+  }
+
+  body[data-ui-mode="basic"] .basic-status-actions .btn,
+  body[data-ui-mode="basic"] .basic-connect-actions .btn {
+    height: 48px;
+    padding-inline: 18px;
+    font-size: 16px;
+  }
+
+  body[data-ui-mode="basic"] .basic-passphrase-actions {
+    gap: 12px;
+  }
+
+  body[data-ui-mode="basic"] .basic-passphrase-actions .btn.icon-only {
+    width: 48px;
+    min-width: 48px;
+    flex-basis: 48px;
+    padding: 0;
+  }
+
+  body[data-ui-mode="basic"] .basic-passphrase-actions .basic-qr-toggle {
+    width: 48px;
+    font-size: 12px;
+  }
+
+  body[data-ui-mode="basic"] .qos-basic .seg span {
+    min-height: 48px;
+    padding: 10px 22px;
+    font-size: 15px;
+  }
+
+  body[data-ui-mode="basic"] .segmented {
+    gap: 10px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .pill {
+    gap: 10px;
+    padding: 8px 16px;
+    font-size: 16px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .pill .dot {
+    width: 10px;
+    height: 10px;
+  }
+
+  body[data-ui-mode="basic"] .basic-status-preferences {
+    gap: 14px;
+  }
+
+  body[data-ui-mode="basic"] .basic-status-preferences .tog {
+    min-height: 46px;
+    padding: 0 14px;
+    font-size: 14px !important;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .tog input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+  }
+
+  body[data-ui-mode="basic"] .basic-card .tip {
+    width: 19px;
+    height: 19px;
+    font-size: 12px;
+  }
+
+  body[data-ui-mode="basic"] #basicTelemetryContainer {
+    padding: 12px !important;
+    font-size: 14px !important;
+    line-height: 1.5;
+  }
+}
+
+/*
  * PR #89 introduced a three-column wide-screen grid for Connection Setup,
  * Status & Control, and Adapter Readiness. Adapter Readiness is no longer
- * rendered in Basic mode, so preserve the existing responsive grid while
- * allowing the two remaining cards to use the full desktop container.
+ * rendered in Basic mode, so the two remaining cards keep the full row.
  */
 @media (min-width: 1400px) {
   body[data-ui-mode="basic"] .basic-grid {

--- a/tests/test_basic_mode_desktop_layout.py
+++ b/tests/test_basic_mode_desktop_layout.py
@@ -18,6 +18,24 @@ def test_wide_basic_mode_reuses_two_column_grid_after_readiness_removal() -> Non
     assert ".content-area" not in layout
 
 
+def test_basic_desktop_uses_comfortable_native_density_without_page_scaling() -> None:
+    layout = BASIC_LAYOUT.read_text(encoding="utf-8")
+
+    assert '@media (min-width: 1200px)' in layout
+    assert 'body[data-ui-mode="basic"] .basic-container' in layout
+    assert "max-width: 2480px;" in layout
+    assert 'body[data-ui-mode="basic"] .basic-card .card-header' in layout
+    assert "padding: 24px 30px;" in layout
+    assert 'body[data-ui-mode="basic"] .basic-card .card-body' in layout
+    assert "padding: 30px;" in layout
+    assert "min-height: 50px;" in layout
+    assert 'body[data-ui-mode="basic"] [data-ui-section="basic"] .btn' in layout
+    assert "height: 48px;" in layout
+    assert "font-size: 17px;" in layout
+    assert "zoom:" not in layout
+    assert "transform: scale(" not in layout
+
+
 def test_existing_responsive_container_and_mobile_stack_remain_intact() -> None:
     core = CORE_UI.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Make Basic mode feel intentionally sized for a 2560×1440 desktop at 100% browser zoom, matching the comfortable physical presence the current interface has at approximately 150% zoom.

## Changes

- Expand the existing Basic desktop container from its historical 1720px cap to a Basic-only 2480px cap on viewports at least 1200px wide.
- Increase Basic-only card padding, headings, labels, helper text, inputs, selectors, buttons, segmented controls, status pills, toggles, tooltips, and checkbox targets.
- Slightly enlarge the Basic header logo and mode switch so the entire Basic surface has consistent density.
- Preserve the existing two-column desktop layout and the mobile responsive stack.
- Add focused regression coverage for native sizing and explicitly prohibit blanket `zoom` or `transform: scale()` implementations.

## Safety boundaries

- Uses the already-wired `assets/basic_layout.css` introduced by PR #130.
- No HTML or DOM restructuring.
- No JavaScript behavior or control wiring changes.
- No API, daemon, networking, installer, or Flatpak permission changes.
- No Pro-mode selectors or layout changes.
- No browser zoom, CSS zoom, or whole-page transform scaling.