### PR TITLE
Redesign Basic mode as a guided hotspot setup

### DIFF
--- a/assets/basic_guided.css
+++ b/assets/basic_guided.css
@@ -1,0 +1,722 @@
+/* Guided Basic-mode presentation. Existing controls and IDs remain live. */
+
+body[data-ui-mode="basic"] .basic-container {
+  width: 100%;
+}
+
+body[data-ui-mode="basic"] .basic-grid {
+  align-items: stretch;
+  grid-template-columns: minmax(0, 1.34fr) minmax(440px, .96fr);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card {
+  height: 100%;
+  overflow: hidden;
+  border-color: rgba(115, 126, 180, .28);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(0, 243, 255, .045), transparent 34%),
+    linear-gradient(145deg, rgba(20, 21, 46, .97), rgba(7, 8, 21, .985));
+  box-shadow:
+    0 26px 70px rgba(0, 0, 0, .28),
+    inset 0 1px 0 rgba(255, 255, 255, .025);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-header {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  border-bottom: 1px solid rgba(119, 128, 178, .18);
+  background: linear-gradient(90deg, rgba(20, 22, 52, .92), rgba(15, 16, 39, .78));
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon {
+  position: relative;
+  display: grid;
+  flex: 0 0 54px;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  border: 1px solid rgba(0, 243, 255, .22);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(0, 243, 255, .18), rgba(0, 243, 255, .035) 64%, transparent 66%);
+  box-shadow: 0 0 26px rgba(0, 243, 255, .09);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon::before,
+body[data-ui-mode="basic"] .basic-guided-card-icon::after {
+  content: "";
+  position: absolute;
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon.setup::before {
+  width: 25px;
+  height: 17px;
+  border: 4px solid var(--accent-primary);
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  transform: rotate(45deg) translate(-2px, 2px);
+  opacity: .95;
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon.setup::after {
+  bottom: 13px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  box-shadow: 0 0 12px var(--accent-primary);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon.status::before {
+  inset: 12px;
+  border: 2px solid var(--accent-primary);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 6px rgba(0, 243, 255, .055),
+    0 0 14px rgba(0, 243, 255, .15);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-icon.status::after {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  box-shadow: 0 0 12px var(--accent-primary);
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-heading {
+  min-width: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-heading h2 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 22px !important;
+  font-weight: 760;
+  letter-spacing: .055em;
+  text-transform: uppercase;
+}
+
+body[data-ui-mode="basic"] .basic-guided-card-heading p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+body[data-ui-mode="basic"] .basic-guided-setup-body,
+body[data-ui-mode="basic"] .basic-guided-status-body {
+  min-height: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-notices:empty {
+  display: none;
+}
+
+body[data-ui-mode="basic"] .basic-guided-notices:not(:empty) {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-steps {
+  display: grid;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step {
+  display: grid;
+  grid-template-columns: 62px minmax(0, 1fr);
+  min-width: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-rail {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step:not(:last-of-type) .basic-guided-step-rail::after {
+  content: "";
+  position: absolute;
+  top: 54px;
+  bottom: -2px;
+  width: 2px;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 243, 255, .28) 0,
+    rgba(0, 243, 255, .28) 8px,
+    transparent 8px,
+    transparent 15px
+  );
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-number {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border: 2px solid var(--accent-primary);
+  border-radius: 50%;
+  background: rgba(3, 28, 39, .95);
+  color: var(--accent-primary);
+  font-size: 20px;
+  font-weight: 800;
+  box-shadow:
+    0 0 20px rgba(0, 243, 255, .22),
+    inset 0 0 16px rgba(0, 243, 255, .08);
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-content {
+  min-width: 0;
+  padding: 4px 0 28px 16px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid rgba(119, 128, 178, .17);
+}
+
+body[data-ui-mode="basic"] .basic-guided-step:last-of-type .basic-guided-step-content {
+  padding-bottom: 10px;
+  margin-bottom: 8px;
+  border-bottom: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-heading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 14px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-heading h3 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 18px;
+  font-weight: 700;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-slot {
+  min-width: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-help {
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+body[data-ui-mode="basic"] .basic-guided-tip {
+  border-color: rgba(56, 145, 255, .7);
+  color: #3a9bff;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-slot > [data-field],
+body[data-ui-mode="basic"] .basic-guided-pass-field {
+  margin: 0 !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-slot > [data-field] > label,
+body[data-ui-mode="basic"] .basic-guided-step-slot > [data-field] > .field-label-with-tip,
+body[data-ui-mode="basic"] .basic-guided-pass-field > .field-label-with-tip,
+body[data-ui-mode="basic"] .basic-guided-profile-field > label,
+body[data-ui-mode="basic"] .basic-guided-profile-field #basicQosBanner {
+  display: none !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-slot input:not([type="checkbox"]):not([type="radio"]),
+body[data-ui-mode="basic"] .basic-guided-step-slot select {
+  border-color: rgba(106, 119, 168, .45);
+  background: rgba(1, 3, 10, .92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .015);
+}
+
+body[data-ui-mode="basic"] .basic-guided-step-slot input:focus,
+body[data-ui-mode="basic"] .basic-guided-step-slot select:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(0, 243, 255, .1), 0 0 20px rgba(0, 243, 255, .07);
+}
+
+body[data-ui-mode="basic"] .basic-guided-adapter-field .row {
+  justify-content: flex-end;
+  margin-top: 8px !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-adapter-field #btnReloadAdapters {
+  height: auto !important;
+  padding: 2px 0 !important;
+  border: 0;
+  background: transparent;
+  color: var(--accent-primary);
+  font-size: 13px !important;
+  box-shadow: none;
+}
+
+body[data-ui-mode="basic"] .basic-guided-adapter-field #adapterHint {
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .qos-basic {
+  display: block;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .segmented {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .seg {
+  min-width: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .seg span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 56px;
+  border-color: rgba(106, 119, 168, .4);
+  background: rgba(9, 11, 27, .82);
+  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .seg span::before {
+  content: attr(data-profile-icon);
+  color: currentColor;
+  font-size: 21px;
+  line-height: 1;
+}
+
+body[data-ui-mode="basic"] .basic-guided-profile-field .seg input:checked + span {
+  border-color: var(--accent-primary);
+  background:
+    linear-gradient(180deg, rgba(0, 243, 255, .14), rgba(0, 243, 255, .055)),
+    rgba(9, 11, 27, .92);
+  color: var(--accent-primary);
+  box-shadow:
+    0 0 0 1px rgba(0, 243, 255, .1),
+    0 0 22px rgba(0, 243, 255, .14);
+}
+
+body[data-ui-mode="basic"] .basic-guided-pass-field .input-with-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 52px 52px;
+  gap: 10px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-pass-field .btn.icon-only {
+  width: 52px;
+  min-width: 52px;
+  padding: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-save-password {
+  width: auto;
+  height: 38px !important;
+  margin-top: 10px;
+  padding-inline: 16px !important;
+  font-size: 13px !important;
+}
+
+body[data-ui-mode="basic"] #copyHint {
+  min-height: 0;
+  margin-top: 8px !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-more-actions {
+  margin: 4px 0 0 78px;
+  color: var(--text-muted);
+}
+
+body[data-ui-mode="basic"] .basic-guided-more-actions summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+body[data-ui-mode="basic"] .basic-guided-more-actions-body {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding-top: 12px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-more-actions-body .btn {
+  height: 38px !important;
+  font-size: 13px !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-technical-defaults,
+body[data-ui-mode="basic"] .basic-guided-staging {
+  display: none !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-card {
+  min-height: 100%;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr);
+  align-items: center;
+  gap: 28px;
+  min-height: 190px;
+  padding: 18px 8px 28px;
+  border-bottom: 1px solid rgba(119, 128, 178, .2);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-orb {
+  display: grid;
+  width: 118px;
+  height: 118px;
+  place-items: center;
+  border: 2px solid var(--accent-primary);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(0, 243, 255, .22), rgba(0, 243, 255, .045) 57%, rgba(1, 8, 16, .82) 59%);
+  box-shadow:
+    0 0 30px rgba(0, 243, 255, .22),
+    inset 0 0 28px rgba(0, 243, 255, .13);
+  transition: border-color .2s ease, box-shadow .2s ease, opacity .2s ease;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-orb svg {
+  width: 64px;
+  height: 64px;
+  overflow: visible;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-orb path {
+  fill: none;
+  stroke: #fff;
+  stroke-width: 5;
+  stroke-linecap: round;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-orb circle {
+  fill: #fff;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-copy h3 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 31px;
+  line-height: 1.15;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-copy p {
+  margin: 9px 0 0;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+body[data-ui-mode="basic"] .basic-guided-original-status {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="stopped"] .basic-guided-status-orb,
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="loading"] .basic-guided-status-orb {
+  opacity: .72;
+  border-color: rgba(126, 134, 176, .7);
+  box-shadow: inset 0 0 24px rgba(126, 134, 176, .06);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="error"] .basic-guided-status-orb {
+  border-color: var(--danger);
+  box-shadow: 0 0 30px rgba(255, 0, 85, .18), inset 0 0 28px rgba(255, 0, 85, .1);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-facts {
+  display: grid;
+  gap: 18px;
+  padding: 28px 10px;
+  border-bottom: 1px solid rgba(119, 128, 178, .2);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-fact {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-icon {
+  position: relative;
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(26, 32, 66, .72);
+  color: var(--accent-primary);
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-icon.adapter::before {
+  content: "";
+  width: 14px;
+  height: 23px;
+  border: 2px solid currentColor;
+  border-radius: 3px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-icon.adapter::after {
+  content: "";
+  position: absolute;
+  top: 9px;
+  width: 6px;
+  height: 7px;
+  border: 2px solid currentColor;
+  border-bottom: 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-icon.band::before {
+  content: "~";
+  font-size: 31px;
+  font-weight: 500;
+  transform: rotate(-8deg);
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-copy {
+  display: grid;
+  gap: 5px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-copy > span {
+  color: var(--text-main);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+body[data-ui-mode="basic"] .basic-guided-fact-copy > strong {
+  color: var(--text-muted);
+  font-size: 16px;
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-details {
+  display: grid;
+  gap: 7px;
+  padding: 14px 10px 0;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-details:empty {
+  display: none;
+}
+
+body[data-ui-mode="basic"] #basicStatusAdapterBand {
+  display: none !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-details > :not(:empty) {
+  padding: 10px 12px;
+  border: 1px solid rgba(119, 128, 178, .18);
+  border-radius: var(--radius-sm);
+  background: rgba(4, 6, 16, .55);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px !important;
+  padding: 26px 0 0;
+  margin-top: auto !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
+  position: relative;
+  height: 62px !important;
+  justify-content: center;
+  gap: 10px;
+  font-size: 16px !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-actions .btn::before {
+  content: attr(data-guided-icon);
+  font-size: 18px;
+  line-height: 1;
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-actions #btnStartBasic {
+  border-color: var(--accent-primary);
+  background: linear-gradient(180deg, rgba(0, 243, 255, .14), rgba(0, 243, 255, .055));
+  box-shadow: 0 0 20px rgba(0, 243, 255, .06);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-actions #btnStopBasic {
+  border-color: rgba(255, 0, 85, .65);
+  background: linear-gradient(180deg, rgba(255, 0, 85, .11), rgba(255, 0, 85, .025));
+}
+
+body[data-ui-mode="basic"] .basic-guided-apply-notice {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  min-height: 58px;
+  padding: 12px 14px;
+  margin-top: 18px;
+  border: 1px solid rgba(119, 128, 178, .2);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 10, 25, .74);
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-notice-icon {
+  position: relative;
+  width: 25px;
+  height: 30px;
+  border: 2px solid var(--accent-primary);
+  border-radius: 12px 12px 14px 14px;
+  clip-path: polygon(50% 0, 100% 18%, 92% 72%, 50% 100%, 8% 72%, 0 18%);
+}
+
+body[data-ui-mode="basic"] .basic-guided-notice-copy {
+  display: grid;
+  gap: 4px;
+}
+
+body[data-ui-mode="basic"] #dirtyBasic:empty {
+  display: none;
+}
+
+body[data-ui-mode="basic"] #dirtyBasic:not(:empty) {
+  margin: 0 !important;
+  color: var(--warning);
+  font-size: 12px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-options {
+  margin-top: 14px;
+  border-top: 1px solid rgba(119, 128, 178, .16);
+}
+
+body[data-ui-mode="basic"] .basic-guided-options > summary {
+  width: fit-content;
+  padding: 14px 0 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+body[data-ui-mode="basic"] .basic-guided-options-body {
+  display: grid;
+  gap: 10px;
+  padding-top: 14px;
+}
+
+body[data-ui-mode="basic"] .basic-guided-options .basic-status-preferences {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+body[data-ui-mode="basic"] .basic-guided-options #msgBasic:empty,
+body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty {
+  display: none;
+}
+
+@media (max-width: 1500px) {
+  body[data-ui-mode="basic"] .basic-grid {
+    grid-template-columns: minmax(0, 1.18fr) minmax(390px, .82fr);
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step {
+    grid-template-columns: 56px minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step-content {
+    padding-left: 12px;
+  }
+}
+
+@media (max-width: 1120px) {
+  body[data-ui-mode="basic"] .basic-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-status-card {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  body[data-ui-mode="basic"] .basic-guided-card-header {
+    align-items: flex-start;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-card-icon {
+    flex-basis: 46px;
+    width: 46px;
+    height: 46px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-card-heading h2 {
+    font-size: 18px !important;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-card-heading p {
+    font-size: 13px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step-number {
+    width: 38px;
+    height: 38px;
+    font-size: 16px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step:not(:last-of-type) .basic-guided-step-rail::after {
+    top: 44px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-step-heading h3 {
+    font-size: 16px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-profile-field .segmented,
+  body[data-ui-mode="basic"] .basic-guided-status-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-pass-field .input-with-action {
+    grid-template-columns: minmax(0, 1fr) 46px 46px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-status-hero {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+    text-align: center;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-more-actions {
+    margin-left: 56px;
+  }
+}

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -1,0 +1,489 @@
+(function buildGuidedBasicInterface() {
+  'use strict';
+
+  const BASIC_MODE = 'basic';
+  const TECHNICAL_DEFAULT_FIELDS = [
+    'band_preference',
+    'ap_security',
+    'country',
+    'enable_internet',
+  ];
+
+  let repositionQueued = false;
+  let guidedObserver = null;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function make(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function makeInfoTip(text) {
+    const tip = make('span', 'tip basic-guided-tip', 'ⓘ');
+    tip.setAttribute('data-tip', text);
+    tip.setAttribute('aria-label', text);
+    tip.setAttribute('tabindex', '0');
+    return tip;
+  }
+
+  function setCardHeader(card, kind, title, subtitle) {
+    const header = card && card.querySelector(':scope > .card-header');
+    if (!header || header.dataset.guidedReady === '1') return;
+    header.dataset.guidedReady = '1';
+    header.classList.add('basic-guided-card-header');
+    header.replaceChildren();
+
+    const icon = make('span', `basic-guided-card-icon ${kind}`);
+    icon.setAttribute('aria-hidden', 'true');
+
+    const copy = make('div', 'basic-guided-card-heading');
+    copy.append(
+      make('h2', '', title),
+      make('p', '', subtitle),
+    );
+    header.append(icon, copy);
+  }
+
+  function createStep(number, title, helper, tipText, slotId) {
+    const step = make('section', 'basic-guided-step');
+    step.dataset.step = String(number);
+
+    const rail = make('div', 'basic-guided-step-rail');
+    const badge = make('span', 'basic-guided-step-number', String(number));
+    badge.setAttribute('aria-hidden', 'true');
+    rail.appendChild(badge);
+
+    const content = make('div', 'basic-guided-step-content');
+    const heading = make('div', 'basic-guided-step-heading');
+    heading.append(make('h3', '', title), makeInfoTip(tipText));
+
+    const slot = make('div', 'basic-guided-step-slot');
+    slot.id = slotId;
+
+    const helperNode = make('p', 'basic-guided-step-help', helper);
+    helperNode.id = `${slotId}Help`;
+    content.append(heading, slot, helperNode);
+    step.append(rail, content);
+    return step;
+  }
+
+  function buildSetupCard() {
+    const quickStaging = el('basicQuickFields');
+    if (!quickStaging) return null;
+    const card = quickStaging.closest('.basic-card');
+    if (!card || card.dataset.basicGuidedReady === '1') return card;
+    card.dataset.basicGuidedReady = '1';
+    card.classList.add('basic-guided-card', 'basic-guided-setup-card');
+
+    setCardHeader(
+      card,
+      'setup',
+      'Set Up Hotspot',
+      'Follow these simple steps to create your hotspot.',
+    );
+
+    const body = card.querySelector(':scope > .card-body');
+    if (!body) return card;
+    body.classList.add('basic-guided-setup-body');
+
+    const notices = make('div', 'basic-guided-notices');
+    const infoBanner = el('basicInfoBanner');
+    const channelBanner = el('basicChannelBanner');
+    if (infoBanner) notices.appendChild(infoBanner);
+    if (channelBanner) notices.appendChild(channelBanner);
+
+    const steps = make('div', 'basic-guided-steps');
+    steps.append(
+      createStep(
+        1,
+        'Choose Wi-Fi adapter',
+        'The recommended USB adapter gives the best VR performance.',
+        'Select the USB Wi-Fi adapter VRhotspot should use to create the hotspot.',
+        'basicGuidedAdapterSlot',
+      ),
+      createStep(
+        2,
+        'Choose connection profile',
+        'Speed prioritizes low latency for VR streaming.',
+        'Choose how aggressively VRhotspot tunes the connection. Speed is the recommended default.',
+        'basicGuidedProfileSlot',
+      ),
+      createStep(
+        3,
+        'Hotspot name (SSID)',
+        'This is the Wi-Fi network name other devices will see.',
+        'Choose the name shown in the Wi-Fi list on your headset and other devices.',
+        'basicGuidedSsidSlot',
+      ),
+      createStep(
+        4,
+        'Password (Passphrase)',
+        'Use 8–63 characters. Press Enter or choose Save password.',
+        'This password protects the hotspot. You can reveal it or generate a QR code for easy connection.',
+        'basicGuidedPassSlot',
+      ),
+    );
+
+    const technicalDefaults = make('div', 'basic-guided-technical-defaults');
+    technicalDefaults.id = 'basicGuidedTechnicalDefaults';
+    technicalDefaults.hidden = true;
+
+    const staging = make('div', 'basic-guided-staging');
+    staging.hidden = true;
+    staging.append(quickStaging);
+    const connectStaging = el('basicConnectFields');
+    if (connectStaging) staging.append(connectStaging);
+
+    const passGroup = el('wpa2_passphrase_basic')?.closest('.form-group');
+    const passSlot = steps.querySelector('#basicGuidedPassSlot');
+    if (passGroup && passSlot) passSlot.appendChild(passGroup);
+
+    const oldConnectArea = card.querySelector('.basic-connect-inline');
+    const actionGroup = oldConnectArea?.querySelector('.basic-connect-actions');
+    const savePass = el('btnSavePassBasic');
+    const copySsid = el('btnCopySsid');
+    const copyPass = el('btnCopyPass');
+
+    if (savePass && passSlot) {
+      savePass.textContent = 'Save password';
+      savePass.classList.add('basic-guided-save-password');
+      passSlot.appendChild(savePass);
+    }
+
+    if (copySsid || copyPass) {
+      const more = make('details', 'basic-guided-more-actions');
+      more.appendChild(make('summary', '', 'More actions'));
+      const moreBody = make('div', 'basic-guided-more-actions-body');
+      if (copySsid) moreBody.appendChild(copySsid);
+      if (copyPass) moreBody.appendChild(copyPass);
+      more.appendChild(moreBody);
+      steps.appendChild(more);
+    }
+
+    const copyHint = el('copyHint');
+    if (copyHint && passSlot) passSlot.appendChild(copyHint);
+    if (actionGroup && !actionGroup.children.length) actionGroup.remove();
+    if (oldConnectArea) oldConnectArea.hidden = true;
+
+    body.replaceChildren(notices, steps, technicalDefaults, staging);
+    return card;
+  }
+
+  function makeWifiOrb() {
+    const orb = make('div', 'basic-guided-status-orb');
+    orb.setAttribute('aria-hidden', 'true');
+    orb.innerHTML = [
+      '<svg viewBox="0 0 64 64" focusable="false" aria-hidden="true">',
+      '<path d="M10 25.5C22.2 14.7 41.8 14.7 54 25.5"/>',
+      '<path d="M17.5 34C25.7 26.8 38.3 26.8 46.5 34"/>',
+      '<path d="M25 42.5C29 39 35 39 39 42.5"/>',
+      '<circle cx="32" cy="49" r="3.5"/>',
+      '</svg>',
+    ].join('');
+    return orb;
+  }
+
+  function makeFact(iconClass, label, valueId) {
+    const fact = make('div', 'basic-guided-status-fact');
+    const icon = make('span', `basic-guided-fact-icon ${iconClass}`);
+    icon.setAttribute('aria-hidden', 'true');
+    const copy = make('div', 'basic-guided-fact-copy');
+    const value = make('strong', '', '--');
+    value.id = valueId;
+    copy.append(make('span', '', label), value);
+    fact.append(icon, copy);
+    return fact;
+  }
+
+  function buildStatusCard() {
+    const pill = el('basicPill');
+    if (!pill) return null;
+    const card = pill.closest('.basic-card');
+    if (!card || card.dataset.basicGuidedReady === '1') return card;
+    card.dataset.basicGuidedReady = '1';
+    card.classList.add('basic-guided-card', 'basic-guided-status-card');
+
+    setCardHeader(
+      card,
+      'status',
+      'Status & Control',
+      'See the hotspot state and control it from one place.',
+    );
+
+    const body = card.querySelector(':scope > .card-body');
+    if (!body) return card;
+    body.classList.add('basic-guided-status-body');
+
+    const hero = make('section', 'basic-guided-status-hero');
+    const orb = makeWifiOrb();
+    const heroCopy = make('div', 'basic-guided-status-copy');
+    const stateText = make('h3', '', 'Loading…');
+    stateText.id = 'basicGuidedStateText';
+    const summary = make('p', '', 'Checking the hotspot status.');
+    summary.id = 'basicGuidedStatusSummary';
+    heroCopy.append(stateText, summary);
+    hero.append(orb, heroCopy);
+
+    const originalPillContainer = el('basicPillContainer');
+    if (originalPillContainer) {
+      originalPillContainer.classList.add('basic-guided-original-status');
+      hero.appendChild(originalPillContainer);
+    }
+
+    const facts = make('section', 'basic-guided-status-facts');
+    facts.append(
+      makeFact('adapter', 'Adapter', 'basicGuidedAdapterValue'),
+      makeFact('band', 'Band', 'basicGuidedBandValue'),
+    );
+
+    const diagnosticDetails = make('div', 'basic-guided-status-details');
+    const originalMeta = el('basicStatusAdapterBand');
+    const statusDetails = el('basicStatusDetails');
+    const lastError = el('basicLastError');
+    const errorDetail = el('basicLastErrorDetail');
+    if (originalMeta) diagnosticDetails.appendChild(originalMeta);
+    if (statusDetails) diagnosticDetails.appendChild(statusDetails);
+    if (lastError) diagnosticDetails.appendChild(lastError);
+    if (errorDetail) diagnosticDetails.appendChild(errorDetail);
+
+    const actions = card.querySelector('.basic-status-actions');
+    if (actions) {
+      actions.classList.add('basic-guided-status-actions');
+      const buttonIcons = {
+        btnStartBasic: '▶',
+        btnStopBasic: '■',
+        btnRepairBasic: '◆',
+        btnRefreshBasic: '↻',
+      };
+      for (const button of actions.querySelectorAll('button')) {
+        button.dataset.guidedIcon = buttonIcons[button.id] || '';
+      }
+    }
+
+    const notice = make('div', 'basic-guided-apply-notice');
+    const noticeIcon = make('span', 'basic-guided-notice-icon');
+    noticeIcon.setAttribute('aria-hidden', 'true');
+    const noticeCopy = make('div', 'basic-guided-notice-copy');
+    noticeCopy.append(
+      make('span', '', 'Changes apply when you start the hotspot.'),
+    );
+    const dirty = el('dirtyBasic');
+    if (dirty) noticeCopy.appendChild(dirty);
+    notice.append(noticeIcon, noticeCopy);
+
+    const options = make('details', 'basic-guided-options');
+    options.appendChild(make('summary', '', 'Options'));
+    const optionsBody = make('div', 'basic-guided-options-body');
+    const preferences = card.querySelector('.basic-status-preferences');
+    const privacyHint = el('privacyHintBasic');
+    const telemetry = el('basicTelemetryContainer');
+    const message = el('msgBasic');
+    if (preferences) optionsBody.appendChild(preferences);
+    if (privacyHint) optionsBody.appendChild(privacyHint);
+    if (telemetry) optionsBody.appendChild(telemetry);
+    if (message) optionsBody.appendChild(message);
+    options.appendChild(optionsBody);
+
+    body.replaceChildren(hero, facts, diagnosticDetails);
+    if (actions) body.appendChild(actions);
+    body.append(notice, options);
+    return card;
+  }
+
+  function fieldNode(key) {
+    return document.querySelector(`[data-field="${key}"]`);
+  }
+
+  function isInStaging(node) {
+    if (!node) return false;
+    const quick = el('basicQuickFields');
+    const connect = el('basicConnectFields');
+    return !!(
+      (quick && quick.contains(node))
+      || (connect && connect.contains(node))
+    );
+  }
+
+  function moveManagedField(key, slotId) {
+    const node = fieldNode(key);
+    const slot = el(slotId);
+    if (!node || !slot || slot.contains(node)) return;
+    if (isInStaging(node)) slot.appendChild(node);
+  }
+
+  function repositionBasicFields() {
+    repositionQueued = false;
+    if (!document.body || document.body.dataset.uiMode !== BASIC_MODE) return;
+
+    moveManagedField('ap_adapter', 'basicGuidedAdapterSlot');
+    moveManagedField('qos_preset', 'basicGuidedProfileSlot');
+    moveManagedField('ssid', 'basicGuidedSsidSlot');
+
+    const defaults = el('basicGuidedTechnicalDefaults');
+    if (defaults) {
+      for (const key of TECHNICAL_DEFAULT_FIELDS) {
+        const node = fieldNode(key);
+        if (node && !defaults.contains(node) && isInStaging(node)) {
+          defaults.appendChild(node);
+        }
+      }
+    }
+
+    decorateMovedFields();
+    syncStatusPresentation();
+  }
+
+  function queueReposition() {
+    if (repositionQueued) return;
+    repositionQueued = true;
+    window.setTimeout(repositionBasicFields, 0);
+  }
+
+  function decorateMovedFields() {
+    const adapterField = fieldNode('ap_adapter');
+    if (adapterField) {
+      adapterField.classList.add('basic-guided-adapter-field');
+      const recommended = el('btnUseRecommended');
+      if (recommended) recommended.hidden = true;
+      const rescan = el('btnReloadAdapters');
+      if (rescan) rescan.textContent = 'Rescan adapters';
+    }
+
+    const profileField = fieldNode('qos_preset');
+    if (profileField) profileField.classList.add('basic-guided-profile-field');
+    const profileIcons = {
+      off: '○',
+      ultra_low_latency: '↗',
+      vr: '◇',
+    };
+    document.querySelectorAll('input[name="qos_basic"]').forEach((input) => {
+      const span = input.closest('label')?.querySelector('span');
+      if (span) span.dataset.profileIcon = profileIcons[input.value] || '•';
+    });
+
+    const ssidField = fieldNode('ssid');
+    if (ssidField) ssidField.classList.add('basic-guided-ssid-field');
+
+    const passField = el('wpa2_passphrase_basic');
+    const passGroup = passField?.closest('.form-group');
+    if (passGroup) passGroup.classList.add('basic-guided-pass-field');
+
+    updateProfileHelp();
+  }
+
+  function updateProfileHelp() {
+    const helper = el('basicGuidedProfileSlotHelp');
+    if (!helper) return;
+    const selected = document.querySelector('input[name="qos_basic"]:checked');
+    const copy = {
+      off: 'Uses standard hotspot behavior without extra performance tuning.',
+      ultra_low_latency: 'Speed prioritizes low latency for VR streaming.',
+      vr: 'Stable favors reliability on busy or noisy wireless networks.',
+    };
+    helper.textContent = copy[selected?.value] || 'Choose the profile that matches how you use the hotspot.';
+  }
+
+  function selectedAdapterLabel() {
+    const select = el('ap_adapter');
+    if (!select || select.selectedIndex < 0) return '--';
+    return (select.options[select.selectedIndex]?.textContent || '--')
+      .replace(/\s*\(Recommended\)\s*/i, '')
+      .trim() || '--';
+  }
+
+  function parseStatusMeta() {
+    const raw = el('basicStatusAdapterBand')?.textContent || '';
+    const adapterMatch = raw.match(/Adapter:\s*([^|]+)/i);
+    const bandMatch = raw.match(/Band:\s*([^|]+)/i);
+    let adapter = adapterMatch ? adapterMatch[1].trim() : '--';
+    const band = bandMatch ? bandMatch[1].trim() : '--';
+    if (!adapter || adapter === '--') adapter = selectedAdapterLabel();
+    return { adapter: adapter || '--', band: band || '--' };
+  }
+
+  function syncStatusPresentation() {
+    const rawStatus = (el('basicPillTxt')?.textContent || 'Loading…').trim();
+    const state = (rawStatus.split('|')[0] || 'Loading…').trim();
+    const normalized = state.toLowerCase();
+    const card = document.querySelector('.basic-guided-status-card');
+    const stateText = el('basicGuidedStateText');
+    const summary = el('basicGuidedStatusSummary');
+    const facts = parseStatusMeta();
+
+    if (stateText) stateText.textContent = state;
+    if (el('basicGuidedAdapterValue')) el('basicGuidedAdapterValue').textContent = facts.adapter;
+    if (el('basicGuidedBandValue')) el('basicGuidedBandValue').textContent = facts.band;
+
+    let stateName = 'loading';
+    let summaryText = 'Checking the hotspot status.';
+    if (normalized.includes('running')) {
+      stateName = 'running';
+      summaryText = 'Your hotspot is active and ready.';
+    } else if (normalized.includes('error')) {
+      stateName = 'error';
+      summaryText = 'The hotspot needs attention.';
+    } else if (normalized.includes('starting') || normalized.includes('repair')) {
+      stateName = 'working';
+      summaryText = 'VRhotspot is preparing the connection.';
+    } else if (normalized.includes('stopped')) {
+      stateName = 'stopped';
+      summaryText = 'Your hotspot is not active.';
+    }
+    if (card) card.dataset.hotspotState = stateName;
+    if (summary) summary.textContent = summaryText;
+  }
+
+  function wireGuidedInteractions() {
+    document.addEventListener('change', (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.matches('input[name="qos_basic"]')) updateProfileHelp();
+      if (target.id === 'ap_adapter') syncStatusPresentation();
+    });
+  }
+
+  function startObservers() {
+    const basic = document.querySelector('[data-ui-section="basic"]');
+    if (basic) {
+      guidedObserver = new MutationObserver(() => {
+        queueReposition();
+        syncStatusPresentation();
+      });
+      guidedObserver.observe(basic, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ['class', 'disabled'],
+      });
+    }
+
+    const bodyObserver = new MutationObserver(() => {
+      if (document.body.dataset.uiMode === BASIC_MODE) queueReposition();
+    });
+    bodyObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['data-ui-mode'],
+    });
+  }
+
+  function initialize() {
+    buildSetupCard();
+    buildStatusCard();
+    wireGuidedInteractions();
+    startObservers();
+    queueReposition();
+    syncStatusPresentation();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialize, { once: true });
+  } else {
+    initialize();
+  }
+})();

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -8,8 +8,10 @@
     'country',
     'enable_internet',
   ];
+  const SAVE_WAIT_MS = 12000;
 
   let repositionQueued = false;
+  let saveBeforeStartRunning = false;
 
   function el(id) {
     return document.getElementById(id);
@@ -250,7 +252,6 @@
     const lastError = el('basicLastError');
     const errorDetail = el('basicLastErrorDetail');
     if (originalMeta) diagnosticDetails.appendChild(originalMeta);
-    if (statusDetails) diagnosticDetails.appendChild(statusDetails);
     if (lastError) diagnosticDetails.appendChild(lastError);
     if (errorDetail) diagnosticDetails.appendChild(errorDetail);
 
@@ -273,7 +274,7 @@
     noticeIcon.setAttribute('aria-hidden', 'true');
     const noticeCopy = make('div', 'basic-guided-notice-copy');
     noticeCopy.append(
-      make('span', '', 'Changes apply when you start the hotspot.'),
+      make('span', '', 'Pending changes are saved automatically when you start the hotspot.'),
     );
     const dirty = el('dirtyBasic');
     if (dirty) noticeCopy.appendChild(dirty);
@@ -286,6 +287,7 @@
     const privacyHint = el('privacyHintBasic');
     const telemetry = el('basicTelemetryContainer');
     const message = el('msgBasic');
+    if (statusDetails) optionsBody.appendChild(statusDetails);
     if (preferences) optionsBody.appendChild(preferences);
     if (privacyHint) optionsBody.appendChild(privacyHint);
     if (telemetry) optionsBody.appendChild(telemetry);
@@ -395,22 +397,34 @@
     );
   }
 
-  function selectedAdapterLabel() {
-    const select = el('ap_adapter');
-    if (!select || select.selectedIndex < 0) return '--';
-    return (select.options[select.selectedIndex]?.textContent || '--')
+  function cleanAdapterLabel(text) {
+    return String(text || '')
       .replace(/\s*\(Recommended\)\s*/i, '')
       .trim() || '--';
+  }
+
+  function adapterLabelForValue(value) {
+    const select = el('ap_adapter');
+    if (!select) return value || '--';
+    const match = Array.from(select.options).find((option) => option.value === value);
+    if (match) return cleanAdapterLabel(match.textContent);
+    if (!value || value === '--') {
+      const selected = select.options[select.selectedIndex];
+      return cleanAdapterLabel(selected?.textContent);
+    }
+    return value;
   }
 
   function parseStatusMeta() {
     const raw = el('basicStatusAdapterBand')?.textContent || '';
     const adapterMatch = raw.match(/Adapter:\s*([^|]+)/i);
     const bandMatch = raw.match(/Band:\s*([^|]+)/i);
-    let adapter = adapterMatch ? adapterMatch[1].trim() : '--';
+    const adapterValue = adapterMatch ? adapterMatch[1].trim() : '--';
     const band = bandMatch ? bandMatch[1].trim() : '--';
-    if (!adapter || adapter === '--') adapter = selectedAdapterLabel();
-    return { adapter: adapter || '--', band: band || '--' };
+    return {
+      adapter: adapterLabelForValue(adapterValue),
+      band: band || '--',
+    };
   }
 
   function syncStatusPresentation() {
@@ -447,6 +461,67 @@
     setTextIfChanged(summary, summaryText);
   }
 
+  function pendingBasicChanges() {
+    return !!(el('dirtyBasic')?.textContent || '').trim();
+  }
+
+  function waitForBasicSave() {
+    const started = Date.now();
+    return new Promise((resolve) => {
+      function check() {
+        if (!pendingBasicChanges()) {
+          resolve(true);
+          return;
+        }
+        if ((Date.now() - started) >= SAVE_WAIT_MS) {
+          resolve(false);
+          return;
+        }
+        window.setTimeout(check, 100);
+      }
+      check();
+    });
+  }
+
+  function wireSaveBeforeStart() {
+    document.addEventListener('click', async (event) => {
+      const target = event.target instanceof Element
+        ? event.target.closest('#btnStartBasic')
+        : null;
+      if (!target) return;
+
+      if (target.dataset.guidedResume === '1') {
+        delete target.dataset.guidedResume;
+        return;
+      }
+      if (!pendingBasicChanges()) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      if (saveBeforeStartRunning) return;
+      saveBeforeStartRunning = true;
+      target.classList.add('is-saving');
+      setTextIfChanged(el('basicGuidedStatusSummary'), 'Saving your changes before starting…');
+
+      const saveButton = el('btnSaveConfig');
+      if (saveButton) saveButton.click();
+      const saved = !!saveButton && await waitForBasicSave();
+
+      target.classList.remove('is-saving');
+      saveBeforeStartRunning = false;
+      if (!saved) {
+        setTextIfChanged(
+          el('basicGuidedStatusSummary'),
+          'Your changes could not be saved. Review the message under Options.',
+        );
+        return;
+      }
+
+      target.dataset.guidedResume = '1';
+      target.click();
+    }, true);
+  }
+
   function wireGuidedInteractions() {
     document.addEventListener('change', (event) => {
       const target = event.target;
@@ -454,6 +529,7 @@
       if (target.matches('input[name="qos_basic"]')) updateProfileHelp();
       if (target.id === 'ap_adapter') syncStatusPresentation();
     });
+    wireSaveBeforeStart();
   }
 
   function observeStagingContainer(container) {

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -10,7 +10,6 @@
   ];
 
   let repositionQueued = false;
-  let guidedObserver = null;
 
   function el(id) {
     return document.getElementById(id);
@@ -21,6 +20,10 @@
     if (className) node.className = className;
     if (text !== undefined) node.textContent = text;
     return node;
+  }
+
+  function setTextIfChanged(node, text) {
+    if (node && node.textContent !== text) node.textContent = text;
   }
 
   function makeInfoTip(text) {
@@ -351,7 +354,7 @@
       const recommended = el('btnUseRecommended');
       if (recommended) recommended.hidden = true;
       const rescan = el('btnReloadAdapters');
-      if (rescan) rescan.textContent = 'Rescan adapters';
+      if (rescan) setTextIfChanged(rescan, 'Rescan adapters');
     }
 
     const profileField = fieldNode('qos_preset');
@@ -363,7 +366,8 @@
     };
     document.querySelectorAll('input[name="qos_basic"]').forEach((input) => {
       const span = input.closest('label')?.querySelector('span');
-      if (span) span.dataset.profileIcon = profileIcons[input.value] || '•';
+      const icon = profileIcons[input.value] || '•';
+      if (span && span.dataset.profileIcon !== icon) span.dataset.profileIcon = icon;
     });
 
     const ssidField = fieldNode('ssid');
@@ -385,7 +389,10 @@
       ultra_low_latency: 'Speed prioritizes low latency for VR streaming.',
       vr: 'Stable favors reliability on busy or noisy wireless networks.',
     };
-    helper.textContent = copy[selected?.value] || 'Choose the profile that matches how you use the hotspot.';
+    setTextIfChanged(
+      helper,
+      copy[selected?.value] || 'Choose the profile that matches how you use the hotspot.',
+    );
   }
 
   function selectedAdapterLabel() {
@@ -415,9 +422,9 @@
     const summary = el('basicGuidedStatusSummary');
     const facts = parseStatusMeta();
 
-    if (stateText) stateText.textContent = state;
-    if (el('basicGuidedAdapterValue')) el('basicGuidedAdapterValue').textContent = facts.adapter;
-    if (el('basicGuidedBandValue')) el('basicGuidedBandValue').textContent = facts.band;
+    setTextIfChanged(stateText, state);
+    setTextIfChanged(el('basicGuidedAdapterValue'), facts.adapter);
+    setTextIfChanged(el('basicGuidedBandValue'), facts.band);
 
     let stateName = 'loading';
     let summaryText = 'Checking the hotspot status.';
@@ -434,8 +441,10 @@
       stateName = 'stopped';
       summaryText = 'Your hotspot is not active.';
     }
-    if (card) card.dataset.hotspotState = stateName;
-    if (summary) summary.textContent = summaryText;
+    if (card && card.dataset.hotspotState !== stateName) {
+      card.dataset.hotspotState = stateName;
+    }
+    setTextIfChanged(summary, summaryText);
   }
 
   function wireGuidedInteractions() {
@@ -447,21 +456,27 @@
     });
   }
 
+  function observeStagingContainer(container) {
+    if (!container) return;
+    const observer = new MutationObserver(queueReposition);
+    observer.observe(container, { childList: true, subtree: true });
+  }
+
+  function observeStatusSource(source) {
+    if (!source) return;
+    const observer = new MutationObserver(syncStatusPresentation);
+    observer.observe(source, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
   function startObservers() {
-    const basic = document.querySelector('[data-ui-section="basic"]');
-    if (basic) {
-      guidedObserver = new MutationObserver(() => {
-        queueReposition();
-        syncStatusPresentation();
-      });
-      guidedObserver.observe(basic, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-        attributes: true,
-        attributeFilter: ['class', 'disabled'],
-      });
-    }
+    observeStagingContainer(el('basicQuickFields'));
+    observeStagingContainer(el('basicConnectFields'));
+    observeStatusSource(el('basicPillTxt'));
+    observeStatusSource(el('basicStatusAdapterBand'));
 
     const bodyObserver = new MutationObserver(() => {
       if (document.body.dataset.uiMode === BASIC_MODE) queueReposition();

--- a/assets/field_visibility.js
+++ b/assets/field_visibility.js
@@ -70,6 +70,18 @@ window.UI_FIELD_VISIBILITY = {
   document.head.appendChild(stylesheet);
 })();
 
+(function loadGuidedBasicModeAssets() {
+  const stylesheet = document.createElement('link');
+  stylesheet.rel = 'stylesheet';
+  stylesheet.href = '/assets/basic_guided.css';
+  document.head.appendChild(stylesheet);
+
+  const script = document.createElement('script');
+  script.src = '/assets/basic_guided.js';
+  script.async = false;
+  document.head.appendChild(script);
+})();
+
 (function loadDeveloperHubAssets() {
   const stylesheet = document.createElement('link');
   stylesheet.rel = 'stylesheet';

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -44,6 +44,8 @@ WIRELESS_BOOTSTRAP_PATH = "/v1/devbridge/adb/enable-wireless"
 
 _DEVHUB_ASSET_TYPES = {
     "/assets/basic_layout.css": "text/css; charset=utf-8",
+    "/assets/basic_guided.css": "text/css; charset=utf-8",
+    "/assets/basic_guided.js": "application/javascript; charset=utf-8",
     "/assets/devhub.css": "text/css; charset=utf-8",
     "/assets/devhub.js": "application/javascript; charset=utf-8",
     "/assets/devhub_upload.css": "text/css; charset=utf-8",

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -43,7 +43,6 @@ def test_guided_interface_reuses_existing_live_control_ids() -> None:
 
     assert "api(" not in source
     assert "fetch(" not in source
-    assert "addEventListener('click'" not in source
 
 
 def test_guided_setup_uses_four_plain_language_steps() -> None:
@@ -85,6 +84,28 @@ def test_status_presentation_is_idempotent_and_source_scoped() -> None:
     assert "observeStatusSource(el('basicStatusAdapterBand'))" in source
     assert "observeStagingContainer(el('basicQuickFields'))" in source
     assert "observer.observe(basic" not in source
+
+
+def test_start_saves_pending_basic_changes_before_existing_start_handler() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "function wireSaveBeforeStart" in source
+    assert "event.stopImmediatePropagation();" in source
+    assert "const saveButton = el('btnSaveConfig');" in source
+    assert "saveButton.click();" in source
+    assert "await waitForBasicSave();" in source
+    assert "target.dataset.guidedResume = '1';" in source
+    assert "target.click();" in source
+    assert "Pending changes are saved automatically when you start the hotspot." in source
+
+
+def test_status_uses_friendly_adapter_labels_and_hides_technical_details() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "function adapterLabelForValue" in source
+    assert ".find((option) => option.value === value)" in source
+    assert "if (statusDetails) optionsBody.appendChild(statusDetails);" in source
+    assert "if (statusDetails) diagnosticDetails.appendChild(statusDetails);" not in source
 
 
 def test_guided_styles_are_basic_only_and_use_native_sizing() -> None:

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -35,9 +35,6 @@ def test_guided_interface_reuses_existing_live_control_ids() -> None:
         "btnStopBasic",
         "btnRepairBasic",
         "btnRefreshBasic",
-        "privacyModeBasic",
-        "autoRefreshBasic",
-        "showTelemetryBasic",
     ):
         assert control_id in source
 
@@ -124,6 +121,7 @@ def test_secondary_controls_are_preserved_in_collapsed_options() -> None:
 
     assert "make('details', 'basic-guided-options')" in source
     assert "'Options'" in source
-    assert "basic-status-preferences" in source
+    assert "card.querySelector('.basic-status-preferences')" in source
+    assert "optionsBody.appendChild(preferences)" in source
     assert "basicTelemetryContainer" in source
     assert "privacyHintBasic" in source

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDED_JS = ROOT / "assets" / "basic_guided.js"
+GUIDED_CSS = ROOT / "assets" / "basic_guided.css"
+FIELD_VISIBILITY = ROOT / "assets" / "field_visibility.js"
+DEVHUB_API = ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py"
+
+
+def test_guided_basic_assets_are_loaded_and_served() -> None:
+    loader = FIELD_VISIBILITY.read_text(encoding="utf-8")
+    api = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert "loadGuidedBasicModeAssets" in loader
+    assert "'/assets/basic_guided.css'" in loader
+    assert "'/assets/basic_guided.js'" in loader
+    assert '"/assets/basic_guided.css": "text/css; charset=utf-8"' in api
+    assert '"/assets/basic_guided.js": "application/javascript; charset=utf-8"' in api
+
+
+def test_guided_interface_reuses_existing_live_control_ids() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    for control_id in (
+        "basicQuickFields",
+        "basicConnectFields",
+        "wpa2_passphrase_basic",
+        "btnSavePassBasic",
+        "btnCopySsid",
+        "btnCopyPass",
+        "basicPillTxt",
+        "basicStatusAdapterBand",
+        "btnStartBasic",
+        "btnStopBasic",
+        "btnRepairBasic",
+        "btnRefreshBasic",
+        "privacyModeBasic",
+        "autoRefreshBasic",
+        "showTelemetryBasic",
+    ):
+        assert control_id in source
+
+    assert "api(" not in source
+    assert "fetch(" not in source
+    assert "addEventListener('click'" not in source
+
+
+def test_guided_setup_uses_four_plain_language_steps() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "'Set Up Hotspot'" in source
+    assert "'Choose Wi-Fi adapter'" in source
+    assert "'Choose connection profile'" in source
+    assert "'Hotspot name (SSID)'" in source
+    assert "'Password (Passphrase)'" in source
+    assert "basicGuidedAdapterSlot" in source
+    assert "basicGuidedProfileSlot" in source
+    assert "basicGuidedSsidSlot" in source
+    assert "basicGuidedPassSlot" in source
+
+
+def test_technical_basic_defaults_remain_live_but_hidden() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    for field in (
+        "band_preference",
+        "ap_security",
+        "country",
+        "enable_internet",
+    ):
+        assert f"'{field}'" in source
+
+    assert "basicGuidedTechnicalDefaults" in source
+    assert ".basic-guided-technical-defaults" in styles
+    assert "display: none !important;" in styles
+
+
+def test_status_presentation_is_idempotent_and_source_scoped() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "function setTextIfChanged" in source
+    assert "observeStatusSource(el('basicPillTxt'))" in source
+    assert "observeStatusSource(el('basicStatusAdapterBand'))" in source
+    assert "observeStagingContainer(el('basicQuickFields'))" in source
+    assert "observer.observe(basic" not in source
+
+
+def test_guided_styles_are_basic_only_and_use_native_sizing() -> None:
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert 'body[data-ui-mode="basic"] .basic-guided-step' in styles
+    assert 'body[data-ui-mode="basic"] .basic-guided-status-hero' in styles
+    assert 'body[data-ui-mode="basic"] .basic-guided-status-actions' in styles
+    assert 'body[data-ui-mode="advanced"]' not in styles
+    assert "zoom:" not in styles
+    assert "transform: scale(" not in styles
+
+
+def test_secondary_controls_are_preserved_in_collapsed_options() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "make('details', 'basic-guided-options')" in source
+    assert "'Options'" in source
+    assert "basic-status-preferences" in source
+    assert "basicTelemetryContainer" in source
+    assert "privacyHintBasic" in source


### PR DESCRIPTION
## Summary

Rebuild Basic mode around the approved guided-interface concept while preserving the existing working controls and behavior underneath.

## Experience

- Replace the generic Connection Setup card presentation with a four-step flow:
  1. Choose Wi-Fi adapter
  2. Choose connection profile
  3. Choose hotspot name
  4. Set the hotspot password
- Present Status & Control with a large visual state, friendly adapter and band labels, and a clear 2×2 action grid.
- Move technical status details, Privacy, automatic refresh, and Stats into a collapsed Options section.
- Keep copy actions available under More actions without competing with the primary workflow.
- Hide Basic-mode technical defaults such as band, security, country, and internet sharing while keeping those controls active and available to the existing configuration payload.
- Automatically save pending Basic changes through the existing Save handler before continuing into the existing Start handler.

## Safety boundaries

- Reuses the current DOM control IDs, API calls, event handlers, QR flow, passphrase save flow, QoS autosave, privacy state, and Pro-mode restoration logic.
- No duplicate configuration fields or duplicate hotspot API implementation.
- No changes to Pro mode styling or behavior.
- No daemon, networking, installer, or Flatpak permission changes.
- Status observers are scoped to their source nodes and use idempotent text updates to avoid the MutationObserver loop previously fixed in PR #124.

## Validation

- Added contracts for asset serving/loading, live-control reuse, four-step structure, hidden technical defaults, source-scoped observers, friendly adapter labels, collapsed secondary controls, save-before-start behavior, Basic-only CSS, responsive layout, and absence of page scaling.