### PR TITLE
Align guided Basic mode with the original VRhotspot theme

### DIFF
--- a/assets/basic_guided.css
+++ b/assets/basic_guided.css
@@ -1,4 +1,4 @@
-/* Guided Basic-mode presentation. Existing controls and IDs remain live. */
+/* Guided Basic-mode layout using the existing VRhotspot visual language. */
 
 body[data-ui-mode="basic"] .basic-container {
   width: 100%;
@@ -12,78 +12,15 @@ body[data-ui-mode="basic"] .basic-grid {
 body[data-ui-mode="basic"] .basic-guided-card {
   height: 100%;
   overflow: hidden;
-  border-color: rgba(115, 126, 180, .28);
-  background:
-    radial-gradient(circle at 12% 0%, rgba(0, 243, 255, .045), transparent 34%),
-    linear-gradient(145deg, rgba(20, 21, 46, .97), rgba(7, 8, 21, .985));
-  box-shadow:
-    0 26px 70px rgba(0, 0, 0, .28),
-    inset 0 1px 0 rgba(255, 255, 255, .025);
+  border-color: var(--border-subtle);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-sm);
 }
 
 body[data-ui-mode="basic"] .basic-guided-card-header {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  border-bottom: 1px solid rgba(119, 128, 178, .18);
-  background: linear-gradient(90deg, rgba(20, 22, 52, .92), rgba(15, 16, 39, .78));
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon {
-  position: relative;
-  display: grid;
-  flex: 0 0 54px;
-  width: 54px;
-  height: 54px;
-  place-items: center;
-  border: 1px solid rgba(0, 243, 255, .22);
-  border-radius: 50%;
-  background:
-    radial-gradient(circle, rgba(0, 243, 255, .18), rgba(0, 243, 255, .035) 64%, transparent 66%);
-  box-shadow: 0 0 26px rgba(0, 243, 255, .09);
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon::before,
-body[data-ui-mode="basic"] .basic-guided-card-icon::after {
-  content: "";
-  position: absolute;
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon.setup::before {
-  width: 25px;
-  height: 17px;
-  border: 4px solid var(--accent-primary);
-  border-right-color: transparent;
-  border-bottom-color: transparent;
-  border-radius: 50%;
-  transform: rotate(45deg) translate(-2px, 2px);
-  opacity: .95;
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon.setup::after {
-  bottom: 13px;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--accent-primary);
-  box-shadow: 0 0 12px var(--accent-primary);
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon.status::before {
-  inset: 12px;
-  border: 2px solid var(--accent-primary);
-  border-radius: 50%;
-  box-shadow:
-    inset 0 0 0 6px rgba(0, 243, 255, .055),
-    0 0 14px rgba(0, 243, 255, .15);
-}
-
-body[data-ui-mode="basic"] .basic-guided-card-icon.status::after {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent-primary);
-  box-shadow: 0 0 12px var(--accent-primary);
+  display: block;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
 }
 
 body[data-ui-mode="basic"] .basic-guided-card-heading {
@@ -93,16 +30,16 @@ body[data-ui-mode="basic"] .basic-guided-card-heading {
 body[data-ui-mode="basic"] .basic-guided-card-heading h2 {
   margin: 0;
   color: var(--text-main);
-  font-size: 22px !important;
-  font-weight: 760;
+  font-size: 18px !important;
+  font-weight: 700;
   letter-spacing: .055em;
   text-transform: uppercase;
 }
 
 body[data-ui-mode="basic"] .basic-guided-card-heading p {
-  margin: 6px 0 0;
+  margin: 5px 0 0;
   color: var(--text-muted);
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1.45;
 }
 
@@ -118,7 +55,7 @@ body[data-ui-mode="basic"] .basic-guided-notices:empty {
 body[data-ui-mode="basic"] .basic-guided-notices:not(:empty) {
   display: grid;
   gap: 10px;
-  margin-bottom: 8px;
+  margin-bottom: 18px;
 }
 
 body[data-ui-mode="basic"] .basic-guided-steps {
@@ -127,74 +64,49 @@ body[data-ui-mode="basic"] .basic-guided-steps {
 
 body[data-ui-mode="basic"] .basic-guided-step {
   display: grid;
-  grid-template-columns: 62px minmax(0, 1fr);
+  grid-template-columns: 42px minmax(0, 1fr);
   min-width: 0;
 }
 
-body[data-ui-mode="basic"] .basic-guided-step-rail {
-  position: relative;
-  display: flex;
-  justify-content: center;
-}
-
-body[data-ui-mode="basic"] .basic-guided-step:not(:last-of-type) .basic-guided-step-rail::after {
-  content: "";
-  position: absolute;
-  top: 54px;
-  bottom: -2px;
-  width: 2px;
-  background: repeating-linear-gradient(
-    to bottom,
-    rgba(0, 243, 255, .28) 0,
-    rgba(0, 243, 255, .28) 8px,
-    transparent 8px,
-    transparent 15px
-  );
-}
-
 body[data-ui-mode="basic"] .basic-guided-step-number {
-  position: relative;
-  z-index: 1;
   display: grid;
-  width: 48px;
-  height: 48px;
+  width: 32px;
+  height: 32px;
   place-items: center;
-  border: 2px solid var(--accent-primary);
+  margin-top: 2px;
+  border: 1px solid var(--border-active);
   border-radius: 50%;
-  background: rgba(3, 28, 39, .95);
+  background: var(--bg-subtle);
   color: var(--accent-primary);
-  font-size: 20px;
-  font-weight: 800;
-  box-shadow:
-    0 0 20px rgba(0, 243, 255, .22),
-    inset 0 0 16px rgba(0, 243, 255, .08);
+  font-size: 14px;
+  font-weight: 700;
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-content {
   min-width: 0;
-  padding: 4px 0 28px 16px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid rgba(119, 128, 178, .17);
+  padding: 0 0 24px 8px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
-body[data-ui-mode="basic"] .basic-guided-step:last-of-type .basic-guided-step-content {
-  padding-bottom: 10px;
-  margin-bottom: 8px;
+body[data-ui-mode="basic"] .basic-guided-step:last-child .basic-guided-step-content {
+  padding-bottom: 0;
+  margin-bottom: 0;
   border-bottom: 0;
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-heading {
   display: flex;
   align-items: center;
-  gap: 9px;
-  margin-bottom: 14px;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-heading h3 {
   margin: 0;
   color: var(--text-main);
-  font-size: 18px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 650;
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-slot {
@@ -202,15 +114,15 @@ body[data-ui-mode="basic"] .basic-guided-step-slot {
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-help {
-  margin: 10px 0 0;
+  margin: 9px 0 0;
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
 }
 
 body[data-ui-mode="basic"] .basic-guided-tip {
-  border-color: rgba(56, 145, 255, .7);
-  color: #3a9bff;
+  border-color: var(--border-active);
+  color: var(--accent-primary);
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-slot > [data-field],
@@ -226,22 +138,13 @@ body[data-ui-mode="basic"] .basic-guided-profile-field #basicQosBanner {
   display: none !important;
 }
 
-body[data-ui-mode="basic"] .basic-guided-step-slot input:not([type="checkbox"]):not([type="radio"]),
-body[data-ui-mode="basic"] .basic-guided-step-slot select {
-  border-color: rgba(106, 119, 168, .45);
-  background: rgba(1, 3, 10, .92);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .015);
-}
-
-body[data-ui-mode="basic"] .basic-guided-step-slot input:focus,
-body[data-ui-mode="basic"] .basic-guided-step-slot select:focus {
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px rgba(0, 243, 255, .1), 0 0 20px rgba(0, 243, 255, .07);
-}
-
 body[data-ui-mode="basic"] .basic-guided-adapter-field .row {
   justify-content: flex-end;
   margin-top: 8px !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-adapter-field #btnUseRecommended[hidden] {
+  display: none !important;
 }
 
 body[data-ui-mode="basic"] .basic-guided-adapter-field #btnReloadAdapters {
@@ -276,50 +179,38 @@ body[data-ui-mode="basic"] .basic-guided-profile-field .seg {
 
 body[data-ui-mode="basic"] .basic-guided-profile-field .seg span {
   display: flex;
+  min-height: 48px;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  min-height: 56px;
-  border-color: rgba(106, 119, 168, .4);
-  background: rgba(9, 11, 27, .82);
+  border-color: var(--border-subtle);
+  background: var(--bg-subtle);
   color: var(--text-muted);
-  font-size: 15px;
-  font-weight: 700;
-}
-
-body[data-ui-mode="basic"] .basic-guided-profile-field .seg span::before {
-  content: attr(data-profile-icon);
-  color: currentColor;
-  font-size: 21px;
-  line-height: 1;
+  font-size: 14px;
+  font-weight: 650;
 }
 
 body[data-ui-mode="basic"] .basic-guided-profile-field .seg input:checked + span {
-  border-color: var(--accent-primary);
-  background:
-    linear-gradient(180deg, rgba(0, 243, 255, .14), rgba(0, 243, 255, .055)),
-    rgba(9, 11, 27, .92);
+  border-color: var(--border-active);
+  background: var(--accent-subtle);
   color: var(--accent-primary);
-  box-shadow:
-    0 0 0 1px rgba(0, 243, 255, .1),
-    0 0 22px rgba(0, 243, 255, .14);
+  box-shadow: var(--shadow-glow);
 }
 
 body[data-ui-mode="basic"] .basic-guided-pass-field .input-with-action {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 52px 52px;
+  grid-template-columns: minmax(0, 1fr) 50px 50px;
   gap: 10px;
 }
 
 body[data-ui-mode="basic"] .basic-guided-pass-field .btn.icon-only {
-  width: 52px;
-  min-width: 52px;
+  width: 50px;
+  min-width: 50px;
   padding: 0;
 }
 
 body[data-ui-mode="basic"] .basic-guided-save-password {
   width: auto;
-  height: 38px !important;
+  height: 40px !important;
   margin-top: 10px;
   padding-inline: 16px !important;
   font-size: 13px !important;
@@ -330,33 +221,9 @@ body[data-ui-mode="basic"] #copyHint {
   margin-top: 8px !important;
 }
 
-body[data-ui-mode="basic"] .basic-guided-more-actions {
-  margin: 4px 0 0 78px;
-  color: var(--text-muted);
-}
-
-body[data-ui-mode="basic"] .basic-guided-more-actions summary {
-  width: fit-content;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 650;
-}
-
-body[data-ui-mode="basic"] .basic-guided-more-actions-body {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  padding-top: 12px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-more-actions-body .btn {
-  height: 38px !important;
-  font-size: 13px !important;
-}
-
 body[data-ui-mode="basic"] .basic-guided-technical-defaults,
-body[data-ui-mode="basic"] .basic-guided-staging {
+body[data-ui-mode="basic"] .basic-guided-staging,
+body[data-ui-mode="basic"] .basic-guided-hidden-status {
   display: none !important;
 }
 
@@ -367,257 +234,101 @@ body[data-ui-mode="basic"] .basic-guided-status-card {
 body[data-ui-mode="basic"] .basic-guided-status-body {
   display: flex;
   flex-direction: column;
-  gap: 0;
 }
 
 body[data-ui-mode="basic"] .basic-guided-status-hero {
-  position: relative;
-  display: grid;
-  grid-template-columns: 128px minmax(0, 1fr);
+  padding: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-state {
+  display: flex;
   align-items: center;
-  gap: 28px;
-  min-height: 190px;
-  padding: 18px 8px 28px;
-  border-bottom: 1px solid rgba(119, 128, 178, .2);
+  gap: 12px;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-orb {
-  display: grid;
-  width: 118px;
-  height: 118px;
-  place-items: center;
-  border: 2px solid var(--accent-primary);
+body[data-ui-mode="basic"] .basic-guided-status-dot {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 11px;
   border-radius: 50%;
-  background:
-    radial-gradient(circle, rgba(0, 243, 255, .22), rgba(0, 243, 255, .045) 57%, rgba(1, 8, 16, .82) 59%);
-  box-shadow:
-    0 0 30px rgba(0, 243, 255, .22),
-    inset 0 0 28px rgba(0, 243, 255, .13);
-  transition: border-color .2s ease, box-shadow .2s ease, opacity .2s ease;
+  background: var(--text-muted);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-orb svg {
-  width: 64px;
-  height: 64px;
-  overflow: visible;
+body[data-ui-mode="basic"] .basic-guided-status-copy,
+body[data-ui-mode="basic"] .basic-guided-original-status {
+  display: none;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-orb path {
-  fill: none;
-  stroke: #fff;
-  stroke-width: 5;
-  stroke-linecap: round;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-orb circle {
-  fill: #fff;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-copy h3 {
+body[data-ui-mode="basic"] .basic-guided-status-state h3 {
   margin: 0;
   color: var(--text-main);
-  font-size: 31px;
-  line-height: 1.15;
+  font-size: 26px;
+  line-height: 1.2;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-copy p {
-  margin: 9px 0 0;
+body[data-ui-mode="basic"] .basic-guided-status-hero > p {
+  margin: 8px 0 0 23px;
   color: var(--text-muted);
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1.5;
 }
 
-body[data-ui-mode="basic"] .basic-guided-original-status {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="running"] .basic-guided-status-dot {
+  background: var(--success);
+  box-shadow: 0 0 8px rgba(0, 255, 157, .45);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="stopped"] .basic-guided-status-orb,
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="loading"] .basic-guided-status-orb {
-  opacity: .72;
-  border-color: rgba(126, 134, 176, .7);
-  box-shadow: inset 0 0 24px rgba(126, 134, 176, .06);
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="working"] .basic-guided-status-dot {
+  background: var(--accent-primary);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="error"] .basic-guided-status-orb {
-  border-color: var(--danger);
-  box-shadow: 0 0 30px rgba(255, 0, 85, .18), inset 0 0 28px rgba(255, 0, 85, .1);
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-facts {
-  display: grid;
-  gap: 18px;
-  padding: 28px 10px;
-  border-bottom: 1px solid rgba(119, 128, 178, .2);
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-fact {
-  display: grid;
-  grid-template-columns: 52px minmax(0, 1fr);
-  align-items: center;
-  gap: 16px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-icon {
-  position: relative;
-  display: grid;
-  width: 48px;
-  height: 48px;
-  place-items: center;
-  border-radius: 50%;
-  background: rgba(26, 32, 66, .72);
-  color: var(--accent-primary);
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-icon.adapter::before {
-  content: "";
-  width: 14px;
-  height: 23px;
-  border: 2px solid currentColor;
-  border-radius: 3px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-icon.adapter::after {
-  content: "";
-  position: absolute;
-  top: 9px;
-  width: 6px;
-  height: 7px;
-  border: 2px solid currentColor;
-  border-bottom: 0;
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-icon.band::before {
-  content: "~";
-  font-size: 31px;
-  font-weight: 500;
-  transform: rotate(-8deg);
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-copy {
-  display: grid;
-  gap: 5px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-copy > span {
-  color: var(--text-main);
-  font-size: 15px;
-  font-weight: 700;
-}
-
-body[data-ui-mode="basic"] .basic-guided-fact-copy > strong {
-  color: var(--text-muted);
-  font-size: 16px;
-  font-weight: 500;
-  overflow-wrap: anywhere;
+body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="error"] .basic-guided-status-dot {
+  background: var(--danger);
+  box-shadow: 0 0 8px rgba(255, 0, 85, .4);
 }
 
 body[data-ui-mode="basic"] .basic-guided-status-details {
   display: grid;
-  gap: 7px;
-  padding: 14px 10px 0;
+  gap: 8px;
+  margin-top: 14px;
 }
 
 body[data-ui-mode="basic"] .basic-guided-status-details:empty {
   display: none;
 }
 
-body[data-ui-mode="basic"] #basicStatusAdapterBand {
-  display: none !important;
-}
-
 body[data-ui-mode="basic"] .basic-guided-status-details > :not(:empty) {
   padding: 10px 12px;
-  border: 1px solid rgba(119, 128, 178, .18);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
-  background: rgba(4, 6, 16, .55);
+  background: var(--bg-subtle);
 }
 
 body[data-ui-mode="basic"] .basic-guided-status-actions {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px !important;
-  padding: 26px 0 0;
+  padding-top: 22px;
   margin-top: auto !important;
 }
 
 body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
-  position: relative;
-  height: 62px !important;
+  height: 50px !important;
   justify-content: center;
-  gap: 10px;
-  font-size: 16px !important;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-actions .btn::before {
-  content: attr(data-guided-icon);
-  font-size: 18px;
-  line-height: 1;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-actions #btnStartBasic {
-  border-color: var(--accent-primary);
-  background: linear-gradient(180deg, rgba(0, 243, 255, .14), rgba(0, 243, 255, .055));
-  box-shadow: 0 0 20px rgba(0, 243, 255, .06);
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-actions #btnStopBasic {
-  border-color: rgba(255, 0, 85, .65);
-  background: linear-gradient(180deg, rgba(255, 0, 85, .11), rgba(255, 0, 85, .025));
-}
-
-body[data-ui-mode="basic"] .basic-guided-apply-notice {
-  display: grid;
-  grid-template-columns: 36px minmax(0, 1fr);
-  align-items: center;
-  gap: 12px;
-  min-height: 58px;
-  padding: 12px 14px;
-  margin-top: 18px;
-  border: 1px solid rgba(119, 128, 178, .2);
-  border-radius: var(--radius-sm);
-  background: rgba(8, 10, 25, .74);
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-notice-icon {
-  position: relative;
-  width: 25px;
-  height: 30px;
-  border: 2px solid var(--accent-primary);
-  border-radius: 12px 12px 14px 14px;
-  clip-path: polygon(50% 0, 100% 18%, 92% 72%, 50% 100%, 8% 72%, 0 18%);
-}
-
-body[data-ui-mode="basic"] .basic-guided-notice-copy {
-  display: grid;
-  gap: 4px;
-}
-
-body[data-ui-mode="basic"] #dirtyBasic:empty {
-  display: none;
-}
-
-body[data-ui-mode="basic"] #dirtyBasic:not(:empty) {
-  margin: 0 !important;
-  color: var(--warning);
-  font-size: 12px;
+  font-size: 15px !important;
 }
 
 body[data-ui-mode="basic"] .basic-guided-options {
-  margin-top: 14px;
-  border-top: 1px solid rgba(119, 128, 178, .16);
+  margin-top: 18px;
+  border-top: 1px solid var(--border-subtle);
 }
 
 body[data-ui-mode="basic"] .basic-guided-options > summary {
   width: fit-content;
-  padding: 14px 0 0;
+  padding-top: 14px;
   cursor: pointer;
   color: var(--text-muted);
   font-size: 13px;
@@ -636,21 +347,21 @@ body[data-ui-mode="basic"] .basic-guided-options .basic-status-preferences {
 }
 
 body[data-ui-mode="basic"] .basic-guided-options #msgBasic:empty,
-body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty {
+body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty,
+body[data-ui-mode="basic"] .basic-guided-options #dirtyBasic:empty,
+body[data-ui-mode="basic"] .basic-guided-options #basicStatusDetails:empty {
   display: none;
+}
+
+body[data-ui-mode="basic"] .basic-guided-options #dirtyBasic:not(:empty) {
+  margin: 0 !important;
+  color: var(--warning);
+  font-size: 12px;
 }
 
 @media (max-width: 1500px) {
   body[data-ui-mode="basic"] .basic-grid {
     grid-template-columns: minmax(0, 1.18fr) minmax(390px, .82fr);
-  }
-
-  body[data-ui-mode="basic"] .basic-guided-step {
-    grid-template-columns: 56px minmax(0, 1fr);
-  }
-
-  body[data-ui-mode="basic"] .basic-guided-step-content {
-    padding-left: 12px;
   }
 }
 
@@ -665,18 +376,8 @@ body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty {
 }
 
 @media (max-width: 720px) {
-  body[data-ui-mode="basic"] .basic-guided-card-header {
-    align-items: flex-start;
-  }
-
-  body[data-ui-mode="basic"] .basic-guided-card-icon {
-    flex-basis: 46px;
-    width: 46px;
-    height: 46px;
-  }
-
   body[data-ui-mode="basic"] .basic-guided-card-heading h2 {
-    font-size: 18px !important;
+    font-size: 17px !important;
   }
 
   body[data-ui-mode="basic"] .basic-guided-card-heading p {
@@ -684,21 +385,17 @@ body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty {
   }
 
   body[data-ui-mode="basic"] .basic-guided-step {
-    grid-template-columns: 44px minmax(0, 1fr);
+    grid-template-columns: 36px minmax(0, 1fr);
   }
 
   body[data-ui-mode="basic"] .basic-guided-step-number {
-    width: 38px;
-    height: 38px;
-    font-size: 16px;
-  }
-
-  body[data-ui-mode="basic"] .basic-guided-step:not(:last-of-type) .basic-guided-step-rail::after {
-    top: 44px;
+    width: 28px;
+    height: 28px;
+    font-size: 13px;
   }
 
   body[data-ui-mode="basic"] .basic-guided-step-heading h3 {
-    font-size: 16px;
+    font-size: 15px;
   }
 
   body[data-ui-mode="basic"] .basic-guided-profile-field .segmented,
@@ -711,12 +408,10 @@ body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty {
   }
 
   body[data-ui-mode="basic"] .basic-guided-status-hero {
-    grid-template-columns: minmax(0, 1fr);
-    justify-items: center;
-    text-align: center;
+    padding: 20px;
   }
 
-  body[data-ui-mode="basic"] .basic-guided-more-actions {
-    margin-left: 56px;
+  body[data-ui-mode="basic"] .basic-guided-status-state h3 {
+    font-size: 23px;
   }
 }

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -36,32 +36,27 @@
     return tip;
   }
 
-  function setCardHeader(card, kind, title, subtitle) {
+  function setCardHeader(card, title, subtitle) {
     const header = card && card.querySelector(':scope > .card-header');
     if (!header || header.dataset.guidedReady === '1') return;
     header.dataset.guidedReady = '1';
     header.classList.add('basic-guided-card-header');
     header.replaceChildren();
 
-    const icon = make('span', `basic-guided-card-icon ${kind}`);
-    icon.setAttribute('aria-hidden', 'true');
-
     const copy = make('div', 'basic-guided-card-heading');
     copy.append(
       make('h2', '', title),
       make('p', '', subtitle),
     );
-    header.append(icon, copy);
+    header.appendChild(copy);
   }
 
   function createStep(number, title, helper, tipText, slotId) {
     const step = make('section', 'basic-guided-step');
     step.dataset.step = String(number);
 
-    const rail = make('div', 'basic-guided-step-rail');
     const badge = make('span', 'basic-guided-step-number', String(number));
     badge.setAttribute('aria-hidden', 'true');
-    rail.appendChild(badge);
 
     const content = make('div', 'basic-guided-step-content');
     const heading = make('div', 'basic-guided-step-heading');
@@ -73,7 +68,7 @@
     const helperNode = make('p', 'basic-guided-step-help', helper);
     helperNode.id = `${slotId}Help`;
     content.append(heading, slot, helperNode);
-    step.append(rail, content);
+    step.append(badge, content);
     return step;
   }
 
@@ -87,7 +82,6 @@
 
     setCardHeader(
       card,
-      'setup',
       'Set Up Hotspot',
       'Follow these simple steps to create your hotspot.',
     );
@@ -139,6 +133,7 @@
     technicalDefaults.hidden = true;
 
     const staging = make('div', 'basic-guided-staging');
+    staging.id = 'basicGuidedHiddenSetup';
     staging.hidden = true;
     staging.append(quickStaging);
     const connectStaging = el('basicConnectFields');
@@ -160,15 +155,10 @@
       passSlot.appendChild(savePass);
     }
 
-    if (copySsid || copyPass) {
-      const more = make('details', 'basic-guided-more-actions');
-      more.appendChild(make('summary', '', 'More actions'));
-      const moreBody = make('div', 'basic-guided-more-actions-body');
-      if (copySsid) moreBody.appendChild(copySsid);
-      if (copyPass) moreBody.appendChild(copyPass);
-      more.appendChild(moreBody);
-      steps.appendChild(more);
-    }
+    // Keep the existing copy controls and their handlers alive without exposing
+    // an empty disclosure in the simplified Basic interface.
+    if (copySsid) staging.appendChild(copySsid);
+    if (copyPass) staging.appendChild(copyPass);
 
     const copyHint = el('copyHint');
     if (copyHint && passSlot) passSlot.appendChild(copyHint);
@@ -177,32 +167,6 @@
 
     body.replaceChildren(notices, steps, technicalDefaults, staging);
     return card;
-  }
-
-  function makeWifiOrb() {
-    const orb = make('div', 'basic-guided-status-orb');
-    orb.setAttribute('aria-hidden', 'true');
-    orb.innerHTML = [
-      '<svg viewBox="0 0 64 64" focusable="false" aria-hidden="true">',
-      '<path d="M10 25.5C22.2 14.7 41.8 14.7 54 25.5"/>',
-      '<path d="M17.5 34C25.7 26.8 38.3 26.8 46.5 34"/>',
-      '<path d="M25 42.5C29 39 35 39 39 42.5"/>',
-      '<circle cx="32" cy="49" r="3.5"/>',
-      '</svg>',
-    ].join('');
-    return orb;
-  }
-
-  function makeFact(iconClass, label, valueId) {
-    const fact = make('div', 'basic-guided-status-fact');
-    const icon = make('span', `basic-guided-fact-icon ${iconClass}`);
-    icon.setAttribute('aria-hidden', 'true');
-    const copy = make('div', 'basic-guided-fact-copy');
-    const value = make('strong', '', '--');
-    value.id = valueId;
-    copy.append(make('span', '', label), value);
-    fact.append(icon, copy);
-    return fact;
   }
 
   function buildStatusCard() {
@@ -215,7 +179,6 @@
 
     setCardHeader(
       card,
-      'status',
       'Status & Control',
       'See the hotspot state and control it from one place.',
     );
@@ -225,60 +188,37 @@
     body.classList.add('basic-guided-status-body');
 
     const hero = make('section', 'basic-guided-status-hero');
-    const orb = makeWifiOrb();
-    const heroCopy = make('div', 'basic-guided-status-copy');
+    const stateRow = make('div', 'basic-guided-status-state');
+    const stateDot = make('span', 'basic-guided-status-dot');
+    stateDot.setAttribute('aria-hidden', 'true');
     const stateText = make('h3', '', 'Loading…');
     stateText.id = 'basicGuidedStateText';
+    stateRow.append(stateDot, stateText);
+
     const summary = make('p', '', 'Checking the hotspot status.');
     summary.id = 'basicGuidedStatusSummary';
-    heroCopy.append(stateText, summary);
-    hero.append(orb, heroCopy);
+    hero.append(stateRow, summary);
+
+    const hiddenStatus = make('div', 'basic-guided-hidden-status');
+    hiddenStatus.id = 'basicGuidedHiddenStatus';
+    hiddenStatus.hidden = true;
 
     const originalPillContainer = el('basicPillContainer');
-    if (originalPillContainer) {
-      originalPillContainer.classList.add('basic-guided-original-status');
-      hero.appendChild(originalPillContainer);
-    }
+    if (originalPillContainer) hiddenStatus.appendChild(originalPillContainer);
 
-    const facts = make('section', 'basic-guided-status-facts');
-    facts.append(
-      makeFact('adapter', 'Adapter', 'basicGuidedAdapterValue'),
-      makeFact('band', 'Band', 'basicGuidedBandValue'),
-    );
-
-    const diagnosticDetails = make('div', 'basic-guided-status-details');
     const originalMeta = el('basicStatusAdapterBand');
+    if (originalMeta) hiddenStatus.appendChild(originalMeta);
+
     const statusDetails = el('basicStatusDetails');
     const lastError = el('basicLastError');
     const errorDetail = el('basicLastErrorDetail');
-    if (originalMeta) diagnosticDetails.appendChild(originalMeta);
+
+    const diagnosticDetails = make('div', 'basic-guided-status-details');
     if (lastError) diagnosticDetails.appendChild(lastError);
     if (errorDetail) diagnosticDetails.appendChild(errorDetail);
 
     const actions = card.querySelector('.basic-status-actions');
-    if (actions) {
-      actions.classList.add('basic-guided-status-actions');
-      const buttonIcons = {
-        btnStartBasic: '▶',
-        btnStopBasic: '■',
-        btnRepairBasic: '◆',
-        btnRefreshBasic: '↻',
-      };
-      for (const button of actions.querySelectorAll('button')) {
-        button.dataset.guidedIcon = buttonIcons[button.id] || '';
-      }
-    }
-
-    const notice = make('div', 'basic-guided-apply-notice');
-    const noticeIcon = make('span', 'basic-guided-notice-icon');
-    noticeIcon.setAttribute('aria-hidden', 'true');
-    const noticeCopy = make('div', 'basic-guided-notice-copy');
-    noticeCopy.append(
-      make('span', '', 'Pending changes are saved automatically when you start the hotspot.'),
-    );
-    const dirty = el('dirtyBasic');
-    if (dirty) noticeCopy.appendChild(dirty);
-    notice.append(noticeIcon, noticeCopy);
+    if (actions) actions.classList.add('basic-guided-status-actions');
 
     const options = make('details', 'basic-guided-options');
     options.appendChild(make('summary', '', 'Options'));
@@ -287,16 +227,18 @@
     const privacyHint = el('privacyHintBasic');
     const telemetry = el('basicTelemetryContainer');
     const message = el('msgBasic');
+    const dirty = el('dirtyBasic');
     if (statusDetails) optionsBody.appendChild(statusDetails);
     if (preferences) optionsBody.appendChild(preferences);
     if (privacyHint) optionsBody.appendChild(privacyHint);
     if (telemetry) optionsBody.appendChild(telemetry);
     if (message) optionsBody.appendChild(message);
+    if (dirty) optionsBody.appendChild(dirty);
     options.appendChild(optionsBody);
 
-    body.replaceChildren(hero, facts, diagnosticDetails);
+    body.replaceChildren(hero, diagnosticDetails);
     if (actions) body.appendChild(actions);
-    body.append(notice, options);
+    body.append(options, hiddenStatus);
     return card;
   }
 
@@ -361,16 +303,6 @@
 
     const profileField = fieldNode('qos_preset');
     if (profileField) profileField.classList.add('basic-guided-profile-field');
-    const profileIcons = {
-      off: '○',
-      ultra_low_latency: '↗',
-      vr: '◇',
-    };
-    document.querySelectorAll('input[name="qos_basic"]').forEach((input) => {
-      const span = input.closest('label')?.querySelector('span');
-      const icon = profileIcons[input.value] || '•';
-      if (span && span.dataset.profileIcon !== icon) span.dataset.profileIcon = icon;
-    });
 
     const ssidField = fieldNode('ssid');
     if (ssidField) ssidField.classList.add('basic-guided-ssid-field');
@@ -397,36 +329,6 @@
     );
   }
 
-  function cleanAdapterLabel(text) {
-    return String(text || '')
-      .replace(/\s*\(Recommended\)\s*/i, '')
-      .trim() || '--';
-  }
-
-  function adapterLabelForValue(value) {
-    const select = el('ap_adapter');
-    if (!select) return value || '--';
-    const match = Array.from(select.options).find((option) => option.value === value);
-    if (match) return cleanAdapterLabel(match.textContent);
-    if (!value || value === '--') {
-      const selected = select.options[select.selectedIndex];
-      return cleanAdapterLabel(selected?.textContent);
-    }
-    return value;
-  }
-
-  function parseStatusMeta() {
-    const raw = el('basicStatusAdapterBand')?.textContent || '';
-    const adapterMatch = raw.match(/Adapter:\s*([^|]+)/i);
-    const bandMatch = raw.match(/Band:\s*([^|]+)/i);
-    const adapterValue = adapterMatch ? adapterMatch[1].trim() : '--';
-    const band = bandMatch ? bandMatch[1].trim() : '--';
-    return {
-      adapter: adapterLabelForValue(adapterValue),
-      band: band || '--',
-    };
-  }
-
   function syncStatusPresentation() {
     const rawStatus = (el('basicPillTxt')?.textContent || 'Loading…').trim();
     const state = (rawStatus.split('|')[0] || 'Loading…').trim();
@@ -434,11 +336,8 @@
     const card = document.querySelector('.basic-guided-status-card');
     const stateText = el('basicGuidedStateText');
     const summary = el('basicGuidedStatusSummary');
-    const facts = parseStatusMeta();
 
     setTextIfChanged(stateText, state);
-    setTextIfChanged(el('basicGuidedAdapterValue'), facts.adapter);
-    setTextIfChanged(el('basicGuidedBandValue'), facts.band);
 
     let stateName = 'loading';
     let summaryText = 'Checking the hotspot status.';
@@ -527,7 +426,6 @@
       const target = event.target;
       if (!(target instanceof Element)) return;
       if (target.matches('input[name="qos_basic"]')) updateProfileHelp();
-      if (target.id === 'ap_adapter') syncStatusPresentation();
     });
     wireSaveBeforeStart();
   }
@@ -552,7 +450,6 @@
     observeStagingContainer(el('basicQuickFields'));
     observeStagingContainer(el('basicConnectFields'));
     observeStatusSource(el('basicPillTxt'));
-    observeStatusSource(el('basicStatusAdapterBand'));
 
     const bodyObserver = new MutationObserver(() => {
       if (document.body.dataset.uiMode === BASIC_MODE) queueReposition();

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -32,12 +32,10 @@ def test_guided_interface_reuses_existing_live_control_ids() -> None:
         "basicPillTxt",
         "basicStatusAdapterBand",
         "btnStartBasic",
-        "btnStopBasic",
-        "btnRepairBasic",
-        "btnRefreshBasic",
     ):
         assert control_id in source
 
+    assert "card.querySelector('.basic-status-actions')" in source
     assert "api(" not in source
     assert "fetch(" not in source
 

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -78,8 +78,8 @@ def test_status_presentation_is_idempotent_and_source_scoped() -> None:
 
     assert "function setTextIfChanged" in source
     assert "observeStatusSource(el('basicPillTxt'))" in source
-    assert "observeStatusSource(el('basicStatusAdapterBand'))" in source
     assert "observeStagingContainer(el('basicQuickFields'))" in source
+    assert "observeStatusSource(el('basicStatusAdapterBand'))" not in source
     assert "observer.observe(basic" not in source
 
 
@@ -93,24 +93,42 @@ def test_start_saves_pending_basic_changes_before_existing_start_handler() -> No
     assert "await waitForBasicSave();" in source
     assert "target.dataset.guidedResume = '1';" in source
     assert "target.click();" in source
-    assert "Pending changes are saved automatically when you start the hotspot." in source
 
 
-def test_status_uses_friendly_adapter_labels_and_hides_technical_details() -> None:
+def test_status_omits_adapter_band_facts_and_decorative_notice() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
-    assert "function adapterLabelForValue" in source
-    assert ".find((option) => option.value === value)" in source
-    assert "if (statusDetails) optionsBody.appendChild(statusDetails);" in source
-    assert "if (statusDetails) diagnosticDetails.appendChild(statusDetails);" not in source
+    assert "makeFact(" not in source
+    assert "basicGuidedAdapterValue" not in source
+    assert "basicGuidedBandValue" not in source
+    assert "basic-guided-status-facts" not in source
+    assert "Pending changes are saved automatically" not in source
+    assert "basic-guided-apply-notice" not in source
+    assert "if (originalMeta) hiddenStatus.appendChild(originalMeta);" in source
 
 
-def test_guided_styles_are_basic_only_and_use_native_sizing() -> None:
+def test_empty_more_actions_disclosure_is_removed_but_controls_stay_alive() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "'More actions'" not in source
+    assert "basic-guided-more-actions" not in source
+    assert "if (copySsid) staging.appendChild(copySsid);" in source
+    assert "if (copyPass) staging.appendChild(copyPass);" in source
+
+
+def test_guided_styles_match_existing_theme_and_avoid_custom_iconography() -> None:
     styles = GUIDED_CSS.read_text(encoding="utf-8")
+    source = GUIDED_JS.read_text(encoding="utf-8")
 
     assert 'body[data-ui-mode="basic"] .basic-guided-step' in styles
     assert 'body[data-ui-mode="basic"] .basic-guided-status-hero' in styles
     assert 'body[data-ui-mode="basic"] .basic-guided-status-actions' in styles
+    assert "background: var(--bg-panel);" in styles
+    assert "border-color: var(--border-subtle);" in styles
+    assert "basic-guided-card-icon" not in styles
+    assert "basic-guided-status-orb" not in styles
+    assert "data-guided-icon" not in source
+    assert "data-profile-icon" not in source
     assert 'body[data-ui-mode="advanced"]' not in styles
     assert "zoom:" not in styles
     assert "transform: scale(" not in styles
@@ -125,3 +143,4 @@ def test_secondary_controls_are_preserved_in_collapsed_options() -> None:
     assert "optionsBody.appendChild(preferences)" in source
     assert "basicTelemetryContainer" in source
     assert "privacyHintBasic" in source
+    assert "if (dirty) optionsBody.appendChild(dirty);" in source


### PR DESCRIPTION
## Summary

Refine the guided Basic interface from PR #133 so it feels native to the existing VRhotspot UI rather than introducing a separate visual language.

## Changes

- Remove the custom decorative icons from both card headers.
- Replace the oversized Wi-Fi status medallion with a simple native status panel and state dot.
- Remove generated glyphs from connection-profile and action buttons.
- Reduce step numbers and remove the decorative connecting rail/glow.
- Restore existing panel backgrounds, borders, shadows, typography, spacing, and button density.
- Remove the Adapter/Band fact block from Status & Control.
- Remove the automatic-save notice from the visible interface while retaining save-before-start behavior.
- Remove the empty More actions disclosure; keep its existing copy controls alive in hidden staging so no handlers are broken.
- Keep technical status and secondary controls inside Options.

## Safety

- No backend, API, networking, installer, or Pro-mode changes.
- Existing Basic IDs, listeners, QR behavior, passphrase handling, QoS autosave, mode restoration, and save-before-start flow remain intact.
- Status observation remains source-scoped and idempotent.

## Validation

- JavaScript syntax checked with Node.
- Updated regression contracts cover removal of decorative facts/notices/disclosures, hidden control preservation, original-theme variables, and absence of custom generated iconography.