### PR TITLE
Simplify remaining Basic-mode controls

### DIFF
--- a/assets/basic_guided.css
+++ b/assets/basic_guided.css
@@ -120,9 +120,13 @@ body[data-ui-mode="basic"] .basic-guided-step-help {
   line-height: 1.5;
 }
 
+/* The base .tip class already draws the circle. Use a plain i to avoid a
+ * second circled glyph inside it. */
 body[data-ui-mode="basic"] .basic-guided-tip {
-  border-color: var(--border-active);
+  border-color: var(--border-subtle);
   color: var(--accent-primary);
+  font-family: var(--font-sans);
+  font-style: normal;
 }
 
 body[data-ui-mode="basic"] .basic-guided-step-slot > [data-field],
@@ -170,23 +174,28 @@ body[data-ui-mode="basic"] .basic-guided-profile-field .qos-basic {
 body[data-ui-mode="basic"] .basic-guided-profile-field .segmented {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  gap: 14px;
+  width: 100%;
 }
 
 body[data-ui-mode="basic"] .basic-guided-profile-field .seg {
+  display: block;
+  width: 100%;
   min-width: 0;
 }
 
 body[data-ui-mode="basic"] .basic-guided-profile-field .seg span {
   display: flex;
-  min-height: 48px;
+  width: 100%;
+  min-height: 64px;
+  padding: 0 24px;
   align-items: center;
   justify-content: center;
   border-color: var(--border-subtle);
   background: var(--bg-subtle);
   color: var(--text-muted);
-  font-size: 14px;
-  font-weight: 650;
+  font-size: 16px;
+  font-weight: 700;
 }
 
 body[data-ui-mode="basic"] .basic-guided-profile-field .seg input:checked + span {
@@ -196,16 +205,41 @@ body[data-ui-mode="basic"] .basic-guided-profile-field .seg input:checked + span
   box-shadow: var(--shadow-glow);
 }
 
-body[data-ui-mode="basic"] .basic-guided-pass-field .input-with-action {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 50px 50px;
-  gap: 10px;
+/* Lock the existing live passphrase controls into one explicit row. This wins
+ * over older Basic flex sizing without replacing any IDs or handlers. */
+body[data-ui-mode="basic"] .basic-guided-password-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) 50px 50px !important;
+  gap: 10px !important;
+  align-items: stretch;
+  width: 100%;
 }
 
-body[data-ui-mode="basic"] .basic-guided-pass-field .btn.icon-only {
-  width: 50px;
-  min-width: 50px;
-  padding: 0;
+body[data-ui-mode="basic"] .basic-guided-password-row #wpa2_passphrase_basic {
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+  height: 50px;
+  margin: 0 !important;
+}
+
+body[data-ui-mode="basic"] .basic-guided-password-row #btnRevealPassBasic {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+body[data-ui-mode="basic"] .basic-guided-password-row #btnShowQrBasic {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+body[data-ui-mode="basic"] .basic-guided-password-row .btn.icon-only {
+  width: 50px !important;
+  min-width: 50px !important;
+  height: 50px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  align-self: stretch;
 }
 
 body[data-ui-mode="basic"] .basic-guided-save-password {
@@ -321,44 +355,6 @@ body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
   font-size: 15px !important;
 }
 
-body[data-ui-mode="basic"] .basic-guided-options {
-  margin-top: 18px;
-  border-top: 1px solid var(--border-subtle);
-}
-
-body[data-ui-mode="basic"] .basic-guided-options > summary {
-  width: fit-content;
-  padding-top: 14px;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 650;
-}
-
-body[data-ui-mode="basic"] .basic-guided-options-body {
-  display: grid;
-  gap: 10px;
-  padding-top: 14px;
-}
-
-body[data-ui-mode="basic"] .basic-guided-options .basic-status-preferences {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-body[data-ui-mode="basic"] .basic-guided-options #msgBasic:empty,
-body[data-ui-mode="basic"] .basic-guided-options #privacyHintBasic:empty,
-body[data-ui-mode="basic"] .basic-guided-options #dirtyBasic:empty,
-body[data-ui-mode="basic"] .basic-guided-options #basicStatusDetails:empty {
-  display: none;
-}
-
-body[data-ui-mode="basic"] .basic-guided-options #dirtyBasic:not(:empty) {
-  margin: 0 !important;
-  color: var(--warning);
-  font-size: 12px;
-}
-
 @media (max-width: 1500px) {
   body[data-ui-mode="basic"] .basic-grid {
     grid-template-columns: minmax(0, 1.18fr) minmax(390px, .82fr);
@@ -403,8 +399,19 @@ body[data-ui-mode="basic"] .basic-guided-options #dirtyBasic:not(:empty) {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  body[data-ui-mode="basic"] .basic-guided-pass-field .input-with-action {
-    grid-template-columns: minmax(0, 1fr) 46px 46px;
+  body[data-ui-mode="basic"] .basic-guided-profile-field .seg span {
+    min-height: 54px;
+    font-size: 15px;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-password-row {
+    grid-template-columns: minmax(0, 1fr) 46px 46px !important;
+  }
+
+  body[data-ui-mode="basic"] .basic-guided-password-row .btn.icon-only {
+    width: 46px !important;
+    min-width: 46px !important;
+    height: 50px !important;
   }
 
   body[data-ui-mode="basic"] .basic-guided-status-hero {

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -29,7 +29,7 @@
   }
 
   function makeInfoTip(text) {
-    const tip = make('span', 'tip basic-guided-tip', 'ⓘ');
+    const tip = make('span', 'tip basic-guided-tip', 'i');
     tip.setAttribute('data-tip', text);
     tip.setAttribute('aria-label', text);
     tip.setAttribute('tabindex', '0');
@@ -139,9 +139,20 @@
     const connectStaging = el('basicConnectFields');
     if (connectStaging) staging.append(connectStaging);
 
-    const passGroup = el('wpa2_passphrase_basic')?.closest('.form-group');
+    const passField = el('wpa2_passphrase_basic');
+    const passGroup = passField?.closest('.form-group');
     const passSlot = steps.querySelector('#basicGuidedPassSlot');
     if (passGroup && passSlot) passSlot.appendChild(passGroup);
+
+    const passActions = passGroup?.querySelector('.basic-passphrase-actions');
+    const revealPass = el('btnRevealPassBasic');
+    const showQr = el('btnShowQrBasic');
+    if (passActions) {
+      passActions.classList.add('basic-guided-password-row');
+      if (passField) passActions.appendChild(passField);
+      if (revealPass) passActions.appendChild(revealPass);
+      if (showQr) passActions.appendChild(showQr);
+    }
 
     const oldConnectArea = card.querySelector('.basic-connect-inline');
     const actionGroup = oldConnectArea?.querySelector('.basic-connect-actions');
@@ -220,25 +231,23 @@
     const actions = card.querySelector('.basic-status-actions');
     if (actions) actions.classList.add('basic-guided-status-actions');
 
-    const options = make('details', 'basic-guided-options');
-    options.appendChild(make('summary', '', 'Options'));
-    const optionsBody = make('div', 'basic-guided-options-body');
+    // These controls remain connected so switching to Pro mode and the existing
+    // state synchronization keep working, but Basic mode intentionally does not
+    // expose privacy, refresh, telemetry, or technical feedback controls.
     const preferences = card.querySelector('.basic-status-preferences');
     const privacyHint = el('privacyHintBasic');
     const telemetry = el('basicTelemetryContainer');
     const message = el('msgBasic');
     const dirty = el('dirtyBasic');
-    if (statusDetails) optionsBody.appendChild(statusDetails);
-    if (preferences) optionsBody.appendChild(preferences);
-    if (privacyHint) optionsBody.appendChild(privacyHint);
-    if (telemetry) optionsBody.appendChild(telemetry);
-    if (message) optionsBody.appendChild(message);
-    if (dirty) optionsBody.appendChild(dirty);
-    options.appendChild(optionsBody);
+    for (const node of (
+      [statusDetails, preferences, privacyHint, telemetry, message, dirty]
+    )) {
+      if (node) hiddenStatus.appendChild(node);
+    }
 
     body.replaceChildren(hero, diagnosticDetails);
     if (actions) body.appendChild(actions);
-    body.append(options, hiddenStatus);
+    body.appendChild(hiddenStatus);
     return card;
   }
 
@@ -411,7 +420,7 @@
       if (!saved) {
         setTextIfChanged(
           el('basicGuidedStatusSummary'),
-          'Your changes could not be saved. Review the message under Options.',
+          'Your changes could not be saved. Switch to Pro mode for details.',
         );
         return;
       }

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -26,6 +26,8 @@ def test_guided_interface_reuses_existing_live_control_ids() -> None:
         "basicQuickFields",
         "basicConnectFields",
         "wpa2_passphrase_basic",
+        "btnRevealPassBasic",
+        "btnShowQrBasic",
         "btnSavePassBasic",
         "btnCopySsid",
         "btnCopyPass",
@@ -91,6 +93,7 @@ def test_start_saves_pending_basic_changes_before_existing_start_handler() -> No
     assert "await waitForBasicSave();" in source
     assert "target.dataset.guidedResume = '1';" in source
     assert "target.click();" in source
+    assert "Switch to Pro mode for details." in source
 
 
 def test_status_omits_adapter_band_facts_and_decorative_notice() -> None:
@@ -132,13 +135,46 @@ def test_guided_styles_match_existing_theme_and_avoid_custom_iconography() -> No
     assert "transform: scale(" not in styles
 
 
-def test_secondary_controls_are_preserved_in_collapsed_options() -> None:
+def test_info_tips_use_one_native_circle_instead_of_a_circled_glyph() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
-    assert "make('details', 'basic-guided-options')" in source
-    assert "'Options'" in source
+    assert "make('span', 'tip basic-guided-tip', 'i')" in source
+    assert "make('span', 'tip basic-guided-tip', 'ⓘ')" not in source
+
+
+def test_pro_only_status_controls_stay_alive_but_are_hidden_in_basic() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert "make('details', 'basic-guided-options')" not in source
+    assert "'Options'" not in source
     assert "card.querySelector('.basic-status-preferences')" in source
-    assert "optionsBody.appendChild(preferences)" in source
     assert "basicTelemetryContainer" in source
     assert "privacyHintBasic" in source
-    assert "if (dirty) optionsBody.appendChild(dirty);" in source
+    assert "hiddenStatus.appendChild(node)" in source
+    assert ".basic-guided-options" not in styles
+    assert ".basic-guided-hidden-status" in styles
+
+
+def test_connection_profiles_fill_the_available_width() -> None:
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert ".basic-guided-profile-field .segmented" in styles
+    assert "grid-template-columns: repeat(3, minmax(0, 1fr));" in styles
+    assert ".basic-guided-profile-field .seg span" in styles
+    assert "min-height: 64px;" in styles
+    assert "width: 100%;" in styles
+
+
+def test_password_field_reveal_and_qr_are_locked_to_one_row() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert "passActions.classList.add('basic-guided-password-row');" in source
+    assert "passActions.appendChild(passField);" in source
+    assert "passActions.appendChild(revealPass);" in source
+    assert "passActions.appendChild(showQr);" in source
+    assert ".basic-guided-password-row #wpa2_passphrase_basic" in styles
+    assert ".basic-guided-password-row #btnRevealPassBasic" in styles
+    assert ".basic-guided-password-row #btnShowQrBasic" in styles
+    assert "grid-template-columns: minmax(0, 1fr) 50px 50px !important;" in styles


### PR DESCRIPTION
## Summary

Finish the Basic-mode simplification pass based on the latest real-system screenshot.

## Changes

- Replace the doubled circled-info glyph with a plain `i` inside the existing native tooltip circle.
- Remove the Options disclosure from Basic mode.
- Keep Privacy, Refresh Status, Stats, telemetry, status details, messages, and dirty-state controls connected in hidden staging so Pro synchronization and save-before-start behavior remain intact.
- Enlarge the Off / Speed / Stable connection-profile controls so all three fill equal columns with larger click targets.
- Lock the existing passphrase field, reveal button, and QR button into one explicit aligned row.
- Update save-failure guidance to direct users to Pro mode instead of a removed Options section.

## Safety

- Reuses all existing control IDs and event handlers.
- No backend, networking, installer, API, or Pro-mode changes.
- Existing QR generation, passphrase reveal/save, profile selection, status observers, and Start save-before-run behavior remain unchanged.

## Validation

- Focused regression contracts cover tooltip rendering, hidden Pro-only controls, full-width profile controls, and explicit password-action grid placement.