### PR TITLE
Turn Basic mode into one five-step hotspot flow

### DIFF
--- a/assets/basic_guided.css
+++ b/assets/basic_guided.css
@@ -5,16 +5,24 @@ body[data-ui-mode="basic"] .basic-container {
 }
 
 body[data-ui-mode="basic"] .basic-grid {
-  align-items: stretch;
-  grid-template-columns: minmax(0, 1.34fr) minmax(440px, .96fr);
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  width: 100%;
+  max-width: 1900px;
+  margin: 0 auto;
 }
 
 body[data-ui-mode="basic"] .basic-guided-card {
-  height: 100%;
+  width: 100%;
+  height: auto;
   overflow: hidden;
   border-color: var(--border-subtle);
   background: var(--bg-panel);
   box-shadow: var(--shadow-sm);
+}
+
+body[data-ui-mode="basic"] .basic-guided-status-source-card {
+  display: none !important;
 }
 
 body[data-ui-mode="basic"] .basic-guided-card-header {
@@ -41,11 +49,6 @@ body[data-ui-mode="basic"] .basic-guided-card-heading p {
   color: var(--text-muted);
   font-size: 14px;
   line-height: 1.45;
-}
-
-body[data-ui-mode="basic"] .basic-guided-setup-body,
-body[data-ui-mode="basic"] .basic-guided-status-body {
-  min-height: 0;
 }
 
 body[data-ui-mode="basic"] .basic-guided-notices:empty {
@@ -120,8 +123,10 @@ body[data-ui-mode="basic"] .basic-guided-step-help {
   line-height: 1.5;
 }
 
-/* The base .tip class already draws the circle. Use a plain i to avoid a
- * second circled glyph inside it. */
+body[data-ui-mode="basic"] .basic-guided-step-help:empty {
+  display: none;
+}
+
 body[data-ui-mode="basic"] .basic-guided-tip {
   border-color: var(--border-subtle);
   color: var(--accent-primary);
@@ -205,8 +210,6 @@ body[data-ui-mode="basic"] .basic-guided-profile-field .seg input:checked + span
   box-shadow: var(--shadow-glow);
 }
 
-/* Lock the existing live passphrase controls into one explicit row. This wins
- * over older Basic flex sizing without replacing any IDs or handlers. */
 body[data-ui-mode="basic"] .basic-guided-password-row {
   display: grid !important;
   grid-template-columns: minmax(0, 1fr) 50px 50px !important;
@@ -261,16 +264,11 @@ body[data-ui-mode="basic"] .basic-guided-hidden-status {
   display: none !important;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card {
-  min-height: 100%;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-body {
-  display: flex;
-  flex-direction: column;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-hero {
+body[data-ui-mode="basic"] .basic-guided-hotspot-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 340px);
+  gap: 24px;
+  align-items: center;
   padding: 24px;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
@@ -291,83 +289,113 @@ body[data-ui-mode="basic"] .basic-guided-status-dot {
   background: var(--text-muted);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-copy,
-body[data-ui-mode="basic"] .basic-guided-original-status {
-  display: none;
-}
-
-body[data-ui-mode="basic"] .basic-guided-status-state h3 {
+body[data-ui-mode="basic"] .basic-guided-status-state h4 {
   margin: 0;
   color: var(--text-main);
-  font-size: 26px;
+  font-size: 24px;
   line-height: 1.2;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-hero > p {
+body[data-ui-mode="basic"] .basic-guided-hotspot-copy > p {
   margin: 8px 0 0 23px;
   color: var(--text-muted);
   font-size: 14px;
   line-height: 1.5;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="running"] .basic-guided-status-dot {
+body[data-ui-mode="basic"] .basic-guided-setup-card[data-hotspot-state="running"] .basic-guided-status-dot {
   background: var(--success);
   box-shadow: 0 0 8px rgba(0, 255, 157, .45);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="working"] .basic-guided-status-dot {
+body[data-ui-mode="basic"] .basic-guided-setup-card[data-hotspot-state="working"] .basic-guided-status-dot {
   background: var(--accent-primary);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-card[data-hotspot-state="error"] .basic-guided-status-dot {
+body[data-ui-mode="basic"] .basic-guided-setup-card[data-hotspot-state="error"] .basic-guided-status-dot {
   background: var(--danger);
   box-shadow: 0 0 8px rgba(255, 0, 85, .4);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-details {
+body[data-ui-mode="basic"] .basic-guided-primary-action {
+  width: 100%;
+  min-height: 56px;
+  justify-content: center;
+  font-size: 16px !important;
+}
+
+body.basic-hotspot-modal-open {
+  overflow: hidden;
+}
+
+.basic-hotspot-error-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483000;
   display: grid;
-  gap: 8px;
-  margin-top: 14px;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, .78);
+  backdrop-filter: blur(8px);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-details:empty {
-  display: none;
+.basic-hotspot-error-overlay[hidden] {
+  display: none !important;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-details > :not(:empty) {
-  padding: 10px 12px;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
+.basic-hotspot-error-dialog {
+  width: min(560px, 100%);
+  overflow: hidden;
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+}
+
+.basic-hotspot-error-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-subtle);
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-actions {
+.basic-hotspot-error-header h2 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 18px;
+}
+
+.basic-hotspot-error-body {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px !important;
-  padding-top: 22px;
-  margin-top: auto !important;
+  gap: 10px;
+  padding: 24px;
 }
 
-body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
-  height: 50px !important;
-  justify-content: center;
-  font-size: 15px !important;
+.basic-hotspot-error-body p {
+  margin: 0;
+  color: var(--text-main);
+  line-height: 1.5;
 }
 
-@media (max-width: 1500px) {
-  body[data-ui-mode="basic"] .basic-grid {
-    grid-template-columns: minmax(0, 1.18fr) minmax(390px, .82fr);
-  }
+.basic-hotspot-error-body .small {
+  color: var(--text-muted);
 }
 
-@media (max-width: 1120px) {
-  body[data-ui-mode="basic"] .basic-grid {
+.basic-hotspot-error-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 18px 20px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
+}
+
+@media (max-width: 900px) {
+  body[data-ui-mode="basic"] .basic-guided-hotspot-control {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  body[data-ui-mode="basic"] .basic-guided-status-card {
-    min-height: auto;
   }
 }
 
@@ -394,8 +422,7 @@ body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
     font-size: 15px;
   }
 
-  body[data-ui-mode="basic"] .basic-guided-profile-field .segmented,
-  body[data-ui-mode="basic"] .basic-guided-status-actions {
+  body[data-ui-mode="basic"] .basic-guided-profile-field .segmented {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -414,11 +441,19 @@ body[data-ui-mode="basic"] .basic-guided-status-actions .btn {
     height: 50px !important;
   }
 
-  body[data-ui-mode="basic"] .basic-guided-status-hero {
+  body[data-ui-mode="basic"] .basic-guided-hotspot-control {
     padding: 20px;
   }
 
-  body[data-ui-mode="basic"] .basic-guided-status-state h3 {
-    font-size: 23px;
+  body[data-ui-mode="basic"] .basic-guided-status-state h4 {
+    font-size: 21px;
+  }
+
+  .basic-hotspot-error-footer {
+    flex-direction: column-reverse;
+  }
+
+  .basic-hotspot-error-footer .btn {
+    width: 100%;
   }
 }

--- a/assets/basic_guided.js
+++ b/assets/basic_guided.js
@@ -12,6 +12,7 @@
 
   let repositionQueued = false;
   let saveBeforeStartRunning = false;
+  let lastStateName = '';
 
   function el(id) {
     return document.getElementById(id);
@@ -60,7 +61,10 @@
 
     const content = make('div', 'basic-guided-step-content');
     const heading = make('div', 'basic-guided-step-heading');
-    heading.append(make('h3', '', title), makeInfoTip(tipText));
+    const titleNode = make('h3', '', title);
+    titleNode.id = `${slotId}Title`;
+    heading.appendChild(titleNode);
+    if (tipText) heading.appendChild(makeInfoTip(tipText));
 
     const slot = make('div', 'basic-guided-step-slot');
     slot.id = slotId;
@@ -107,24 +111,31 @@
       ),
       createStep(
         2,
-        'Choose connection profile',
+        'Choose performance mode',
         'Speed prioritizes low latency for VR streaming.',
-        'Choose how aggressively VRhotspot tunes the connection. Speed is the recommended default.',
+        'Standard uses normal hotspot behavior. Speed prioritizes latency. Stable favors reliability.',
         'basicGuidedProfileSlot',
       ),
       createStep(
         3,
-        'Hotspot name (SSID)',
+        'Hotspot name',
         'This is the Wi-Fi network name other devices will see.',
         'Choose the name shown in the Wi-Fi list on your headset and other devices.',
         'basicGuidedSsidSlot',
       ),
       createStep(
         4,
-        'Password (Passphrase)',
+        'Password',
         'Use 8–63 characters. Press Enter or choose Save password.',
         'This password protects the hotspot. You can reveal it or generate a QR code for easy connection.',
         'basicGuidedPassSlot',
+      ),
+      createStep(
+        5,
+        'Start hotspot',
+        '',
+        'Start or stop the hotspot. VRhotspot saves pending Basic-mode changes before starting.',
+        'basicGuidedActionSlot',
       ),
     );
 
@@ -138,6 +149,10 @@
     staging.append(quickStaging);
     const connectStaging = el('basicConnectFields');
     if (connectStaging) staging.append(connectStaging);
+
+    const hiddenStatus = make('div', 'basic-guided-hidden-status');
+    hiddenStatus.id = 'basicGuidedHiddenStatus';
+    hiddenStatus.hidden = true;
 
     const passField = el('wpa2_passphrase_basic');
     const passGroup = passField?.closest('.form-group');
@@ -166,8 +181,6 @@
       passSlot.appendChild(savePass);
     }
 
-    // Keep the existing copy controls and their handlers alive without exposing
-    // an empty disclosure in the simplified Basic interface.
     if (copySsid) staging.appendChild(copySsid);
     if (copyPass) staging.appendChild(copyPass);
 
@@ -176,79 +189,180 @@
     if (actionGroup && !actionGroup.children.length) actionGroup.remove();
     if (oldConnectArea) oldConnectArea.hidden = true;
 
-    body.replaceChildren(notices, steps, technicalDefaults, staging);
+    body.replaceChildren(
+      notices,
+      steps,
+      technicalDefaults,
+      staging,
+      hiddenStatus,
+    );
     return card;
   }
 
-  function buildStatusCard() {
+  function buildHotspotStep() {
     const pill = el('basicPill');
-    if (!pill) return null;
-    const card = pill.closest('.basic-card');
-    if (!card || card.dataset.basicGuidedReady === '1') return card;
-    card.dataset.basicGuidedReady = '1';
-    card.classList.add('basic-guided-card', 'basic-guided-status-card');
+    const actionSlot = el('basicGuidedActionSlot');
+    const hiddenStatus = el('basicGuidedHiddenStatus');
+    if (!pill || !actionSlot || !hiddenStatus) return null;
 
-    setCardHeader(
-      card,
-      'Status & Control',
-      'See the hotspot state and control it from one place.',
-    );
+    const statusCard = pill.closest('.basic-card');
+    if (!statusCard || statusCard.dataset.basicGuidedReady === '1') return statusCard;
+    statusCard.dataset.basicGuidedReady = '1';
+    statusCard.classList.add('basic-guided-status-source-card');
+    statusCard.hidden = true;
 
-    const body = card.querySelector(':scope > .card-body');
-    if (!body) return card;
-    body.classList.add('basic-guided-status-body');
-
-    const hero = make('section', 'basic-guided-status-hero');
+    const control = make('section', 'basic-guided-hotspot-control');
+    const statusCopy = make('div', 'basic-guided-hotspot-copy');
     const stateRow = make('div', 'basic-guided-status-state');
     const stateDot = make('span', 'basic-guided-status-dot');
     stateDot.setAttribute('aria-hidden', 'true');
-    const stateText = make('h3', '', 'Loading…');
+    const stateText = make('h4', '', 'Loading…');
     stateText.id = 'basicGuidedStateText';
     stateRow.append(stateDot, stateText);
 
     const summary = make('p', '', 'Checking the hotspot status.');
     summary.id = 'basicGuidedStatusSummary';
-    hero.append(stateRow, summary);
+    statusCopy.append(stateRow, summary);
 
-    const hiddenStatus = make('div', 'basic-guided-hidden-status');
-    hiddenStatus.id = 'basicGuidedHiddenStatus';
-    hiddenStatus.hidden = true;
+    const startButton = el('btnStartBasic');
+    if (startButton) {
+      startButton.classList.add('basic-guided-primary-action');
+      control.append(statusCopy, startButton);
+    } else {
+      control.appendChild(statusCopy);
+    }
+    actionSlot.appendChild(control);
 
     const originalPillContainer = el('basicPillContainer');
-    if (originalPillContainer) hiddenStatus.appendChild(originalPillContainer);
-
     const originalMeta = el('basicStatusAdapterBand');
-    if (originalMeta) hiddenStatus.appendChild(originalMeta);
-
     const statusDetails = el('basicStatusDetails');
     const lastError = el('basicLastError');
     const errorDetail = el('basicLastErrorDetail');
-
-    const diagnosticDetails = make('div', 'basic-guided-status-details');
-    if (lastError) diagnosticDetails.appendChild(lastError);
-    if (errorDetail) diagnosticDetails.appendChild(errorDetail);
-
-    const actions = card.querySelector('.basic-status-actions');
-    if (actions) actions.classList.add('basic-guided-status-actions');
-
-    // These controls remain connected so switching to Pro mode and the existing
-    // state synchronization keep working, but Basic mode intentionally does not
-    // expose privacy, refresh, telemetry, or technical feedback controls.
-    const preferences = card.querySelector('.basic-status-preferences');
+    const actions = statusCard.querySelector('.basic-status-actions');
+    const stopButton = el('btnStopBasic');
+    const repairButton = el('btnRepairBasic');
+    const refreshButton = el('btnRefreshBasic');
+    const preferences = statusCard.querySelector('.basic-status-preferences');
     const privacyHint = el('privacyHintBasic');
     const telemetry = el('basicTelemetryContainer');
     const message = el('msgBasic');
     const dirty = el('dirtyBasic');
-    for (const node of (
-      [statusDetails, preferences, privacyHint, telemetry, message, dirty]
-    )) {
+
+    for (const node of [
+      originalPillContainer,
+      originalMeta,
+      statusDetails,
+      lastError,
+      errorDetail,
+      actions,
+      stopButton,
+      repairButton,
+      refreshButton,
+      preferences,
+      privacyHint,
+      telemetry,
+      message,
+      dirty,
+    ]) {
       if (node) hiddenStatus.appendChild(node);
     }
 
-    body.replaceChildren(hero, diagnosticDetails);
-    if (actions) body.appendChild(actions);
-    body.appendChild(hiddenStatus);
-    return card;
+    return statusCard;
+  }
+
+  function buildErrorDialog() {
+    if (el('basicHotspotError')) return;
+
+    const overlay = make('div', 'basic-hotspot-error-overlay');
+    overlay.id = 'basicHotspotError';
+    overlay.hidden = true;
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'basicHotspotErrorTitle');
+
+    const dialog = make('div', 'basic-hotspot-error-dialog');
+    const header = make('div', 'basic-hotspot-error-header');
+    const title = make('h2', '', 'Hotspot could not start');
+    title.id = 'basicHotspotErrorTitle';
+    const close = make('button', 'btn sm secondary', 'Close');
+    close.type = 'button';
+    close.id = 'basicHotspotErrorClose';
+    close.addEventListener('click', closeHotspotErrorDialog);
+    header.append(title, close);
+
+    const body = make('div', 'basic-hotspot-error-body');
+    body.append(
+      make('p', '', 'VRhotspot encountered a network problem.'),
+      make(
+        'p',
+        'small',
+        'Try starting it again, or open Pro mode to review diagnostics and use Repair Network.',
+      ),
+    );
+
+    const footer = make('div', 'basic-hotspot-error-footer');
+    const retry = make('button', 'btn secondary', 'Try Again');
+    retry.type = 'button';
+    retry.id = 'basicHotspotRetry';
+    retry.addEventListener('click', retryHotspotStart);
+    const openPro = make('button', 'btn primary', 'Open Pro Mode');
+    openPro.type = 'button';
+    openPro.id = 'basicHotspotOpenPro';
+    openPro.addEventListener('click', openProRepair);
+    footer.append(retry, openPro);
+
+    dialog.append(header, body, footer);
+    overlay.appendChild(dialog);
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) closeHotspotErrorDialog();
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !overlay.hidden) closeHotspotErrorDialog();
+    });
+    document.body.appendChild(overlay);
+  }
+
+  function openHotspotErrorDialog() {
+    if (!document.body || document.body.dataset.uiMode !== BASIC_MODE) return;
+    const overlay = el('basicHotspotError');
+    if (!overlay) return;
+    overlay.hidden = false;
+    document.body.classList.add('basic-hotspot-modal-open');
+    const openPro = el('basicHotspotOpenPro');
+    if (openPro) openPro.focus();
+  }
+
+  function closeHotspotErrorDialog() {
+    const overlay = el('basicHotspotError');
+    if (!overlay) return;
+    overlay.hidden = true;
+    document.body.classList.remove('basic-hotspot-modal-open');
+    const action = el('btnStartBasic');
+    if (action && document.body.dataset.uiMode === BASIC_MODE) action.focus();
+  }
+
+  function retryHotspotStart() {
+    closeHotspotErrorDialog();
+    const action = el('btnStartBasic');
+    if (!action) return;
+    action.dataset.guidedRetry = '1';
+    action.click();
+  }
+
+  function openProRepair() {
+    closeHotspotErrorDialog();
+    const toggle = el('uiModeToggle');
+    if (toggle && !toggle.checked) toggle.click();
+
+    window.setTimeout(() => {
+      const overview = document.querySelector('.nav-item[data-tab="overview"]');
+      if (overview && !overview.classList.contains('active')) overview.click();
+      const repair = el('btnRepair');
+      if (repair) {
+        repair.scrollIntoView({ block: 'center' });
+        repair.focus();
+      }
+    }, 250);
   }
 
   function fieldNode(key) {
@@ -300,6 +414,18 @@
     window.setTimeout(repositionBasicFields, 0);
   }
 
+  function renameProfileOptions() {
+    const names = {
+      off: 'Standard',
+      ultra_low_latency: 'Speed',
+      vr: 'Stable',
+    };
+    document.querySelectorAll('input[name="qos_basic"]').forEach((input) => {
+      const label = input.nextElementSibling;
+      if (label && names[input.value]) setTextIfChanged(label, names[input.value]);
+    });
+  }
+
   function decorateMovedFields() {
     const adapterField = fieldNode('ap_adapter');
     if (adapterField) {
@@ -320,6 +446,7 @@
     const passGroup = passField?.closest('.form-group');
     if (passGroup) passGroup.classList.add('basic-guided-pass-field');
 
+    renameProfileOptions();
     updateProfileHelp();
   }
 
@@ -328,45 +455,115 @@
     if (!helper) return;
     const selected = document.querySelector('input[name="qos_basic"]:checked');
     const copy = {
-      off: 'Uses standard hotspot behavior without extra performance tuning.',
+      off: 'Standard uses normal hotspot behavior without extra performance tuning.',
       ultra_low_latency: 'Speed prioritizes low latency for VR streaming.',
       vr: 'Stable favors reliability on busy or noisy wireless networks.',
     };
     setTextIfChanged(
       helper,
-      copy[selected?.value] || 'Choose the profile that matches how you use the hotspot.',
+      copy[selected?.value] || 'Choose the mode that matches how you use the hotspot.',
     );
+  }
+
+  function hotspotState(rawStatus) {
+    const state = (rawStatus.split('|')[0] || 'Loading…').trim();
+    const normalized = state.toLowerCase();
+
+    if (normalized.includes('error') || normalized.includes('failed')) {
+      return { name: 'error', label: 'Needs attention' };
+    }
+    if (
+      normalized.includes('stopped')
+      || normalized.includes('inactive')
+      || normalized.includes('not running')
+    ) {
+      return { name: 'stopped', label: 'Stopped' };
+    }
+    if (normalized.includes('stopping')) return { name: 'working', label: 'Stopping…' };
+    if (normalized.includes('starting') || normalized.includes('repair')) {
+      return { name: 'working', label: 'Starting…' };
+    }
+    if (normalized.includes('running')) return { name: 'running', label: state };
+    return { name: 'loading', label: state || 'Loading…' };
+  }
+
+  function syncPrimaryAction(stateName) {
+    const action = el('btnStartBasic');
+    if (!action) return;
+
+    action.classList.remove('primary', 'secondary', 'danger');
+    action.disabled = false;
+
+    if (stateName === 'running') {
+      action.dataset.guidedAction = 'stop';
+      action.textContent = 'Stop hotspot';
+      action.classList.add('danger');
+      return;
+    }
+    if (stateName === 'error') {
+      action.dataset.guidedAction = 'problem';
+      action.textContent = 'View problem';
+      action.classList.add('danger');
+      return;
+    }
+    if (stateName === 'working') {
+      action.dataset.guidedAction = 'wait';
+      action.textContent = 'Working…';
+      action.classList.add('secondary');
+      action.disabled = true;
+      return;
+    }
+    if (stateName === 'stopped') {
+      action.dataset.guidedAction = 'start';
+      action.textContent = 'Start hotspot';
+      action.classList.add('primary');
+      return;
+    }
+
+    action.dataset.guidedAction = 'wait';
+    action.textContent = 'Checking status…';
+    action.classList.add('secondary');
+    action.disabled = true;
   }
 
   function syncStatusPresentation() {
     const rawStatus = (el('basicPillTxt')?.textContent || 'Loading…').trim();
-    const state = (rawStatus.split('|')[0] || 'Loading…').trim();
-    const normalized = state.toLowerCase();
-    const card = document.querySelector('.basic-guided-status-card');
+    const current = hotspotState(rawStatus);
+    const card = document.querySelector('.basic-guided-setup-card');
     const stateText = el('basicGuidedStateText');
     const summary = el('basicGuidedStatusSummary');
+    const title = el('basicGuidedActionSlotTitle');
 
-    setTextIfChanged(stateText, state);
+    setTextIfChanged(stateText, current.label);
 
-    let stateName = 'loading';
     let summaryText = 'Checking the hotspot status.';
-    if (normalized.includes('running')) {
-      stateName = 'running';
-      summaryText = 'Your hotspot is active and ready.';
-    } else if (normalized.includes('error')) {
-      stateName = 'error';
-      summaryText = 'The hotspot needs attention.';
-    } else if (normalized.includes('starting') || normalized.includes('repair')) {
-      stateName = 'working';
-      summaryText = 'VRhotspot is preparing the connection.';
-    } else if (normalized.includes('stopped')) {
-      stateName = 'stopped';
-      summaryText = 'Your hotspot is not active.';
+    let titleText = 'Start hotspot';
+    if (current.name === 'running') {
+      titleText = 'Hotspot running';
+      summaryText = 'Your hotspot is active and ready for your headset.';
+    } else if (current.name === 'error') {
+      titleText = 'Hotspot needs attention';
+      summaryText = 'VRhotspot encountered a network problem.';
+    } else if (current.name === 'working') {
+      titleText = current.label.toLowerCase().includes('stopping')
+        ? 'Stopping hotspot'
+        : 'Starting hotspot';
+      summaryText = 'VRhotspot is applying the connection settings.';
+    } else if (current.name === 'stopped') {
+      summaryText = 'Review your settings, then start the hotspot.';
     }
-    if (card && card.dataset.hotspotState !== stateName) {
-      card.dataset.hotspotState = stateName;
+
+    if (card && card.dataset.hotspotState !== current.name) {
+      card.dataset.hotspotState = current.name;
     }
+    setTextIfChanged(title, titleText);
     setTextIfChanged(summary, summaryText);
+    syncPrimaryAction(current.name);
+
+    if (current.name === 'error' && lastStateName !== 'error') {
+      openHotspotErrorDialog();
+    }
+    lastStateName = current.name;
   }
 
   function pendingBasicChanges() {
@@ -391,15 +588,39 @@
     });
   }
 
-  function wireSaveBeforeStart() {
+  function wirePrimaryAction() {
     document.addEventListener('click', async (event) => {
       const target = event.target instanceof Element
         ? event.target.closest('#btnStartBasic')
         : null;
       if (!target) return;
 
+      if (target.dataset.guidedRetry === '1') {
+        delete target.dataset.guidedRetry;
+        return;
+      }
       if (target.dataset.guidedResume === '1') {
         delete target.dataset.guidedResume;
+        return;
+      }
+
+      const action = target.dataset.guidedAction || 'start';
+      if (action === 'stop') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const stopButton = el('btnStopBasic');
+        if (stopButton) stopButton.click();
+        return;
+      }
+      if (action === 'problem') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        openHotspotErrorDialog();
+        return;
+      }
+      if (action !== 'start') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
         return;
       }
       if (!pendingBasicChanges()) return;
@@ -409,6 +630,7 @@
       if (saveBeforeStartRunning) return;
       saveBeforeStartRunning = true;
       target.classList.add('is-saving');
+      target.disabled = true;
       setTextIfChanged(el('basicGuidedStatusSummary'), 'Saving your changes before starting…');
 
       const saveButton = el('btnSaveConfig');
@@ -418,10 +640,12 @@
       target.classList.remove('is-saving');
       saveBeforeStartRunning = false;
       if (!saved) {
+        target.disabled = false;
         setTextIfChanged(
           el('basicGuidedStatusSummary'),
           'Your changes could not be saved. Switch to Pro mode for details.',
         );
+        openHotspotErrorDialog();
         return;
       }
 
@@ -436,7 +660,7 @@
       if (!(target instanceof Element)) return;
       if (target.matches('input[name="qos_basic"]')) updateProfileHelp();
     });
-    wireSaveBeforeStart();
+    wirePrimaryAction();
   }
 
   function observeStagingContainer(container) {
@@ -461,7 +685,12 @@
     observeStatusSource(el('basicPillTxt'));
 
     const bodyObserver = new MutationObserver(() => {
-      if (document.body.dataset.uiMode === BASIC_MODE) queueReposition();
+      if (document.body.dataset.uiMode === BASIC_MODE) {
+        queueReposition();
+        syncStatusPresentation();
+      } else {
+        closeHotspotErrorDialog();
+      }
     });
     bodyObserver.observe(document.body, {
       attributes: true,
@@ -471,7 +700,8 @@
 
   function initialize() {
     buildSetupCard();
-    buildStatusCard();
+    buildHotspotStep();
+    buildErrorDialog();
     wireGuidedInteractions();
     startObservers();
     queueReposition();

--- a/tests/test_basic_guided_interface.py
+++ b/tests/test_basic_guided_interface.py
@@ -34,26 +34,45 @@ def test_guided_interface_reuses_existing_live_control_ids() -> None:
         "basicPillTxt",
         "basicStatusAdapterBand",
         "btnStartBasic",
+        "btnStopBasic",
+        "btnRepairBasic",
+        "btnRefreshBasic",
+        "uiModeToggle",
+        "btnRepair",
     ):
         assert control_id in source
 
-    assert "card.querySelector('.basic-status-actions')" in source
     assert "api(" not in source
     assert "fetch(" not in source
 
 
-def test_guided_setup_uses_four_plain_language_steps() -> None:
+def test_guided_setup_uses_five_plain_language_steps() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
     assert "'Set Up Hotspot'" in source
     assert "'Choose Wi-Fi adapter'" in source
-    assert "'Choose connection profile'" in source
-    assert "'Hotspot name (SSID)'" in source
-    assert "'Password (Passphrase)'" in source
+    assert "'Choose performance mode'" in source
+    assert "'Hotspot name'" in source
+    assert "'Password'" in source
+    assert "'Start hotspot'" in source
     assert "basicGuidedAdapterSlot" in source
     assert "basicGuidedProfileSlot" in source
     assert "basicGuidedSsidSlot" in source
     assert "basicGuidedPassSlot" in source
+    assert "basicGuidedActionSlot" in source
+    assert "'Choose connection profile'" not in source
+    assert "'Hotspot name (SSID)'" not in source
+    assert "'Password (Passphrase)'" not in source
+
+
+def test_standard_profile_renames_only_the_visible_label() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "function renameProfileOptions" in source
+    assert "off: 'Standard'" in source
+    assert "ultra_low_latency: 'Speed'" in source
+    assert "vr: 'Stable'" in source
+    assert 'input[name="qos_basic"]' in source
 
 
 def test_technical_basic_defaults_remain_live_but_hidden() -> None:
@@ -73,6 +92,20 @@ def test_technical_basic_defaults_remain_live_but_hidden() -> None:
     assert "display: none !important;" in styles
 
 
+def test_status_is_embedded_as_step_five_and_old_card_is_hidden() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert "function buildHotspotStep" in source
+    assert "actionSlot.appendChild(control);" in source
+    assert "statusCard.hidden = true;" in source
+    assert "basic-guided-status-source-card" in source
+    assert ".basic-guided-status-source-card" in styles
+    assert "grid-template-columns: minmax(0, 1fr);" in styles
+    assert "max-width: 1900px;" in styles
+    assert "Status & Control" not in source
+
+
 def test_status_presentation_is_idempotent_and_source_scoped() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
@@ -83,10 +116,24 @@ def test_status_presentation_is_idempotent_and_source_scoped() -> None:
     assert "observer.observe(basic" not in source
 
 
+def test_single_primary_action_maps_to_start_stop_and_problem_states() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+
+    assert "function syncPrimaryAction" in source
+    assert "action.dataset.guidedAction = 'start';" in source
+    assert "action.dataset.guidedAction = 'stop';" in source
+    assert "action.dataset.guidedAction = 'problem';" in source
+    assert "action.textContent = 'Start hotspot';" in source
+    assert "action.textContent = 'Stop hotspot';" in source
+    assert "action.textContent = 'View problem';" in source
+    assert "const stopButton = el('btnStopBasic');" in source
+    assert "stopButton.click();" in source
+
+
 def test_start_saves_pending_basic_changes_before_existing_start_handler() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
-    assert "function wireSaveBeforeStart" in source
+    assert "function wirePrimaryAction" in source
     assert "event.stopImmediatePropagation();" in source
     assert "const saveButton = el('btnSaveConfig');" in source
     assert "saveButton.click();" in source
@@ -96,16 +143,46 @@ def test_start_saves_pending_basic_changes_before_existing_start_handler() -> No
     assert "Switch to Pro mode for details." in source
 
 
-def test_status_omits_adapter_band_facts_and_decorative_notice() -> None:
+def test_basic_error_dialog_recommends_pro_repair_without_auto_repair() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert "function buildErrorDialog" in source
+    assert "'Hotspot could not start'" in source
+    assert "'Try Again'" in source
+    assert "'Open Pro Mode'" in source
+    assert "function openProRepair" in source
+    assert "toggle.click();" in source
+    assert "const repair = el('btnRepair');" in source
+    assert "repair.focus();" in source
+    assert "el('btnRepair').click()" not in source
+    assert ".basic-hotspot-error-overlay" in styles
+    assert ".basic-hotspot-error-dialog" in styles
+
+
+def test_pro_only_basic_controls_stay_alive_in_hidden_staging() -> None:
+    source = GUIDED_JS.read_text(encoding="utf-8")
+    styles = GUIDED_CSS.read_text(encoding="utf-8")
+
+    assert "statusCard.querySelector('.basic-status-preferences')" in source
+    assert "basicTelemetryContainer" in source
+    assert "privacyHintBasic" in source
+    assert "hiddenStatus.appendChild(node)" in source
+    assert "make('details', 'basic-guided-options')" not in source
+    assert ".basic-guided-hidden-status" in styles
+
+
+def test_status_omits_adapter_band_facts_and_manual_basic_repair_refresh() -> None:
     source = GUIDED_JS.read_text(encoding="utf-8")
 
     assert "makeFact(" not in source
     assert "basicGuidedAdapterValue" not in source
     assert "basicGuidedBandValue" not in source
     assert "basic-guided-status-facts" not in source
-    assert "Pending changes are saved automatically" not in source
-    assert "basic-guided-apply-notice" not in source
-    assert "if (originalMeta) hiddenStatus.appendChild(originalMeta);" in source
+    assert "if (originalMeta) hiddenStatus.appendChild(originalMeta);" not in source
+    assert "btnRepairBasic" in source
+    assert "btnRefreshBasic" in source
+    assert "basic-guided-status-actions" not in source
 
 
 def test_empty_more_actions_disclosure_is_removed_but_controls_stay_alive() -> None:
@@ -117,13 +194,12 @@ def test_empty_more_actions_disclosure_is_removed_but_controls_stay_alive() -> N
     assert "if (copyPass) staging.appendChild(copyPass);" in source
 
 
-def test_guided_styles_match_existing_theme_and_avoid_custom_iconography() -> None:
+def test_guided_styles_match_existing_theme_and_avoid_page_scaling() -> None:
     styles = GUIDED_CSS.read_text(encoding="utf-8")
     source = GUIDED_JS.read_text(encoding="utf-8")
 
     assert 'body[data-ui-mode="basic"] .basic-guided-step' in styles
-    assert 'body[data-ui-mode="basic"] .basic-guided-status-hero' in styles
-    assert 'body[data-ui-mode="basic"] .basic-guided-status-actions' in styles
+    assert 'body[data-ui-mode="basic"] .basic-guided-hotspot-control' in styles
     assert "background: var(--bg-panel);" in styles
     assert "border-color: var(--border-subtle);" in styles
     assert "basic-guided-card-icon" not in styles
@@ -140,20 +216,6 @@ def test_info_tips_use_one_native_circle_instead_of_a_circled_glyph() -> None:
 
     assert "make('span', 'tip basic-guided-tip', 'i')" in source
     assert "make('span', 'tip basic-guided-tip', 'ⓘ')" not in source
-
-
-def test_pro_only_status_controls_stay_alive_but_are_hidden_in_basic() -> None:
-    source = GUIDED_JS.read_text(encoding="utf-8")
-    styles = GUIDED_CSS.read_text(encoding="utf-8")
-
-    assert "make('details', 'basic-guided-options')" not in source
-    assert "'Options'" not in source
-    assert "card.querySelector('.basic-status-preferences')" in source
-    assert "basicTelemetryContainer" in source
-    assert "privacyHintBasic" in source
-    assert "hiddenStatus.appendChild(node)" in source
-    assert ".basic-guided-options" not in styles
-    assert ".basic-guided-hidden-status" in styles
 
 
 def test_connection_profiles_fill_the_available_width() -> None:


### PR DESCRIPTION
## Summary

Collapse Basic mode into one guided five-step hotspot workflow.

## Changes

- Move hotspot status and control into Step 5 of the existing setup card.
- Remove the separate Status & Control card from the visible Basic grid.
- Replace separate Start and Stop controls with one state-aware action button:
  - Start hotspot
  - Stop hotspot
  - Working…
  - View problem
- Keep Repair and Refresh out of Basic mode while preserving their existing handlers in hidden staging.
- Add a Basic-mode error dialog with Try Again and Open Pro Mode actions.
- Open Pro mode on Overview and focus Repair Network without starting repair automatically.
- Rename user-facing Basic terminology:
  - Choose connection profile → Choose performance mode
  - Off → Standard
  - Hotspot name (SSID) → Hotspot name
  - Password (Passphrase) → Password
- Center one wide Basic card to remove the unused second-column space.

## Safety

- Reuses existing Start, Stop, save, QR, password, profile, status, and mode-switch controls.
- Pending Basic changes are still saved before the existing Start handler runs.
- No backend, networking, installer, API, or Pro-mode changes.
- Error-dialog Retry reuses the existing Start handler; Open Pro Mode only focuses Repair Network.

## Validation

- JavaScript syntax checked with Node.
- Focused regression contracts cover five-step structure, state-aware action mapping, hidden technical controls, error-modal behavior, terminology, and single-card layout.