### PR TITLE
Fix portal reload authentication and Pro runtime

### DIFF
--- a/assets/browser_session.js
+++ b/assets/browser_session.js
@@ -2,6 +2,7 @@
   'use strict';
 
   const SESSION_PATH = '/v1/auth/browser-session';
+  const SESSION_SENTINEL = 'browser-session';
   const MAX_WAIT_MS = 15000;
   let installed = false;
   let pendingCandidate = '';
@@ -15,6 +16,7 @@
         cache: 'no-store',
       });
       if (!response.ok) return false;
+      if (typeof setToken === 'function') setToken(SESSION_SENTINEL);
       if (typeof enterAuthenticatedApp === 'function') enterAuthenticatedApp();
       return true;
     } catch {
@@ -56,7 +58,13 @@
 
   function install() {
     if (installed) return true;
-    if (typeof enterAuthenticatedApp !== 'function' || !document.body) return false;
+    if (
+      typeof enterAuthenticatedApp !== 'function'
+      || typeof setToken !== 'function'
+      || !document.body
+    ) {
+      return false;
+    }
     installed = true;
 
     const form = document.getElementById('loginForm');

--- a/assets/browser_session.js
+++ b/assets/browser_session.js
@@ -1,0 +1,81 @@
+(function persistBrowserTabAuthentication() {
+  'use strict';
+
+  const SESSION_PATH = '/v1/auth/browser-session';
+  const MAX_WAIT_MS = 15000;
+  let installed = false;
+  let pendingCandidate = '';
+  const startedAt = Date.now();
+
+  async function restoreBrowserSession() {
+    try {
+      const response = await fetch(SESSION_PATH, {
+        method: 'GET',
+        credentials: 'same-origin',
+        cache: 'no-store',
+      });
+      if (!response.ok) return false;
+      if (typeof enterAuthenticatedApp === 'function') enterAuthenticatedApp();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async function createBrowserSession(token) {
+    const candidate = String(token || '').trim();
+    if (!candidate) return false;
+    try {
+      const response = await fetch(SESSION_PATH, {
+        method: 'POST',
+        credentials: 'same-origin',
+        cache: 'no-store',
+        headers: {
+          'X-Api-Token': candidate,
+          'X-Correlation-Id': `ui-session-${Date.now()}`,
+        },
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  function captureLoginCandidate() {
+    const input = document.getElementById('loginToken');
+    pendingCandidate = String((input && input.value) || '').trim();
+  }
+
+  function syncAuthenticatedState() {
+    const state = document.body && document.body.getAttribute('data-auth-state');
+    if (state !== 'authenticated' || !pendingCandidate) return;
+    const candidate = pendingCandidate;
+    pendingCandidate = '';
+    void createBrowserSession(candidate);
+  }
+
+  function install() {
+    if (installed) return true;
+    if (typeof enterAuthenticatedApp !== 'function' || !document.body) return false;
+    installed = true;
+
+    const form = document.getElementById('loginForm');
+    if (form) form.addEventListener('submit', captureLoginCandidate, true);
+
+    const observer = new MutationObserver(syncAuthenticatedState);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['data-auth-state'],
+    });
+    void restoreBrowserSession();
+    return true;
+  }
+
+  function waitForUiAuth() {
+    if (install()) return;
+    if (Date.now() - startedAt > MAX_WAIT_MS) return;
+    window.setTimeout(waitForUiAuth, 25);
+  }
+
+  waitForUiAuth();
+})();

--- a/assets/devhub_upload.js
+++ b/assets/devhub_upload.js
@@ -3,8 +3,7 @@
 
   const UPLOAD_PATH = '/v1/devbridge/adb/install-upload';
   const MAX_APK_BYTES = 8 * 1024 * 1024 * 1024;
-
-  function el(id) { return document.getElementById(id); }
+  const el = (id) => document.getElementById(id);
 
   function feedback(message, state) {
     const node = el('devhubFeedback');
@@ -66,6 +65,7 @@
     const pathInput = el('devhubApkPath');
     const serialInput = el('devhubPackageSerial');
     if (!form || !pathInput || !serialInput) return false;
+
     const pathField = pathInput.closest('div');
     const checks = form.querySelector('.devhub-checks');
     const submit = form.querySelector('button[type="submit"]');
@@ -77,23 +77,28 @@
     const uploadField = document.createElement('div');
     uploadField.id = 'devhubApkPicker';
     uploadField.className = 'devhub-wide devhub-upload-field';
+
     const label = document.createElement('label');
     label.textContent = 'APK file';
+
     const fileInput = document.createElement('input');
     fileInput.id = 'devhubApkFile';
     fileInput.type = 'file';
     fileInput.accept = '.apk,application/vnd.android.package-archive';
     fileInput.hidden = true;
+
     const drop = document.createElement('div');
     drop.className = 'devhub-file-drop';
     drop.tabIndex = 0;
     drop.setAttribute('role', 'button');
     drop.setAttribute('aria-controls', fileInput.id);
     drop.setAttribute('aria-label', 'Choose an Android APK file');
+
     const choose = document.createElement('button');
     choose.type = 'button';
     choose.className = 'btn primary';
     choose.textContent = 'Choose APK';
+
     const copy = document.createElement('div');
     copy.className = 'devhub-file-copy';
     const name = document.createElement('div');
@@ -150,6 +155,7 @@
       }
     });
     fileInput.addEventListener('change', updateSelection);
+
     for (const eventName of ['dragenter', 'dragover']) {
       drop.addEventListener(eventName, (event) => {
         event.preventDefault();
@@ -214,6 +220,7 @@
         `Uploading ${file.name} (${formatBytes(file.size)}) and installing it on ${headset}...`,
         'loading',
       );
+
       try {
         const response = await api(UPLOAD_PATH, {
           method: 'POST',
@@ -247,6 +254,7 @@
         submit.textContent = previousLabel;
       }
     }, true);
+
     return true;
   }
 
@@ -265,538 +273,17 @@
   }
 })();
 
-(function buildProGuidedWorkflow() {
+(function loadPortalHotfixAssets() {
   'use strict';
 
-  const AUTOSAVE_DELAY_MS = 650;
-  const SAVE_TIMEOUT_MS = 12000;
-  let initialized = false;
-  let saveTimer = null;
-  let restartRequired = false;
-
-  function el(id) { return document.getElementById(id); }
-  function make(tag, className, text) {
-    const node = document.createElement(tag);
-    if (className) node.className = className;
-    if (text !== undefined) node.textContent = text;
-    return node;
-  }
-  function setText(node, text) {
-    if (node && node.textContent !== text) node.textContent = text;
-  }
-
-  function icon(kind) {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    svg.setAttribute('aria-hidden', 'true');
-    svg.classList.add('pro-nav-svg');
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    path.setAttribute('fill', 'currentColor');
-    path.setAttribute('d', kind === 'wifi'
-      ? 'M12 18.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm0-5a6.45 6.45 0 0 0-4.58 1.9l1.42 1.42a4.48 4.48 0 0 1 6.32 0l1.42-1.42A6.45 6.45 0 0 0 12 13.5Zm0-5a11.42 11.42 0 0 0-8.08 3.35l1.42 1.42a9.42 9.42 0 0 1 13.32 0l1.42-1.42A11.42 11.42 0 0 0 12 8.5Zm0-5A16.4 16.4 0 0 0 .42 8.3l1.42 1.42a14.4 14.4 0 0 1 20.32 0l1.42-1.42A16.4 16.4 0 0 0 12 3.5Z'
-      : 'M11 2h2v3h-2V2Zm0 17h2v3h-2v-3ZM2 11h3v2H2v-2Zm17 0h3v2h-3v-2ZM4.22 5.64l1.42-1.42 2.12 2.12-1.42 1.42-2.12-2.12Zm12.02 12.02 1.42-1.42 2.12 2.12-1.42 1.42-2.12-2.12ZM4.22 18.36l2.12-2.12 1.42 1.42-2.12 2.12-1.42-1.42ZM16.24 6.34l2.12-2.12 1.42 1.42-2.12 2.12-1.42-1.42ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z');
-    svg.appendChild(path);
-    return svg;
-  }
-
-  function replaceNav(item, kind, label) {
-    if (!item) return;
-    item.replaceChildren(icon(kind), document.createTextNode(label));
-  }
-
-  function addStyles() {
-    if (el('proGuidedWorkflowStyles')) return;
-    const style = make('style');
-    style.id = 'proGuidedWorkflowStyles';
-    style.textContent = `
-      body[data-ui-mode="advanced"] .pro-nav-svg {
-        width: 20px; height: 20px; flex: 0 0 20px; margin-right: 12px;
-        color: var(--accent-primary);
-      }
-      body[data-ui-mode="advanced"] .pro-guided-shell {
-        width: min(1540px, 100%); margin: 0 auto; display: grid; gap: 22px;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-card {
-        overflow: hidden; border: 1px solid var(--border-subtle);
-        border-radius: var(--radius-lg); background: var(--bg-panel); box-shadow: var(--shadow-sm);
-      }
-      body[data-ui-mode="advanced"] .pro-guided-header {
-        padding: 22px 26px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-subtle);
-      }
-      body[data-ui-mode="advanced"] .pro-guided-header h2 { margin: 0; font-size: 20px; }
-      body[data-ui-mode="advanced"] .pro-guided-header p {
-        margin: 6px 0 0; color: var(--text-muted); font-size: 14px;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-steps { padding: 26px; }
-      body[data-ui-mode="advanced"] .pro-guided-step {
-        display: grid; grid-template-columns: 42px minmax(0, 1fr); gap: 8px;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-number {
-        display: grid; place-items: center; width: 32px; height: 32px;
-        border: 1px solid var(--border-active); border-radius: 50%;
-        color: var(--accent-primary); background: var(--bg-subtle); font-weight: 700;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-content {
-        min-width: 0; padding: 0 0 26px 8px; margin-bottom: 24px;
-        border-bottom: 1px solid var(--border-subtle);
-      }
-      body[data-ui-mode="advanced"] .pro-guided-step:last-child .pro-guided-content {
-        padding-bottom: 0; margin-bottom: 0; border-bottom: 0;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-title { margin: 2px 0 6px; font-size: 17px; }
-      body[data-ui-mode="advanced"] .pro-guided-help {
-        margin: 0 0 16px; color: var(--text-muted); font-size: 13px; line-height: 1.5;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-slot { display: grid; gap: 16px; min-width: 0; }
-      body[data-ui-mode="advanced"] .pro-guided-slot .form-group,
-      body[data-ui-mode="advanced"] .pro-guided-slot .preset-bar { margin: 0; }
-      body[data-ui-mode="advanced"] .pro-performance-picker .label { display: none; }
-      body[data-ui-mode="advanced"] .pro-performance-picker .btn-group {
-        display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; width: 100%;
-      }
-      body[data-ui-mode="advanced"] .pro-performance-picker .btn {
-        min-height: 58px; width: 100%; justify-content: center; white-space: normal;
-      }
-      body[data-ui-mode="advanced"] .pro-hotspot-fields {
-        display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px;
-      }
-      body[data-ui-mode="advanced"] .pro-hotspot-fields [data-field="enable_internet"] { grid-column: 1 / -1; }
-      body[data-ui-mode="advanced"] .pro-advanced-settings {
-        border: 1px solid var(--border-subtle); border-radius: var(--radius-md); overflow: hidden;
-      }
-      body[data-ui-mode="advanced"] .pro-advanced-settings > summary {
-        padding: 18px 20px; cursor: pointer; background: var(--bg-subtle);
-        color: var(--text-main); font-weight: 700; list-style: none;
-      }
-      body[data-ui-mode="advanced"] .pro-advanced-settings > summary::after {
-        content: '+'; float: right; color: var(--accent-primary);
-      }
-      body[data-ui-mode="advanced"] .pro-advanced-settings[open] > summary::after { content: '−'; }
-      body[data-ui-mode="advanced"] .pro-advanced-body { display: grid; gap: 14px; padding: 18px; }
-      body[data-ui-mode="advanced"] .pro-advanced-body .pro-config-details { margin: 0; }
-      body[data-ui-mode="advanced"] .pro-guided-action {
-        display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
-        gap: 24px; align-items: center; padding: 22px;
-        border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--bg-subtle);
-      }
-      body[data-ui-mode="advanced"] .pro-guided-action .pro-service-state-copy h3 { font-size: 24px; }
-      body[data-ui-mode="advanced"] .pro-guided-action #btnStart {
-        width: 100%; min-height: 56px; justify-content: center;
-      }
-      body[data-ui-mode="advanced"] .pro-guided-hidden,
-      body[data-ui-mode="advanced"] .pro-configuration > .settings-header,
-      body[data-ui-mode="advanced"] .pro-service-secondary { display: none !important; }
-      body[data-ui-mode="advanced"] .pro-save-state {
-        min-height: 20px; color: var(--text-muted); font-size: 13px;
-      }
-      body[data-ui-mode="advanced"] .pro-save-state[data-state="saving"] { color: var(--accent-primary); }
-      body[data-ui-mode="advanced"] .pro-save-state[data-state="restart"] { color: var(--warning); }
-      body[data-ui-mode="advanced"] .pro-quality-card {
-        overflow: hidden; border: 1px solid var(--border-subtle); border-radius: var(--radius-lg);
-        background: var(--bg-panel);
-      }
-      body[data-ui-mode="advanced"] .pro-quality-header {
-        display: flex; align-items: center; justify-content: space-between; gap: 16px;
-        padding: 18px 22px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-subtle);
-      }
-      body[data-ui-mode="advanced"] .pro-quality-header h2 { margin: 0; font-size: 18px; }
-      body[data-ui-mode="advanced"] .pro-quality-body { padding: 20px 22px; }
-      body[data-ui-mode="advanced"] .pro-quality-summary { color: var(--text-main); font-size: 16px; }
-      body[data-ui-mode="advanced"] .pro-quality-details { margin-top: 16px; }
-      body[data-ui-mode="advanced"] .pro-quality-details > summary {
-        cursor: pointer; color: var(--accent-primary); font-weight: 700;
-      }
-      body[data-ui-mode="advanced"] .pro-quality-details .chart-wrapper { min-height: 220px; }
-      body[data-ui-mode="advanced"] .pro-quality-settings { margin-top: 18px; }
-      body[data-ui-mode="advanced"] #tab-telemetry { display: none !important; }
-      body[data-ui-mode="advanced"] .troubleshooting-shell {
-        width: min(1540px, 100%); margin: 0 auto; display: grid; gap: 20px;
-      }
-      body[data-ui-mode="advanced"] .troubleshooting-header {
-        display: flex; justify-content: space-between; gap: 18px; align-items: center;
-        padding: 22px 24px; border: 1px solid var(--border-subtle);
-        border-radius: var(--radius-lg); background: var(--bg-panel);
-      }
-      body[data-ui-mode="advanced"] .troubleshooting-header h2 { margin: 0; font-size: 24px; }
-      body[data-ui-mode="advanced"] .troubleshooting-header p { margin: 6px 0 0; color: var(--text-muted); }
-      body[data-ui-mode="advanced"] .troubleshooting-actions { display: flex; gap: 10px; flex-wrap: wrap; }
-      body[data-ui-mode="advanced"] .troubleshooting-section-label {
-        margin: 0; padding: 16px 20px; border: 1px solid var(--border-subtle);
-        border-radius: var(--radius-md); background: var(--bg-subtle); font-size: 17px;
-      }
-      body[data-ui-mode="advanced"] #tab-logs { display: none !important; }
-      body[data-ui-mode="advanced"] .troubleshooting-shell .preflight-page,
-      body[data-ui-mode="advanced"] .troubleshooting-shell .pro-runtime-details,
-      body[data-ui-mode="advanced"] .troubleshooting-shell .pro-support-bundle-card,
-      body[data-ui-mode="advanced"] .troubleshooting-shell .card { margin: 0; }
-      @media (max-width: 900px) {
-        body[data-ui-mode="advanced"] .pro-performance-picker .btn-group,
-        body[data-ui-mode="advanced"] .pro-hotspot-fields,
-        body[data-ui-mode="advanced"] .pro-guided-action { grid-template-columns: minmax(0, 1fr); }
-        body[data-ui-mode="advanced"] .troubleshooting-header { align-items: flex-start; flex-direction: column; }
-      }
-    `;
-    document.head.appendChild(style);
-  }
-
-  function step(number, title, help, id) {
-    const section = make('section', 'pro-guided-step');
-    const badge = make('span', 'pro-guided-number', String(number));
-    const content = make('div', 'pro-guided-content');
-    content.append(make('h3', 'pro-guided-title', title), make('p', 'pro-guided-help', help));
-    const slot = make('div', 'pro-guided-slot');
-    slot.id = id;
-    content.appendChild(slot);
-    section.append(badge, content);
-    return section;
-  }
-
-  function serviceIsRunning() {
-    const text = String(el('pillTxt')?.textContent || '').toLowerCase();
-    return text.includes('running') && !text.includes('not running');
-  }
-
-  function savingState(state, text) {
-    const node = el('proSaveState');
-    if (!node) return;
-    node.dataset.state = state;
-    setText(node, text);
-  }
-
-  function waitUntilSaved() {
-    const started = Date.now();
-    return new Promise((resolve) => {
-      function check() {
-        const dirty = String(el('dirty')?.textContent || '').trim();
-        if (!dirty) return resolve(true);
-        if (Date.now() - started >= SAVE_TIMEOUT_MS) return resolve(false);
-        window.setTimeout(check, 120);
-      }
-      check();
-    });
-  }
-
-  async function saveConfiguration() {
-    const save = el('btnSaveConfig');
-    if (!save) return false;
-    savingState('saving', 'Saving changes…');
-    save.click();
-    const saved = await waitUntilSaved();
-    if (!saved) {
-      savingState('error', 'Changes could not be saved. Open Troubleshooting for details.');
-      return false;
-    }
-    savingState(restartRequired ? 'restart' : 'saved', restartRequired
-      ? 'Changes saved. Restart the hotspot to apply them.'
-      : 'All changes saved.');
-    syncPrimaryAction();
-    return true;
-  }
-
-  function scheduleSave(markRestart = true) {
-    if (markRestart && serviceIsRunning()) restartRequired = true;
-    savingState('saving', 'Saving changes…');
-    if (saveTimer) window.clearTimeout(saveTimer);
-    saveTimer = window.setTimeout(() => void saveConfiguration(), AUTOSAVE_DELAY_MS);
-  }
-
-  function syncPrimaryAction() {
-    const primary = el('btnStart');
-    if (!primary) return;
-    if (serviceIsRunning() && restartRequired) {
-      primary.dataset.proServiceAction = 'start';
-      primary.dataset.proGuidedAction = 'apply';
-      primary.textContent = 'Apply Changes & Restart';
-      primary.classList.remove('danger', 'secondary');
-      primary.classList.add('primary');
-      primary.disabled = false;
-      return;
-    }
-    delete primary.dataset.proGuidedAction;
-  }
-
-  function wireAutosave(root) {
-    root.addEventListener('change', (event) => {
-      if (!(event.target instanceof HTMLInputElement || event.target instanceof HTMLSelectElement)) return;
-      if (!event.isTrusted) return;
-      scheduleSave(true);
-      updateDependencies();
-    });
-    root.addEventListener('input', (event) => {
-      if (!(event.target instanceof HTMLInputElement)) return;
-      if (!event.isTrusted) return;
-      scheduleSave(true);
-    });
-    root.querySelectorAll('.preset-bar .btn').forEach((button) => {
-      button.addEventListener('click', () => window.setTimeout(() => scheduleSave(true), 0));
-    });
-  }
-
-  function updateDependencies() {
-    const autoChannel = el('channel_auto_select');
-    const channel5 = el('channel_5g');
-    const channel6 = el('channel_6g');
-    if (channel5) channel5.disabled = !!autoChannel?.checked;
-    if (channel6) channel6.disabled = !!autoChannel?.checked;
-    const bridge = el('bridge_mode');
-    for (const id of ['bridge_name', 'bridge_uplink']) {
-      const input = el(id);
-      if (input) input.disabled = !bridge?.checked;
-    }
-  }
-
-  function buildGuidedSetup() {
-    const overview = el('tab-overview');
-    const oldShell = overview?.querySelector('.pro-setup-shell');
-    const configuration = el('proHotspotConfiguration');
-    const serviceCard = overview?.querySelector('.pro-service-card');
-    if (!overview || !oldShell || !configuration || !serviceCard) return false;
-
-    const shell = make('div', 'pro-guided-shell');
-    const card = make('section', 'pro-guided-card');
-    const header = make('div', 'pro-guided-header');
-    header.append(
-      make('h2', '', 'Set Up Hotspot'),
-      make('p', '', 'Configure the hotspot in order, then start it or apply changes safely.'),
-    );
-    const steps = make('div', 'pro-guided-steps');
-    steps.append(
-      step(1, 'Choose Wi-Fi adapter', 'Select the adapter VRhotspot should use. Recommended choices are labeled automatically.', 'proStepAdapter'),
-      step(2, 'Choose performance mode', 'Choose the behavior that best matches your VR workflow.', 'proStepPerformance'),
-      step(3, 'Configure hotspot', 'Set the network name, password, and internet-sharing preference.', 'proStepHotspot'),
-      step(4, 'Fine-tune hotspot', 'Optional expert settings are grouped by purpose and can be left at their recommended defaults.', 'proStepAdvanced'),
-      step(5, 'Start hotspot', 'Start, stop, or safely apply saved changes to a running hotspot.', 'proStepAction'),
-    );
-    card.append(header, steps);
-    shell.appendChild(card);
-
-    const adapter = document.querySelector('[data-field="ap_adapter"]');
-    if (adapter) {
-      const label = adapter.querySelector('label');
-      if (label) label.textContent = 'Wi-Fi adapter';
-      el('proStepAdapter').appendChild(adapter);
-    }
-
-    const preset = configuration.querySelector('.preset-bar');
-    if (preset) {
-      preset.classList.add('pro-performance-picker');
-      const order = [
-        el('btnApplyVrProfileUltra'),
-        el('btnApplyVrProfile'),
-        el('btnApplyVrProfileHigh'),
-        el('btnApplyVrProfileStable'),
-      ].filter(Boolean);
-      const group = preset.querySelector('.btn-group');
-      if (group) order.forEach((button) => group.appendChild(button));
-      el('proStepPerformance').appendChild(preset);
-    }
-    const qos = document.querySelector('[data-field="qos_preset"]');
-    if (qos) {
-      qos.classList.add('pro-guided-hidden');
-      el('proStepPerformance').appendChild(qos);
-    }
-
-    const friendlyLabels = {
-      ssid: 'Hotspot name',
-      wpa2_passphrase: 'Password',
-    };
-    const hotspotFields = make('div', 'pro-hotspot-fields');
-    for (const key of ['ssid', 'wpa2_passphrase', 'enable_internet']) {
-      const field = document.querySelector(`[data-field="${key}"]`);
-      if (field && friendlyLabels[key]) {
-        const label = field.querySelector('label');
-        if (label) label.textContent = friendlyLabels[key];
-      }
-      if (field) hotspotFields.appendChild(field);
-    }
-    el('proStepHotspot').appendChild(hotspotFields);
-
-    const advanced = make('details', 'pro-advanced-settings');
-    const advancedSummary = make('summary', '', 'Advanced wireless, network, and system settings');
-    const advancedBody = make('div', 'pro-advanced-body');
-    configuration.querySelectorAll('.pro-config-details').forEach((details) => advancedBody.appendChild(details));
-    advanced.append(advancedSummary, advancedBody);
-    el('proStepAdvanced').appendChild(advanced);
-
-    const action = make('div', 'pro-guided-action');
-    const stateCopy = serviceCard.querySelector('.pro-service-state-copy');
-    const primary = el('btnStart');
-    if (stateCopy) action.appendChild(stateCopy);
-    if (primary) action.appendChild(primary);
-    el('proStepAction').append(action, make('div', 'pro-save-state', 'All changes saved.'));
-    el('proStepAction').lastElementChild.id = 'proSaveState';
-
-    const hidden = make('div', 'pro-guided-hidden');
-    hidden.id = 'proGuidedHiddenControls';
-    const headerBar = configuration.querySelector('.settings-header');
-    const serviceSecondary = serviceCard.querySelector('.pro-service-secondary');
-    const serviceMeta = serviceCard.querySelector('.hero-meta');
-    const feedback = serviceCard.querySelectorAll('.hero-feedback');
-    for (const node of [headerBar, serviceSecondary, serviceMeta, ...feedback]) {
-      if (node) hidden.appendChild(node);
-    }
-    card.appendChild(hidden);
-
-    overview.replaceChildren(shell);
-    oldShell.remove();
-    serviceCard.remove();
-    configuration.remove();
-    wireAutosave(card);
-    updateDependencies();
-
-    if (primary) {
-      primary.addEventListener('click', async (event) => {
-        if (primary.dataset.proGuidedAction !== 'apply') return;
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        const saved = await saveConfiguration();
-        if (!saved) return;
-        restartRequired = false;
-        savingState('saving', 'Applying changes and restarting…');
-        el('btnSaveRestart')?.click();
-      }, true);
-    }
-
-    const statusSource = el('pillTxt');
-    if (statusSource) {
-      const observer = new MutationObserver(() => {
-        if (!serviceIsRunning()) restartRequired = false;
-        syncPrimaryAction();
-      });
-      observer.observe(statusSource, { childList: true, subtree: true, characterData: true });
-    }
-    return true;
-  }
-
-  function qualityMessage() {
-    if (!serviceIsRunning()) return 'Start the hotspot to measure connection performance.';
-    const summary = String(el('telemetrySummary')?.textContent || '').trim();
-    return summary || 'Connection measurements will appear as clients begin using the hotspot.';
-  }
-
-  function buildConnectionQuality() {
-    const overview = el('tab-overview');
-    const shell = overview?.querySelector('.pro-guided-shell');
-    const telemetryPane = el('tab-telemetry');
-    const telemetryCard = el('cardTelemetry');
-    if (!shell || !telemetryPane || !telemetryCard) return false;
-
-    document.querySelector('.nav-item[data-tab="telemetry"]')?.remove();
-    const card = make('section', 'pro-quality-card');
-    const header = make('div', 'pro-quality-header');
-    header.append(make('h2', '', 'Connection Quality'));
-    const status = make('span', 'pill', serviceIsRunning() ? 'Measuring' : 'Waiting');
-    status.id = 'proQualityStatus';
-    header.appendChild(status);
-    const body = make('div', 'pro-quality-body');
-    const summary = make('div', 'pro-quality-summary', qualityMessage());
-    summary.id = 'proQualitySummary';
-    const warning = el('telemetryWarnings');
-    const details = make('details', 'pro-quality-details');
-    details.appendChild(make('summary', '', 'View detailed charts and client measurements'));
-
-    const telemetryHeader = telemetryCard.querySelector('.card-header');
-    const telemetryBody = telemetryCard.querySelector('.card-body');
-    if (telemetryHeader) telemetryHeader.remove();
-    if (telemetryBody) details.appendChild(telemetryBody);
-    const settings = details.querySelector('[data-field="telemetry_enable"]');
-    if (settings) {
-      settings.classList.add('pro-quality-settings');
-      const label = settings.querySelector(':scope > label');
-      if (label) label.textContent = 'Measurement options';
-      const toggles = settings.querySelectorAll('.tog');
-      if (toggles[0]) toggles[0].lastChild.textContent = ' Measure connection quality';
-      if (toggles[1]) toggles[1].lastChild.textContent = ' Watch for connection problems';
-    }
-    const interval = document.querySelector('[data-field="telemetry_interval_s"]');
-    if (interval) interval.classList.add('pro-guided-hidden');
-    body.append(summary);
-    if (warning) body.appendChild(warning);
-    body.appendChild(details);
-    card.append(header, body);
-    shell.appendChild(card);
-    telemetryPane.hidden = true;
-
-    const sources = [el('telemetrySummary'), el('telemetryWarnings'), el('pillTxt')].filter(Boolean);
-    const observer = new MutationObserver(() => {
-      setText(summary, qualityMessage());
-      setText(status, serviceIsRunning() ? 'Live' : 'Waiting');
-    });
-    sources.forEach((node) => observer.observe(node, { childList: true, subtree: true, characterData: true }));
-    return true;
-  }
-
-  function buildTroubleshooting() {
-    const diagnosticsPane = el('tab-diagnostics');
-    const logsPane = el('tab-logs');
-    const nav = document.querySelector('.nav-item[data-tab="diagnostics"]');
-    const logsNav = document.querySelector('.nav-item[data-tab="logs"]');
-    if (!diagnosticsPane || !logsPane || !nav) return false;
-
-    nav.dataset.tab = 'troubleshooting';
-    diagnosticsPane.id = 'tab-troubleshooting';
-    replaceNav(nav, 'trouble', 'Troubleshooting');
-    logsNav?.remove();
-
-    const shell = make('div', 'troubleshooting-shell');
-    const header = make('section', 'troubleshooting-header');
-    const copy = make('div');
-    copy.append(
-      make('h2', '', 'Troubleshooting'),
-      make('p', '', 'Check system health, repair problems, inspect runtime details, and collect support information.'),
-    );
-    const actions = make('div', 'troubleshooting-actions');
-    const repair = el('btnRepair');
-    const restart = el('btnRestart');
-    const refresh = el('btnRefreshPreflight');
-    if (repair) actions.appendChild(repair);
-    if (restart) actions.appendChild(restart);
-    if (refresh) actions.appendChild(refresh);
-    header.append(copy, actions);
-    shell.append(header, make('h3', 'troubleshooting-section-label', 'System Health & Diagnostic Checks'));
-
-    const preflight = diagnosticsPane.querySelector('.preflight-page');
-    if (preflight) {
-      preflight.querySelector('.preflight-header .action-group')?.remove();
-      shell.appendChild(preflight);
-    }
-
-    shell.appendChild(make('h3', 'troubleshooting-section-label', 'Runtime Details, Logs & Support'));
-    const supportHeading = logsPane.querySelector('.pro-support-heading');
-    if (supportHeading) supportHeading.remove();
-    Array.from(logsPane.children).forEach((node) => shell.appendChild(node));
-    diagnosticsPane.replaceChildren(shell);
-    logsPane.hidden = true;
-    return true;
-  }
-
-  function initialize() {
-    if (initialized) return true;
-    const overviewNav = document.querySelector('.nav-item[data-tab="overview"]');
-    const shell = el('tab-overview')?.querySelector('.pro-setup-shell');
-    if (!overviewNav || !shell || !el('tab-telemetry') || !el('tab-diagnostics') || !el('tab-logs')) {
-      return false;
-    }
-    addStyles();
-    replaceNav(overviewNav, 'wifi', 'Set Up Hotspot');
-    if (!buildGuidedSetup()) return false;
-    buildConnectionQuality();
-    buildTroubleshooting();
-    initialized = true;
-    return true;
-  }
-
-  function start() {
-    if (initialize()) return;
-    const observer = new MutationObserver(() => {
-      if (initialize()) observer.disconnect();
-    });
-    observer.observe(document.documentElement, { childList: true, subtree: true });
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', start, { once: true });
-  } else {
-    start();
+  const assets = [
+    '/assets/browser_session.js?v=139-session-hotfix',
+    '/assets/pro_guided_workflow.js?v=139-pro-hotfix',
+  ];
+  for (const src of assets) {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = false;
+    document.head.appendChild(script);
   }
 })();

--- a/assets/pro_guided_workflow.css
+++ b/assets/pro_guided_workflow.css
@@ -1,0 +1,204 @@
+body[data-ui-mode="advanced"] .pro-nav-svg {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  margin-right: 12px;
+  color: var(--accent-primary);
+}
+body[data-ui-mode="advanced"] .pro-configuration > .settings-header {
+  display: none !important;
+}
+body[data-ui-mode="advanced"] #tab-telemetry,
+body[data-ui-mode="advanced"] #tab-logs {
+  display: none !important;
+}
+body[data-ui-mode="advanced"] .pro-guided-shell,
+body[data-ui-mode="advanced"] .troubleshooting-shell {
+  width: min(1540px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 22px;
+}
+body[data-ui-mode="advanced"] .pro-guided-card,
+body[data-ui-mode="advanced"] .pro-quality-card {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-sm);
+}
+body[data-ui-mode="advanced"] .pro-guided-header,
+body[data-ui-mode="advanced"] .pro-quality-header {
+  padding: 22px 26px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
+}
+body[data-ui-mode="advanced"] .pro-guided-header h2,
+body[data-ui-mode="advanced"] .pro-quality-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+body[data-ui-mode="advanced"] .pro-guided-header p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+body[data-ui-mode="advanced"] .pro-guided-steps {
+  padding: 26px;
+}
+body[data-ui-mode="advanced"] .pro-guided-step {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 8px;
+}
+body[data-ui-mode="advanced"] .pro-guided-number {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-active);
+  border-radius: 50%;
+  color: var(--accent-primary);
+  background: var(--bg-subtle);
+  font-weight: 700;
+}
+body[data-ui-mode="advanced"] .pro-guided-content {
+  min-width: 0;
+  padding: 0 0 26px 8px;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+body[data-ui-mode="advanced"] .pro-guided-step:last-child .pro-guided-content {
+  padding-bottom: 0;
+  margin-bottom: 0;
+  border-bottom: 0;
+}
+body[data-ui-mode="advanced"] .pro-guided-title {
+  margin: 2px 0 0;
+  font-size: 21px;
+}
+body[data-ui-mode="advanced"] .pro-guided-help {
+  margin: 6px 0 18px;
+  color: var(--text-muted);
+}
+body[data-ui-mode="advanced"] .pro-guided-slot {
+  min-width: 0;
+}
+body[data-ui-mode="advanced"] .pro-hotspot-fields,
+body[data-ui-mode="advanced"] .pro-guided-action {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+body[data-ui-mode="advanced"] .pro-hotspot-fields > :last-child {
+  grid-column: 1 / -1;
+}
+body[data-ui-mode="advanced"] .pro-performance-picker .btn-group {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+body[data-ui-mode="advanced"] .pro-performance-picker .btn {
+  min-height: 50px;
+}
+body[data-ui-mode="advanced"] .pro-advanced-settings > summary,
+body[data-ui-mode="advanced"] .pro-quality-details > summary {
+  cursor: pointer;
+  color: var(--accent-primary);
+  font-weight: 700;
+}
+body[data-ui-mode="advanced"] .pro-advanced-body {
+  display: grid;
+  gap: 16px;
+  margin-top: 16px;
+}
+body[data-ui-mode="advanced"] .pro-guided-action {
+  align-items: center;
+}
+body[data-ui-mode="advanced"] .pro-guided-action .pro-service-primary {
+  min-height: 58px;
+}
+body[data-ui-mode="advanced"] .pro-save-state {
+  margin-top: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+body[data-ui-mode="advanced"] .pro-save-state[data-state="error"] {
+  color: var(--danger);
+}
+body[data-ui-mode="advanced"] .pro-save-state[data-state="saved"] {
+  color: var(--success);
+}
+body[data-ui-mode="advanced"] .pro-guided-hidden {
+  display: none !important;
+}
+body[data-ui-mode="advanced"] .pro-quality-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+body[data-ui-mode="advanced"] .pro-quality-body {
+  padding: 20px 22px;
+}
+body[data-ui-mode="advanced"] .pro-quality-summary {
+  color: var(--text-main);
+  font-size: 16px;
+}
+body[data-ui-mode="advanced"] .pro-quality-details {
+  margin-top: 16px;
+}
+body[data-ui-mode="advanced"] .pro-quality-details .chart-wrapper {
+  min-height: 220px;
+}
+body[data-ui-mode="advanced"] .pro-quality-settings {
+  margin-top: 18px;
+}
+body[data-ui-mode="advanced"] .troubleshooting-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  padding: 22px 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+}
+body[data-ui-mode="advanced"] .troubleshooting-header h2 {
+  margin: 0;
+  font-size: 24px;
+}
+body[data-ui-mode="advanced"] .troubleshooting-header p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+}
+body[data-ui-mode="advanced"] .troubleshooting-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+body[data-ui-mode="advanced"] .troubleshooting-section-label {
+  margin: 0;
+  padding: 16px 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+  font-size: 17px;
+}
+body[data-ui-mode="advanced"] .troubleshooting-shell .preflight-page,
+body[data-ui-mode="advanced"] .troubleshooting-shell .pro-runtime-details,
+body[data-ui-mode="advanced"] .troubleshooting-shell .pro-support-bundle-card,
+body[data-ui-mode="advanced"] .troubleshooting-shell .card {
+  margin: 0;
+}
+@media (max-width: 900px) {
+  body[data-ui-mode="advanced"] .pro-performance-picker .btn-group,
+  body[data-ui-mode="advanced"] .pro-hotspot-fields,
+  body[data-ui-mode="advanced"] .pro-guided-action {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  body[data-ui-mode="advanced"] .troubleshooting-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/assets/pro_guided_workflow.js
+++ b/assets/pro_guided_workflow.js
@@ -1,0 +1,475 @@
+(function buildProGuidedWorkflow() {
+  'use strict';
+
+  const AUTOSAVE_DELAY_MS = 650;
+  const SAVE_TIMEOUT_MS = 12000;
+  const RETRY_LIMIT = 120;
+  let initialized = false;
+  let guidedReady = false;
+  let qualityReady = false;
+  let troubleshootingReady = false;
+  let saveTimer = null;
+  let restartRequired = false;
+  let retryCount = 0;
+  let retryTimer = null;
+  let retryQueued = false;
+  let observer = null;
+
+  function el(id) { return document.getElementById(id); }
+
+  function make(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function setText(node, text) {
+    if (node && node.textContent !== text) node.textContent = text;
+  }
+
+  function icon(kind) {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.classList.add('pro-nav-svg');
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('fill', 'currentColor');
+    path.setAttribute('d', kind === 'wifi'
+      ? 'M12 18.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm0-5a6.45 6.45 0 0 0-4.58 1.9l1.42 1.42a4.48 4.48 0 0 1 6.32 0l1.42-1.42A6.45 6.45 0 0 0 12 13.5Zm0-5a11.42 11.42 0 0 0-8.08 3.35l1.42 1.42a9.42 9.42 0 0 1 13.32 0l1.42-1.42A11.42 11.42 0 0 0 12 8.5Zm0-5A16.4 16.4 0 0 0 .42 8.3l1.42 1.42a14.4 14.4 0 0 1 20.32 0l1.42-1.42A16.4 16.4 0 0 0 12 3.5Z'
+      : 'M12 2a2 2 0 0 1 2 2v1.1a7 7 0 0 1 2.27.94l.78-.78a2 2 0 1 1 2.83 2.83l-.78.78A7 7 0 0 1 20 11h1a2 2 0 1 1 0 4h-1a7 7 0 0 1-.9 2.13l.78.78a2 2 0 0 1-2.83 2.83l-.78-.78A7 7 0 0 1 14 20.9V22a2 2 0 1 1-4 0v-1.1a7 7 0 0 1-2.27-.94l-.78.78a2 2 0 0 1-2.83-2.83l.78-.78A7 7 0 0 1 4 15H3a2 2 0 1 1 0-4h1a7 7 0 0 1 .9-2.13l-.78-.78a2 2 0 1 1 2.83-2.83l.78.78A7 7 0 0 1 10 5.1V4a2 2 0 0 1 2-2Zm0 6a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z');
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function replaceNav(item, kind, label) {
+    if (!item) return;
+    if (item.dataset.proNavLabel === label) return;
+    item.dataset.proNavLabel = label;
+    item.replaceChildren(icon(kind), document.createTextNode(label));
+  }
+
+  function addStyles() {
+    if (document.querySelector('link[data-pro-guided-styles]')) return;
+    const stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.href = '/assets/pro_guided_workflow.css?v=139-pro-hotfix';
+    stylesheet.dataset.proGuidedStyles = '1';
+    document.head.appendChild(stylesheet);
+  }
+
+  function step(number, title, help, id) {
+    const section = make('section', 'pro-guided-step');
+    const badge = make('span', 'pro-guided-number', String(number));
+    const content = make('div', 'pro-guided-content');
+    content.append(make('h3', 'pro-guided-title', title), make('p', 'pro-guided-help', help));
+    const slot = make('div', 'pro-guided-slot');
+    slot.id = id;
+    content.appendChild(slot);
+    section.append(badge, content);
+    return section;
+  }
+
+  function serviceIsRunning() {
+    const text = String(el('pillTxt')?.textContent || '').toLowerCase();
+    return text.includes('running') && !text.includes('not running');
+  }
+
+  function savingState(state, text) {
+    const node = el('proSaveState');
+    if (!node) return;
+    node.dataset.state = state;
+    setText(node, text);
+  }
+
+  function waitUntilSaved() {
+    const started = Date.now();
+    return new Promise((resolve) => {
+      function check() {
+        const dirty = String(el('dirty')?.textContent || '').trim();
+        if (!dirty) return resolve(true);
+        if (Date.now() - started >= SAVE_TIMEOUT_MS) return resolve(false);
+        window.setTimeout(check, 120);
+      }
+      check();
+    });
+  }
+
+  async function saveConfiguration() {
+    const save = el('btnSaveConfig');
+    if (!save) return false;
+    savingState('saving', 'Saving changes…');
+    save.click();
+    const saved = await waitUntilSaved();
+    if (!saved) {
+      savingState('error', 'Changes could not be saved. Open Troubleshooting for details.');
+      return false;
+    }
+    savingState(restartRequired ? 'restart' : 'saved', restartRequired
+      ? 'Changes saved. Restart the hotspot to apply them.'
+      : 'All changes saved.');
+    syncPrimaryAction();
+    return true;
+  }
+
+  function scheduleSave(markRestart = true) {
+    if (markRestart && serviceIsRunning()) restartRequired = true;
+    savingState('saving', 'Saving changes…');
+    if (saveTimer) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => void saveConfiguration(), AUTOSAVE_DELAY_MS);
+  }
+
+  function syncPrimaryAction() {
+    const primary = el('btnStart');
+    if (!primary) return;
+    if (serviceIsRunning() && restartRequired) {
+      primary.dataset.proServiceAction = 'start';
+      primary.dataset.proGuidedAction = 'apply';
+      primary.textContent = 'Apply Changes & Restart';
+      primary.classList.remove('danger', 'secondary');
+      primary.classList.add('primary');
+      primary.disabled = false;
+      return;
+    }
+    delete primary.dataset.proGuidedAction;
+  }
+
+  function wireAutosave(root) {
+    if (!root || root.dataset.proAutosaveWired === '1') return;
+    root.dataset.proAutosaveWired = '1';
+    root.addEventListener('change', (event) => {
+      if (!(event.target instanceof HTMLInputElement || event.target instanceof HTMLSelectElement)) return;
+      if (!event.isTrusted) return;
+      scheduleSave(true);
+      updateDependencies();
+    });
+    root.addEventListener('input', (event) => {
+      if (!(event.target instanceof HTMLInputElement)) return;
+      if (!event.isTrusted) return;
+      scheduleSave(true);
+    });
+    root.querySelectorAll('.preset-bar .btn').forEach((button) => {
+      button.addEventListener('click', () => window.setTimeout(() => scheduleSave(true), 0));
+    });
+  }
+
+  function updateDependencies() {
+    const autoChannel = el('channel_auto_select');
+    const channel5 = el('channel_5g');
+    const channel6 = el('channel_6g');
+    if (channel5) channel5.disabled = !!autoChannel?.checked;
+    if (channel6) channel6.disabled = !!autoChannel?.checked;
+    const bridge = el('bridge_mode');
+    for (const id of ['bridge_name', 'bridge_uplink']) {
+      const input = el(id);
+      if (input) input.disabled = !bridge?.checked;
+    }
+  }
+
+  function enforceNavigation() {
+    addStyles();
+    const overviewNav = document.querySelector('.nav-item[data-tab="overview"]');
+    replaceNav(overviewNav, 'wifi', 'Set Up Hotspot');
+
+    document.querySelector('.nav-item[data-tab="telemetry"]')?.remove();
+    const logsNav = document.querySelector('.nav-item[data-tab="logs"]');
+    logsNav?.remove();
+
+    const troubleshootingNav = document.querySelector(
+      '.nav-item[data-tab="troubleshooting"], .nav-item[data-tab="diagnostics"]',
+    );
+    if (troubleshootingNav) {
+      troubleshootingNav.dataset.tab = 'troubleshooting';
+      replaceNav(troubleshootingNav, 'trouble', 'Troubleshooting');
+    }
+
+    const diagnosticsPane = el('tab-diagnostics');
+    if (diagnosticsPane) diagnosticsPane.id = 'tab-troubleshooting';
+  }
+
+  function buildGuidedSetup() {
+    if (el('proGuidedWorkflow')) return true;
+    const overview = el('tab-overview');
+    const oldShell = overview?.querySelector('.pro-setup-shell');
+    const configuration = el('proHotspotConfiguration');
+    const serviceCard = overview?.querySelector('.pro-service-card');
+    if (!overview || !oldShell || !configuration || !serviceCard) return false;
+
+    const shell = make('div', 'pro-guided-shell');
+    shell.id = 'proGuidedWorkflow';
+    const card = make('section', 'pro-guided-card');
+    const header = make('div', 'pro-guided-header');
+    header.append(
+      make('h2', '', 'Set Up Hotspot'),
+      make('p', '', 'Configure the hotspot in order, then start it or apply changes safely.'),
+    );
+    const steps = make('div', 'pro-guided-steps');
+    steps.append(
+      step(1, 'Choose Wi-Fi adapter', 'Select the adapter VRhotspot should use. Recommended choices are labeled automatically.', 'proStepAdapter'),
+      step(2, 'Choose performance mode', 'Choose the behavior that best matches your VR workflow.', 'proStepPerformance'),
+      step(3, 'Configure hotspot', 'Set the network name, password, and internet-sharing preference.', 'proStepHotspot'),
+      step(4, 'Fine-tune hotspot', 'Optional expert settings are grouped by purpose and can be left at their recommended defaults.', 'proStepAdvanced'),
+      step(5, 'Start hotspot', 'Start, stop, or safely apply saved changes to a running hotspot.', 'proStepAction'),
+    );
+    card.append(header, steps);
+    shell.appendChild(card);
+
+    const adapter = document.querySelector('[data-field="ap_adapter"]');
+    if (adapter) {
+      const label = adapter.querySelector('label');
+      if (label) label.textContent = 'Wi-Fi adapter';
+      el('proStepAdapter').appendChild(adapter);
+    }
+
+    const preset = configuration.querySelector('.preset-bar');
+    if (preset) {
+      preset.classList.add('pro-performance-picker');
+      const group = preset.querySelector('.btn-group');
+      const order = [
+        el('btnApplyVrProfileUltra'),
+        el('btnApplyVrProfile'),
+        el('btnApplyVrProfileHigh'),
+        el('btnApplyVrProfileStable'),
+      ].filter(Boolean);
+      if (group) order.forEach((button) => group.appendChild(button));
+      el('proStepPerformance').appendChild(preset);
+    }
+    const qos = document.querySelector('[data-field="qos_preset"]');
+    if (qos) {
+      qos.classList.add('pro-guided-hidden');
+      el('proStepPerformance').appendChild(qos);
+    }
+
+    const hotspotFields = make('div', 'pro-hotspot-fields');
+    for (const key of ['ssid', 'wpa2_passphrase', 'enable_internet']) {
+      const field = document.querySelector(`[data-field="${key}"]`);
+      if (field && key === 'ssid') {
+        const label = field.querySelector('label');
+        if (label) label.textContent = 'Hotspot name';
+      }
+      if (field && key === 'wpa2_passphrase') {
+        const label = field.querySelector('label');
+        if (label) label.textContent = 'Password';
+      }
+      if (field) hotspotFields.appendChild(field);
+    }
+    el('proStepHotspot').appendChild(hotspotFields);
+
+    const advanced = make('details', 'pro-advanced-settings');
+    const advancedSummary = make('summary', '', 'Advanced wireless, network, and system settings');
+    const advancedBody = make('div', 'pro-advanced-body');
+    configuration.querySelectorAll('.pro-config-details').forEach((details) => advancedBody.appendChild(details));
+    advanced.append(advancedSummary, advancedBody);
+    el('proStepAdvanced').appendChild(advanced);
+
+    const action = make('div', 'pro-guided-action');
+    const stateCopy = serviceCard.querySelector('.pro-service-state-copy');
+    const primary = el('btnStart');
+    if (stateCopy) action.appendChild(stateCopy);
+    if (primary) action.appendChild(primary);
+    const actionSlot = el('proStepAction');
+    const saveState = make('div', 'pro-save-state', 'All changes saved.');
+    saveState.id = 'proSaveState';
+    actionSlot.append(action, saveState);
+
+    const hidden = make('div', 'pro-guided-hidden');
+    hidden.id = 'proGuidedHiddenControls';
+    const headerBar = configuration.querySelector('.settings-header');
+    const serviceSecondary = serviceCard.querySelector('.pro-service-secondary');
+    const serviceMeta = serviceCard.querySelector('.hero-meta');
+    const feedback = serviceCard.querySelectorAll('.hero-feedback');
+    for (const node of [headerBar, serviceSecondary, serviceMeta, ...feedback]) {
+      if (node) hidden.appendChild(node);
+    }
+    card.appendChild(hidden);
+
+    overview.replaceChildren(shell);
+    wireAutosave(card);
+    updateDependencies();
+
+    if (primary && primary.dataset.proGuidedWired !== '1') {
+      primary.dataset.proGuidedWired = '1';
+      primary.addEventListener('click', async (event) => {
+        if (primary.dataset.proGuidedAction !== 'apply') return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        const saved = await saveConfiguration();
+        if (!saved) return;
+        restartRequired = false;
+        savingState('saving', 'Applying changes and restarting…');
+        el('btnSaveRestart')?.click();
+      }, true);
+    }
+
+    const statusSource = el('pillTxt');
+    if (statusSource && statusSource.dataset.proGuidedObserved !== '1') {
+      statusSource.dataset.proGuidedObserved = '1';
+      const statusObserver = new MutationObserver(() => {
+        if (!serviceIsRunning()) restartRequired = false;
+        syncPrimaryAction();
+      });
+      statusObserver.observe(statusSource, { childList: true, subtree: true, characterData: true });
+    }
+    return true;
+  }
+
+  function qualityMessage() {
+    if (!serviceIsRunning()) return 'Start the hotspot to measure connection performance.';
+    const summary = String(el('telemetrySummary')?.textContent || '').trim();
+    return summary || 'Connection measurements will appear as clients begin using the hotspot.';
+  }
+
+  function buildConnectionQuality() {
+    if (el('proConnectionQuality')) return true;
+    const overview = el('tab-overview');
+    const shell = overview?.querySelector('.pro-guided-shell');
+    const telemetryPane = el('tab-telemetry');
+    const telemetryCard = el('cardTelemetry');
+    if (!shell || !telemetryPane || !telemetryCard) return false;
+
+    document.querySelector('.nav-item[data-tab="telemetry"]')?.remove();
+    const card = make('section', 'pro-quality-card');
+    card.id = 'proConnectionQuality';
+    const header = make('div', 'pro-quality-header');
+    header.append(make('h2', '', 'Connection Quality'));
+    const status = make('span', 'pill', serviceIsRunning() ? 'Measuring' : 'Waiting');
+    status.id = 'proQualityStatus';
+    header.appendChild(status);
+
+    const body = make('div', 'pro-quality-body');
+    const summary = make('div', 'pro-quality-summary', qualityMessage());
+    summary.id = 'proQualitySummary';
+    const warning = el('telemetryWarnings');
+    const details = make('details', 'pro-quality-details');
+    details.appendChild(make('summary', '', 'View detailed charts and client measurements'));
+
+    const telemetryBody = telemetryCard.querySelector('.card-body');
+    if (telemetryBody) details.appendChild(telemetryBody);
+    const settings = details.querySelector('[data-field="telemetry_enable"]');
+    if (settings) {
+      settings.classList.add('pro-quality-settings');
+      const label = settings.querySelector(':scope > label');
+      if (label) label.textContent = 'Measurement options';
+      const toggles = settings.querySelectorAll('.tog');
+      for (const [toggle, text] of [
+        [toggles[0], 'Measure connection quality'],
+        [toggles[1], 'Watch for connection problems'],
+      ]) {
+        const input = toggle && toggle.querySelector('input');
+        if (toggle && input) toggle.replaceChildren(input, document.createTextNode(` ${text}`));
+      }
+    }
+    const interval = document.querySelector('[data-field="telemetry_interval_s"]');
+    if (interval) interval.classList.add('pro-guided-hidden');
+
+    body.append(summary);
+    if (warning) body.appendChild(warning);
+    body.appendChild(details);
+    card.append(header, body);
+    shell.appendChild(card);
+    telemetryPane.hidden = true;
+
+    const sources = [el('telemetrySummary'), el('telemetryWarnings'), el('pillTxt')].filter(Boolean);
+    const qualityObserver = new MutationObserver(() => {
+      setText(summary, qualityMessage());
+      setText(status, serviceIsRunning() ? 'Live' : 'Waiting');
+    });
+    sources.forEach((node) => qualityObserver.observe(node, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    }));
+    return true;
+  }
+
+  function buildTroubleshooting() {
+    const diagnosticsPane = el('tab-troubleshooting') || el('tab-diagnostics');
+    const logsPane = el('tab-logs');
+    const nav = document.querySelector(
+      '.nav-item[data-tab="troubleshooting"], .nav-item[data-tab="diagnostics"]',
+    );
+    if (!diagnosticsPane || !logsPane || !nav) return false;
+    if (diagnosticsPane.querySelector('.troubleshooting-shell')) return true;
+
+    nav.dataset.tab = 'troubleshooting';
+    diagnosticsPane.id = 'tab-troubleshooting';
+    replaceNav(nav, 'trouble', 'Troubleshooting');
+    const logsNav = document.querySelector('.nav-item[data-tab="logs"]');
+    logsNav?.remove();
+
+    const shell = make('div', 'troubleshooting-shell');
+    const header = make('section', 'troubleshooting-header');
+    const copy = make('div');
+    copy.append(
+      make('h2', '', 'Troubleshooting'),
+      make('p', '', 'Check system health, repair problems, inspect runtime details, and collect support information.'),
+    );
+    const actions = make('div', 'troubleshooting-actions');
+    for (const id of ['btnRepair', 'btnRestart', 'btnRefreshPreflight']) {
+      const control = el(id);
+      if (control) actions.appendChild(control);
+    }
+    header.append(copy, actions);
+    shell.append(header, make('h3', 'troubleshooting-section-label', 'System Health & Diagnostic Checks'));
+
+    const preflight = diagnosticsPane.querySelector('.preflight-page');
+    if (preflight) {
+      preflight.querySelector('.preflight-header .action-group')?.remove();
+      shell.appendChild(preflight);
+    }
+
+    shell.appendChild(make('h3', 'troubleshooting-section-label', 'Runtime Details, Logs & Support'));
+    logsPane.querySelector('.pro-support-heading')?.remove();
+    Array.from(logsPane.children).forEach((node) => shell.appendChild(node));
+    diagnosticsPane.replaceChildren(shell);
+    logsPane.hidden = true;
+    return true;
+  }
+
+  function initialize() {
+    enforceNavigation();
+    try {
+      if (!guidedReady) guidedReady = buildGuidedSetup();
+      if (guidedReady && !qualityReady) qualityReady = buildConnectionQuality();
+      if (!troubleshootingReady) troubleshootingReady = buildTroubleshooting();
+      initialized = guidedReady && qualityReady && troubleshootingReady;
+      if (initialized && document.body) delete document.body.dataset.proGuidedError;
+      return initialized;
+    } catch (error) {
+      if (document.body) {
+        document.body.dataset.proGuidedError = String(error && error.message ? error.message : error);
+      }
+      console.error('VRhotspot Pro workflow retrying after UI error.', error);
+      return false;
+    }
+  }
+
+  function scheduleRetry() {
+    if (retryQueued || initialized || retryCount >= RETRY_LIMIT) return;
+    retryQueued = true;
+    retryTimer = window.setTimeout(() => {
+      retryQueued = false;
+      retryCount += 1;
+      if (initialize()) {
+        if (observer) observer.disconnect();
+        if (retryTimer) window.clearTimeout(retryTimer);
+        return;
+      }
+      scheduleRetry();
+    }, 100);
+  }
+
+  function start() {
+    enforceNavigation();
+    if (initialize()) return;
+    observer = new MutationObserver(scheduleRetry);
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    scheduleRetry();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from http.cookies import SimpleCookie
+import json
 import logging
 from pathlib import Path
+import secrets
+import threading
+import time
 from typing import Any, Mapping, Optional
 
 from vr_hotspotd.api import APIHandler, _resolve_asset_path
@@ -41,6 +46,12 @@ log = logging.getLogger("vr_hotspotd.devhub_api")
 
 DEVICE_OVERVIEW_PATH = "/v1/devbridge/adb/device-overview"
 WIRELESS_BOOTSTRAP_PATH = "/v1/devbridge/adb/enable-wireless"
+BROWSER_SESSION_PATH = "/v1/auth/browser-session"
+BROWSER_SESSION_LOGOUT_PATH = "/v1/auth/browser-session/logout"
+_BROWSER_SESSION_COOKIE = "vrhs_browser_session"
+_BROWSER_SESSION_TTL_S = 8 * 60 * 60
+_BROWSER_SESSIONS: dict[str, float] = {}
+_BROWSER_SESSIONS_LOCK = threading.Lock()
 
 _DEVHUB_ASSET_TYPES = {
     "/assets/basic_layout.css": "text/css; charset=utf-8",
@@ -50,6 +61,9 @@ _DEVHUB_ASSET_TYPES = {
     "/assets/devhub.js": "application/javascript; charset=utf-8",
     "/assets/devhub_upload.css": "text/css; charset=utf-8",
     "/assets/devhub_upload.js": "application/javascript; charset=utf-8",
+    "/assets/browser_session.js": "application/javascript; charset=utf-8",
+    "/assets/pro_guided_workflow.js": "application/javascript; charset=utf-8",
+    "/assets/pro_guided_workflow.css": "text/css; charset=utf-8",
     "/assets/devhub_workspace.css": "text/css; charset=utf-8",
     "/assets/devhub_workspace.js": "application/javascript; charset=utf-8",
     "/assets/devhub_device_overview.css": "text/css; charset=utf-8",
@@ -115,8 +129,98 @@ _BODY_ERROR_WARNINGS = {
 }
 
 
+def _prune_browser_sessions(now: Optional[float] = None) -> None:
+    current = time.monotonic() if now is None else now
+    expired = [
+        session_id
+        for session_id, expires_at in _BROWSER_SESSIONS.items()
+        if expires_at <= current
+    ]
+    for session_id in expired:
+        _BROWSER_SESSIONS.pop(session_id, None)
+
+
+def _create_browser_session() -> str:
+    session_id = secrets.token_urlsafe(32)
+    with _BROWSER_SESSIONS_LOCK:
+        _prune_browser_sessions()
+        _BROWSER_SESSIONS[session_id] = time.monotonic() + _BROWSER_SESSION_TTL_S
+    return session_id
+
+
+def _browser_session_is_valid(session_id: str) -> bool:
+    if not session_id:
+        return False
+    with _BROWSER_SESSIONS_LOCK:
+        _prune_browser_sessions()
+        expires_at = _BROWSER_SESSIONS.get(session_id)
+        if expires_at is None:
+            return False
+        _BROWSER_SESSIONS[session_id] = time.monotonic() + _BROWSER_SESSION_TTL_S
+        return True
+
+
+def _revoke_browser_session(session_id: str) -> None:
+    if not session_id:
+        return
+    with _BROWSER_SESSIONS_LOCK:
+        _BROWSER_SESSIONS.pop(session_id, None)
+
+
 class DevHubAPIHandler(APIHandler):
     """Extend the daemon API with Developer Hub assets and operations."""
+
+    def _browser_session_id(self) -> str:
+        raw_cookie = self.headers.get("Cookie") or ""
+        if not raw_cookie:
+            return ""
+        cookie = SimpleCookie()
+        try:
+            cookie.load(raw_cookie)
+        except Exception:
+            return ""
+        morsel = cookie.get(_BROWSER_SESSION_COOKIE)
+        return morsel.value.strip() if morsel else ""
+
+    def _is_authorized(self) -> bool:
+        return super()._is_authorized() or _browser_session_is_valid(
+            self._browser_session_id()
+        )
+
+    def _respond_browser_session(
+        self,
+        *,
+        cid: str,
+        code: int,
+        result_code: str,
+        session_id: str = "",
+        clear: bool = False,
+    ) -> None:
+        payload = self._envelope(
+            correlation_id=cid,
+            result_code=result_code,
+            data={"authenticated": code == 200 and not clear},
+        )
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self._send_common_headers("application/json; charset=utf-8", len(raw))
+        if clear:
+            self.send_header(
+                "Set-Cookie",
+                f"{_BROWSER_SESSION_COOKIE}=; Path=/; HttpOnly; "
+                "SameSite=Strict; Max-Age=0",
+            )
+        elif session_id:
+            self.send_header(
+                "Set-Cookie",
+                f"{_BROWSER_SESSION_COOKIE}={session_id}; Path=/; HttpOnly; "
+                f"SameSite=Strict; Max-Age={_BROWSER_SESSION_TTL_S}",
+            )
+        self.end_headers()
+        try:
+            self.wfile.write(raw)
+        except (BrokenPipeError, ConnectionResetError):
+            return
 
     def _serve_devhub_asset(self, path: str) -> bool:
         content_type = _DEVHUB_ASSET_TYPES.get(path)
@@ -236,6 +340,21 @@ class DevHubAPIHandler(APIHandler):
         path, qs = self._parse_url()
         if self._serve_devhub_asset(path):
             return
+        if path == BROWSER_SESSION_PATH:
+            if _browser_session_is_valid(self._browser_session_id()):
+                self._respond_browser_session(
+                    cid=cid,
+                    code=200,
+                    result_code="browser_session_active",
+                )
+            else:
+                self._respond_browser_session(
+                    cid=cid,
+                    code=401,
+                    result_code="browser_session_missing",
+                    clear=True,
+                )
+            return
         operation = _GET_OPERATIONS.get(path)
         is_device_overview = path == DEVICE_OVERVIEW_PATH
         if operation is None and not is_device_overview:
@@ -259,11 +378,41 @@ class DevHubAPIHandler(APIHandler):
                 "serial": qs.get("serial"),
                 "third_party_only": self._qbool(qs, "third_party_only", True),
             }
-        self._respond_adb_operation(cid=cid, operation=operation or "", request=request)
+        self._respond_adb_operation(
+            cid=cid,
+            operation=operation or "",
+            request=request,
+        )
 
     def do_POST(self):
         cid = self._cid()
         path, _qs = self._parse_url()
+        if path == BROWSER_SESSION_PATH:
+            if not super()._is_authorized():
+                self._respond_browser_session(
+                    cid=cid,
+                    code=401,
+                    result_code="browser_session_rejected",
+                    clear=True,
+                )
+                return
+            self._respond_browser_session(
+                cid=cid,
+                code=200,
+                result_code="browser_session_created",
+                session_id=_create_browser_session(),
+            )
+            return
+        if path == BROWSER_SESSION_LOGOUT_PATH:
+            _revoke_browser_session(self._browser_session_id())
+            self._respond_browser_session(
+                cid=cid,
+                code=200,
+                result_code="browser_session_cleared",
+                clear=True,
+            )
+            return
+
         operation = _POST_OPERATIONS.get(path)
         tools_operation = _TOOLS_POST_OPERATIONS.get(path)
         is_apk_upload = path == APK_UPLOAD_PATH

--- a/backend/vr_hotspotd/devtools/devhub_api.py
+++ b/backend/vr_hotspotd/devtools/devhub_api.py
@@ -214,7 +214,7 @@ class DevHubAPIHandler(APIHandler):
             self.send_header(
                 "Set-Cookie",
                 f"{_BROWSER_SESSION_COOKIE}={session_id}; Path=/; HttpOnly; "
-                f"SameSite=Strict; Max-Age={_BROWSER_SESSION_TTL_S}",
+                "SameSite=Strict",
             )
         self.end_headers()
         try:

--- a/tests/test_browser_session_refresh.py
+++ b/tests/test_browser_session_refresh.py
@@ -26,7 +26,8 @@ def test_daemon_issues_opaque_http_only_same_site_cookie() -> None:
     assert 'secrets.token_urlsafe(32)' in source
     assert "HttpOnly" in source
     assert "SameSite=Strict" in source
-    assert "Max-Age=" in source
+    assert "SameSite=Strict; Max-Age=0" in source
+    assert "Max-Age={_BROWSER_SESSION_TTL_S}" not in source
     assert "super()._is_authorized()" in source
     assert "_browser_session_is_valid" in source
 

--- a/tests/test_browser_session_refresh.py
+++ b/tests/test_browser_session_refresh.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from vr_hotspotd.devtools import devhub_api
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BROWSER_SESSION_JS = ROOT / "assets" / "browser_session.js"
+DEVHUB_API = ROOT / "backend" / "vr_hotspotd" / "devtools" / "devhub_api.py"
+
+
+def test_browser_session_keeps_api_token_out_of_browser_storage() -> None:
+    source = BROWSER_SESSION_JS.read_text(encoding="utf-8")
+
+    assert "sessionStorage" not in source
+    assert "localStorage" not in source
+    assert "document.cookie" not in source
+    assert "credentials: 'same-origin'" in source
+    assert "X-Api-Token" in source
+    assert "pendingCandidate = ''" in source
+
+
+def test_daemon_issues_opaque_http_only_same_site_cookie() -> None:
+    source = DEVHUB_API.read_text(encoding="utf-8")
+
+    assert 'BROWSER_SESSION_PATH = "/v1/auth/browser-session"' in source
+    assert 'secrets.token_urlsafe(32)' in source
+    assert "HttpOnly" in source
+    assert "SameSite=Strict" in source
+    assert "Max-Age=" in source
+    assert "super()._is_authorized()" in source
+    assert "_browser_session_is_valid" in source
+
+
+def test_browser_session_lifetime_is_sliding_and_expires(monkeypatch) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setattr(devhub_api.time, "monotonic", lambda: clock["now"])
+    devhub_api._BROWSER_SESSIONS.clear()
+
+    session_id = devhub_api._create_browser_session()
+    assert session_id
+    assert devhub_api._browser_session_is_valid(session_id) is True
+
+    clock["now"] += devhub_api._BROWSER_SESSION_TTL_S - 1
+    assert devhub_api._browser_session_is_valid(session_id) is True
+
+    clock["now"] += devhub_api._BROWSER_SESSION_TTL_S + 1
+    assert devhub_api._browser_session_is_valid(session_id) is False

--- a/tests/test_pro_guided_workflow.py
+++ b/tests/test_pro_guided_workflow.py
@@ -6,7 +6,18 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SOURCE = ROOT / "assets" / "devhub_upload.js"
+LOADER = ROOT / "assets" / "devhub_upload.js"
+SOURCE = ROOT / "assets" / "pro_guided_workflow.js"
+STYLE = ROOT / "assets" / "pro_guided_workflow.css"
+SESSION = ROOT / "assets" / "browser_session.js"
+
+
+def test_pro_runtime_is_loaded_as_versioned_dedicated_assets() -> None:
+    source = LOADER.read_text(encoding="utf-8")
+
+    assert "/assets/browser_session.js?v=139-session-hotfix" in source
+    assert "/assets/pro_guided_workflow.js?v=139-pro-hotfix" in source
+    assert "script.async = false" in source
 
 
 def test_pro_setup_is_one_guided_five_step_workflow() -> None:
@@ -30,9 +41,10 @@ def test_pro_setup_is_one_guided_five_step_workflow() -> None:
 
 def test_pro_setup_removes_sticky_save_bar_and_autosaves() -> None:
     source = SOURCE.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
 
-    assert ".pro-configuration > .settings-header" in source
-    assert "display: none !important" in source
+    assert ".pro-configuration > .settings-header" in style
+    assert "display: none !important" in style
     assert "scheduleSave" in source
     assert "saveConfiguration" in source
     assert "btnSaveConfig" in source
@@ -52,14 +64,30 @@ def test_pro_setup_preserves_order_and_dependencies() -> None:
     assert "bridge_uplink" in source
 
 
+def test_navigation_cleanup_runs_before_optional_dom_transforms() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+
+    enforce = source.index("function enforceNavigation()")
+    initialize = source.index("function initialize()")
+    first_call = source.index("enforceNavigation();", initialize)
+    guided_call = source.index("buildGuidedSetup()", initialize)
+
+    assert enforce < initialize
+    assert first_call < guided_call
+    assert "RETRY_LIMIT" in source
+    assert "MutationObserver(scheduleRetry)" in source
+    assert "catch (error)" in source
+
+
 def test_connection_quality_is_pro_only_and_not_a_sidebar_tab() -> None:
     source = SOURCE.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
 
     assert "Connection Quality" in source
     assert "buildConnectionQuality" in source
     assert '.nav-item[data-tab="telemetry"]' in source
     assert "?.remove()" in source
-    assert "#tab-telemetry { display: none !important; }" in source
+    assert "#tab-telemetry" in style
     assert "View detailed charts and client measurements" in source
     assert "Measure connection quality" in source
 
@@ -85,12 +113,13 @@ def test_setup_navigation_uses_vector_wifi_icon_not_emoji() -> None:
     assert "📡" not in source
 
 
-def test_rewritten_extension_parses_with_node() -> None:
+@pytest.mark.parametrize("asset", [LOADER, SOURCE, SESSION])
+def test_portal_extensions_parse_with_node(asset: Path) -> None:
     node = shutil.which("node")
     if node is None:
         pytest.skip("node is not available")
     completed = subprocess.run(
-        [node, "--check", str(SOURCE)],
+        [node, "--check", str(asset)],
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
## Problem

Real-system validation after #138 found two regressions:

- Reloading the Web Portal always returned to the API-token splash because browser authentication existed only in JavaScript memory.
- The Pro workflow transformation could abort before removing the Telemetry tab when one DOM assumption failed or the prerequisite layout had not finished loading.

## Authentication fix

- Add an opaque daemon-managed browser session.
- Exchange a valid API token for a random session identifier.
- Store only the opaque identifier in an `HttpOnly`, `SameSite=Strict` cookie.
- Keep the raw API token out of local storage, session storage, cookies, URLs, and logs.
- Restore an authenticated portal automatically after an ordinary reload.
- Expire inactive browser sessions after eight hours and invalidate all sessions when the daemon restarts.

## Pro runtime fix

- Move the Pro workflow into a dedicated, versioned JavaScript asset.
- Move its styling into a dedicated versioned stylesheet.
- Make sidebar cleanup independent from the optional DOM transformations.
- Remove Telemetry and Logs navigation immediately.
- Rename Diagnostics to Troubleshooting immediately.
- Retry the guided setup, Connection Quality, and Troubleshooting transformations independently when prerequisite nodes are not ready.
- Catch a stage failure instead of permanently aborting the entire Pro workflow.
- Preserve the five-step setup, autosave behavior, dependency controls, inline Connection Quality, and unified Troubleshooting design from #138.

## Compatibility

- Existing API-token headers remain supported.
- Existing Developer Hub APK upload behavior is preserved.
- Basic mode is unchanged.
- No hotspot, adapter, firewall, or networking behavior changes.

## Validation

- Contract coverage for opaque browser sessions, cookie security attributes, sliding expiry, versioned assets, navigation ordering, bounded retries, and JavaScript parsing.
- Full installer and Python 3.11–3.13 matrix required before merge.