### PR TITLE
Compact Pro setup and unify shared controls

### DIFF
--- a/assets/devhub_upload.js
+++ b/assets/devhub_upload.js
@@ -287,3 +287,292 @@
     document.head.appendChild(script);
   }
 })();
+
+(function polishProSetupDensity() {
+  'use strict';
+
+  const RETRY_LIMIT = 200;
+  const PROFILE_COPY = {
+    btnApplyVrProfileUltra: {
+      value: 'ultra_low_latency',
+      description: 'Prioritizes the lowest possible response time for demanding VR streaming.',
+    },
+    btnApplyVrProfile: {
+      value: 'balanced',
+      description: 'Recommended default for a strong balance of responsiveness and stability.',
+    },
+    btnApplyVrProfileHigh: {
+      value: 'high_throughput',
+      description: 'Prioritizes sustained transfer speed for large or bandwidth-heavy workloads.',
+    },
+    btnApplyVrProfileStable: {
+      value: 'vr',
+      description: 'Favors connection consistency when the wireless environment is unpredictable.',
+    },
+  };
+
+  let attempts = 0;
+  let retryTimer = null;
+  let observer = null;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function make(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function serviceState() {
+    const raw = String(el('proServiceStateText')?.textContent || el('pillTxt')?.textContent || 'Checking…').trim();
+    const value = raw.toLowerCase();
+    if (value.includes('error') || value.includes('failed') || value.includes('attention')) {
+      return { name: 'error', label: 'Needs attention' };
+    }
+    if (value.includes('starting') || value.includes('stopping') || value.includes('working') || value.includes('repair')) {
+      return { name: 'working', label: raw || 'Working…' };
+    }
+    if (value.includes('running') && !value.includes('not running')) {
+      return { name: 'running', label: 'Running' };
+    }
+    if (value.includes('stopped') || value.includes('inactive') || value.includes('not running')) {
+      return { name: 'stopped', label: 'Stopped' };
+    }
+    return { name: 'loading', label: raw || 'Checking…' };
+  }
+
+  function syncHeaderStatus() {
+    const status = el('proHeaderStatus');
+    if (!status) return;
+    const state = serviceState();
+    status.dataset.state = state.name;
+    status.textContent = state.label;
+  }
+
+  function compactHeader() {
+    const header = document.querySelector('#proGuidedWorkflow .pro-guided-header');
+    const saveState = el('proSaveState');
+    if (!header || !saveState) return false;
+    if (header.dataset.proDensityReady === '1') {
+      syncHeaderStatus();
+      return true;
+    }
+
+    const heading = header.querySelector(':scope > h2');
+    const summary = header.querySelector(':scope > p');
+    if (!heading || !summary) return false;
+
+    const copy = make('div', 'pro-guided-header-copy');
+    copy.append(heading, summary);
+    const meta = make('div', 'pro-guided-header-meta');
+    const status = make('div', 'pro-header-status', 'Checking…');
+    status.id = 'proHeaderStatus';
+    status.setAttribute('aria-live', 'polite');
+    meta.append(status, saveState);
+    header.replaceChildren(copy, meta);
+    header.dataset.proDensityReady = '1';
+
+    const source = el('proServiceStateText') || el('pillTxt');
+    if (source && source.dataset.proDensityObserved !== '1') {
+      source.dataset.proDensityObserved = '1';
+      const statusObserver = new MutationObserver(syncHeaderStatus);
+      statusObserver.observe(source, { childList: true, subtree: true, characterData: true });
+    }
+    syncHeaderStatus();
+    return true;
+  }
+
+  function compactAdapter() {
+    const field = document.querySelector('#proStepAdapter [data-field="ap_adapter"]');
+    const select = el('ap_adapter');
+    const rescan = el('btnReloadAdapters');
+    if (!field || !select || !rescan) return false;
+    if (field.dataset.proDensityReady === '1') return true;
+
+    field.classList.add('pro-adapter-field');
+    const recommended = el('btnUseRecommended');
+    if (recommended) {
+      recommended.hidden = true;
+      recommended.setAttribute('aria-hidden', 'true');
+    }
+
+    const row = make('div', 'pro-adapter-row');
+    const badge = make('span', 'pro-adapter-badge', 'Recommended');
+    badge.id = 'proAdapterRecommendedBadge';
+    const syncBadge = () => {
+      const preferred = String(select.dataset.recommended || '');
+      badge.hidden = !preferred || select.value !== preferred;
+    };
+
+    rescan.textContent = 'Rescan adapters';
+    rescan.classList.add('pro-adapter-rescan');
+    row.append(select, badge, rescan);
+
+    const hint = el('adapterHint');
+    const label = field.querySelector(':scope > label, :scope > .field-label-with-tip');
+    field.replaceChildren();
+    if (label) field.appendChild(label);
+    field.appendChild(row);
+    if (hint) field.appendChild(hint);
+
+    select.addEventListener('change', syncBadge);
+    const adapterObserver = new MutationObserver(syncBadge);
+    adapterObserver.observe(select, { childList: true, subtree: true, attributes: true });
+    field.dataset.proDensityReady = '1';
+    syncBadge();
+    return true;
+  }
+
+  function compactPerformance() {
+    const preset = document.querySelector('#proStepPerformance .pro-performance-picker');
+    const qosField = document.querySelector('[data-field="qos_preset"]');
+    const qos = el('qos_preset');
+    if (!preset || !qosField || !qos) return false;
+
+    qosField.hidden = true;
+    qosField.setAttribute('aria-hidden', 'true');
+    qosField.classList.add('pro-guided-hidden');
+    const hiddenControls = el('proGuidedHiddenControls');
+    if (hiddenControls && qosField.parentElement !== hiddenControls) hiddenControls.appendChild(qosField);
+
+    let description = el('proPerformanceDescription');
+    if (!description) {
+      description = make('p', 'pro-performance-description');
+      description.id = 'proPerformanceDescription';
+      preset.appendChild(description);
+    }
+
+    const buttons = Object.entries(PROFILE_COPY)
+      .map(([id, profile]) => [el(id), profile])
+      .filter(([button]) => !!button);
+
+    const syncSelection = () => {
+      const selected = String(qos.value || 'off');
+      let selectedCopy = 'Choose the performance behavior that best matches this hotspot.';
+      for (const [button, profile] of buttons) {
+        const active = selected === profile.value;
+        button.classList.toggle('is-selected', active);
+        button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        if (active) selectedCopy = profile.description;
+      }
+      description.textContent = selectedCopy;
+    };
+
+    if (preset.dataset.proDensityReady !== '1') {
+      preset.dataset.proDensityReady = '1';
+      qos.addEventListener('change', syncSelection);
+      for (const [button] of buttons) {
+        button.addEventListener('click', () => window.setTimeout(syncSelection, 0));
+      }
+    }
+    syncSelection();
+    return true;
+  }
+
+  function compactPassword() {
+    const field = document.querySelector('#proStepHotspot [data-field="wpa2_passphrase"]');
+    const input = el('wpa2_passphrase');
+    const reveal = el('btnRevealPass');
+    const qr = el('btnShowQr');
+    if (!field || !input || !reveal || !qr) return false;
+    if (field.dataset.proDensityReady === '1') return true;
+
+    const label = field.querySelector('label');
+    const hint = el('passHint');
+    if (label) label.textContent = 'Password';
+
+    reveal.type = 'button';
+    reveal.classList.add('icon-only');
+    reveal.title = 'Show or hide password';
+    reveal.setAttribute('aria-label', 'Show or hide password');
+
+    qr.type = 'button';
+    qr.textContent = 'QR';
+    qr.className = 'btn icon-only';
+    qr.title = 'Show QR code';
+    qr.setAttribute('aria-label', 'Show QR code');
+
+    const row = make('div', 'pro-password-row');
+    row.append(input, reveal, qr);
+    field.replaceChildren();
+    if (label) field.appendChild(label);
+    field.appendChild(row);
+    if (hint) {
+      hint.classList.add('pro-password-hint');
+      field.appendChild(hint);
+    }
+    field.classList.add('pro-password-field');
+    field.dataset.proDensityReady = '1';
+    return true;
+  }
+
+  function compactHotspotStep() {
+    const slot = el('proStepHotspot');
+    if (!slot) return false;
+    const content = slot.closest('.pro-guided-content');
+    const title = content?.querySelector('.pro-guided-title');
+    const help = content?.querySelector('.pro-guided-help');
+    if (title) title.textContent = 'Hotspot name and password';
+    if (help) help.textContent = 'Choose the network name, password, and whether connected devices can use this computer’s internet connection.';
+
+    const ssid = slot.querySelector('[data-field="ssid"]');
+    if (ssid) ssid.classList.add('pro-hotspot-name-field');
+    const internet = slot.querySelector('[data-field="enable_internet"] .tog');
+    if (internet) {
+      const checkbox = internet.querySelector('input');
+      if (checkbox) internet.replaceChildren(checkbox, document.createTextNode(' Share internet with connected devices'));
+    }
+    return compactPassword();
+  }
+
+  function removeLegacyEssentials() {
+    document.querySelectorAll('.pro-config-essentials').forEach((node) => node.remove());
+    document.querySelectorAll('[data-field="qos_preset"]').forEach((node) => {
+      node.hidden = true;
+      node.setAttribute('aria-hidden', 'true');
+    });
+  }
+
+  function applyDensityPass() {
+    const workflow = el('proGuidedWorkflow');
+    if (!workflow) return false;
+    removeLegacyEssentials();
+    const ready = [
+      compactHeader(),
+      compactAdapter(),
+      compactPerformance(),
+      compactHotspotStep(),
+    ].every(Boolean);
+    if (ready) workflow.dataset.proDensityReady = '1';
+    return ready;
+  }
+
+  function retry() {
+    if (applyDensityPass()) {
+      if (observer) observer.disconnect();
+      if (retryTimer) window.clearTimeout(retryTimer);
+      return;
+    }
+    attempts += 1;
+    if (attempts >= RETRY_LIMIT) return;
+    retryTimer = window.setTimeout(retry, 75);
+  }
+
+  function start() {
+    if (applyDensityPass()) return;
+    observer = new MutationObserver(() => {
+      if (applyDensityPass() && observer) observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    retry();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/pro_guided_workflow.css
+++ b/assets/pro_guided_workflow.css
@@ -5,20 +5,27 @@ body[data-ui-mode="advanced"] .pro-nav-svg {
   margin-right: 12px;
   color: var(--accent-primary);
 }
-body[data-ui-mode="advanced"] .pro-configuration > .settings-header {
-  display: none !important;
-}
+
+body[data-ui-mode="advanced"] .pro-configuration > .settings-header,
 body[data-ui-mode="advanced"] #tab-telemetry,
-body[data-ui-mode="advanced"] #tab-logs {
+body[data-ui-mode="advanced"] #tab-logs,
+body[data-ui-mode="advanced"] [data-field="qos_preset"],
+body[data-ui-mode="advanced"] .pro-config-essentials {
   display: none !important;
 }
+
+body[data-ui-mode="advanced"] #tab-overview {
+  margin: 0;
+}
+
 body[data-ui-mode="advanced"] .pro-guided-shell,
 body[data-ui-mode="advanced"] .troubleshooting-shell {
-  width: min(1540px, 100%);
+  width: min(1280px, 100%);
   margin: 0 auto;
   display: grid;
-  gap: 22px;
+  gap: 16px;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-card,
 body[data-ui-mode="advanced"] .pro-quality-card {
   overflow: hidden;
@@ -27,133 +34,361 @@ body[data-ui-mode="advanced"] .pro-quality-card {
   background: var(--bg-panel);
   box-shadow: var(--shadow-sm);
 }
+
 body[data-ui-mode="advanced"] .pro-guided-header,
 body[data-ui-mode="advanced"] .pro-quality-header {
-  padding: 22px 26px;
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-subtle);
 }
+
+body[data-ui-mode="advanced"] .pro-guided-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 14px 18px;
+}
+
+body[data-ui-mode="advanced"] .pro-guided-header-copy {
+  min-width: 0;
+}
+
 body[data-ui-mode="advanced"] .pro-guided-header h2,
 body[data-ui-mode="advanced"] .pro-quality-header h2 {
   margin: 0;
-  font-size: 20px;
+  color: var(--text-main);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: .055em;
+  text-transform: uppercase;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-header p {
-  margin: 6px 0 0;
+  margin: 4px 0 0;
   color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+body[data-ui-mode="advanced"] .pro-guided-header-meta {
+  display: grid;
+  justify-items: end;
+  gap: 5px;
+  min-width: 190px;
+}
+
+body[data-ui-mode="advanced"] .pro-header-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-main);
   font-size: 14px;
+  font-weight: 700;
 }
+
+body[data-ui-mode="advanced"] .pro-header-status::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+body[data-ui-mode="advanced"] .pro-header-status[data-state="running"]::before {
+  background: var(--success);
+  box-shadow: 0 0 8px rgba(0, 255, 157, .38);
+}
+
+body[data-ui-mode="advanced"] .pro-header-status[data-state="working"]::before {
+  background: var(--accent-primary);
+}
+
+body[data-ui-mode="advanced"] .pro-header-status[data-state="error"]::before {
+  background: var(--danger);
+}
+
 body[data-ui-mode="advanced"] .pro-guided-steps {
-  padding: 26px;
+  display: grid;
+  padding: 18px 20px;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-step {
   display: grid;
-  grid-template-columns: 42px minmax(0, 1fr);
-  gap: 8px;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-number {
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
+  margin-top: 1px;
   border: 1px solid var(--border-active);
   border-radius: 50%;
   color: var(--accent-primary);
   background: var(--bg-subtle);
+  font-size: 13px;
   font-weight: 700;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-content {
+  display: grid;
+  grid-template-columns: minmax(190px, 238px) minmax(0, 1fr);
+  grid-template-rows: auto 1fr;
+  column-gap: 24px;
   min-width: 0;
-  padding: 0 0 26px 8px;
-  margin-bottom: 24px;
+  padding: 0 0 18px 2px;
+  margin-bottom: 18px;
   border-bottom: 1px solid var(--border-subtle);
 }
+
 body[data-ui-mode="advanced"] .pro-guided-step:last-child .pro-guided-content {
   padding-bottom: 0;
   margin-bottom: 0;
   border-bottom: 0;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-title {
+  grid-column: 1;
+  grid-row: 1;
   margin: 2px 0 0;
-  font-size: 21px;
+  color: var(--text-main);
+  font-size: 17px;
+  font-weight: 650;
+  line-height: 1.3;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-help {
-  margin: 6px 0 18px;
+  grid-column: 1;
+  grid-row: 2;
+  margin: 6px 0 0;
   color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.45;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-slot {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: start;
   min-width: 0;
 }
-body[data-ui-mode="advanced"] .pro-hotspot-fields,
-body[data-ui-mode="advanced"] .pro-guided-action {
+
+body[data-ui-mode="advanced"] .pro-guided-slot > [data-field],
+body[data-ui-mode="advanced"] .pro-guided-slot .form-group,
+body[data-ui-mode="advanced"] .pro-guided-slot .preset-bar {
+  margin: 0 !important;
+}
+
+body[data-ui-mode="advanced"] .pro-adapter-field > label,
+body[data-ui-mode="advanced"] .pro-adapter-field > .field-label-with-tip,
+body[data-ui-mode="advanced"] .pro-performance-picker > .label,
+body[data-ui-mode="advanced"] .pro-password-field > label {
+  display: none !important;
+}
+
+body[data-ui-mode="advanced"] .pro-adapter-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
 }
-body[data-ui-mode="advanced"] .pro-hotspot-fields > :last-child {
-  grid-column: 1 / -1;
+
+body[data-ui-mode="advanced"] .pro-adapter-row select {
+  min-width: 0;
+  height: 50px;
 }
+
+body[data-ui-mode="advanced"] .pro-adapter-badge {
+  display: inline-flex;
+  min-height: 32px;
+  padding: 0 11px;
+  align-items: center;
+  border: 1px solid var(--border-active);
+  border-radius: 999px;
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+body[data-ui-mode="advanced"] .pro-adapter-badge[hidden] {
+  display: none !important;
+}
+
+body[data-ui-mode="advanced"] .pro-adapter-rescan {
+  min-height: 40px !important;
+  padding: 0 12px !important;
+  border-color: transparent !important;
+  background: transparent !important;
+  color: var(--accent-primary) !important;
+  box-shadow: none !important;
+}
+
+body[data-ui-mode="advanced"] .pro-adapter-field #adapterHint {
+  margin-top: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 body[data-ui-mode="advanced"] .pro-performance-picker .btn-group {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
+  gap: 9px;
 }
+
 body[data-ui-mode="advanced"] .pro-performance-picker .btn {
-  min-height: 50px;
+  min-width: 0;
+  min-height: 54px;
+  padding: 9px 12px !important;
+  justify-content: center;
+  white-space: normal;
+  line-height: 1.25;
 }
+
+body[data-ui-mode="advanced"] .pro-performance-picker .btn.is-selected,
+body[data-ui-mode="advanced"] .pro-performance-picker .btn[aria-pressed="true"] {
+  border-color: var(--border-active);
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+  box-shadow: var(--shadow-glow);
+}
+
+body[data-ui-mode="advanced"] .pro-performance-description {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+body[data-ui-mode="advanced"] .pro-hotspot-fields {
+  display: grid;
+  grid-template-columns: minmax(0, .8fr) minmax(340px, 1.2fr);
+  gap: 14px 18px;
+  align-items: start;
+}
+
+body[data-ui-mode="advanced"] .pro-hotspot-fields > [data-field="enable_internet"] {
+  grid-column: 1 / -1;
+  padding-top: 2px;
+}
+
+body[data-ui-mode="advanced"] .pro-hotspot-fields input,
+body[data-ui-mode="advanced"] .pro-password-row .btn.icon-only {
+  height: 50px;
+}
+
+body[data-ui-mode="advanced"] .pro-password-field {
+  min-width: 0;
+}
+
+body[data-ui-mode="advanced"] .pro-password-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 50px 50px;
+  gap: 10px;
+  align-items: stretch;
+  width: 100%;
+}
+
+body[data-ui-mode="advanced"] .pro-password-row #wpa2_passphrase {
+  min-width: 0;
+  margin: 0 !important;
+}
+
+body[data-ui-mode="advanced"] .pro-password-row .btn.icon-only {
+  width: 50px !important;
+  min-width: 50px !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  align-self: stretch;
+}
+
+body[data-ui-mode="advanced"] .pro-password-hint {
+  min-height: 0;
+  margin-top: 7px !important;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 body[data-ui-mode="advanced"] .pro-advanced-settings > summary,
 body[data-ui-mode="advanced"] .pro-quality-details > summary {
   cursor: pointer;
   color: var(--accent-primary);
   font-weight: 700;
 }
+
 body[data-ui-mode="advanced"] .pro-advanced-body {
   display: grid;
-  gap: 16px;
-  margin-top: 16px;
+  gap: 14px;
+  margin-top: 14px;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 360px);
+  gap: 18px;
   align-items: center;
 }
+
 body[data-ui-mode="advanced"] .pro-guided-action .pro-service-primary {
-  min-height: 58px;
+  min-height: 54px;
 }
+
 body[data-ui-mode="advanced"] .pro-save-state {
-  margin-top: 10px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 12px;
 }
+
 body[data-ui-mode="advanced"] .pro-save-state[data-state="error"] {
   color: var(--danger);
 }
+
 body[data-ui-mode="advanced"] .pro-save-state[data-state="saved"] {
   color: var(--success);
 }
+
+body[data-ui-mode="advanced"] .pro-guided-header-meta .pro-save-state {
+  margin: 0;
+  text-align: right;
+}
+
 body[data-ui-mode="advanced"] .pro-guided-hidden {
   display: none !important;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  padding: 15px 18px;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-body {
-  padding: 20px 22px;
+  padding: 16px 18px;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-summary {
   color: var(--text-main);
-  font-size: 16px;
+  font-size: 15px;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-details {
-  margin-top: 16px;
+  margin-top: 13px;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-details .chart-wrapper {
   min-height: 220px;
 }
+
 body[data-ui-mode="advanced"] .pro-quality-settings {
-  margin-top: 18px;
+  margin-top: 16px;
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-header {
   display: flex;
   justify-content: space-between;
@@ -164,19 +399,23 @@ body[data-ui-mode="advanced"] .troubleshooting-header {
   border-radius: var(--radius-lg);
   background: var(--bg-panel);
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-header h2 {
   margin: 0;
   font-size: 24px;
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-header p {
   margin: 6px 0 0;
   color: var(--text-muted);
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-actions {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-section-label {
   margin: 0;
   padding: 16px 20px;
@@ -185,18 +424,79 @@ body[data-ui-mode="advanced"] .troubleshooting-section-label {
   background: var(--bg-subtle);
   font-size: 17px;
 }
+
 body[data-ui-mode="advanced"] .troubleshooting-shell .preflight-page,
 body[data-ui-mode="advanced"] .troubleshooting-shell .pro-runtime-details,
 body[data-ui-mode="advanced"] .troubleshooting-shell .pro-support-bundle-card,
 body[data-ui-mode="advanced"] .troubleshooting-shell .card {
   margin: 0;
 }
-@media (max-width: 900px) {
+
+@media (max-width: 1050px) {
+  body[data-ui-mode="advanced"] .pro-guided-content {
+    grid-template-columns: minmax(170px, 210px) minmax(0, 1fr);
+    column-gap: 18px;
+  }
+
+  body[data-ui-mode="advanced"] .pro-performance-picker .btn-group {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  body[data-ui-mode="advanced"] .pro-hotspot-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="advanced"] .pro-hotspot-fields > [data-field="enable_internet"] {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  body[data-ui-mode="advanced"] .pro-guided-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-ui-mode="advanced"] .pro-guided-header-meta {
+    justify-items: start;
+    min-width: 0;
+  }
+
+  body[data-ui-mode="advanced"] .pro-guided-header-meta .pro-save-state {
+    text-align: left;
+  }
+
+  body[data-ui-mode="advanced"] .pro-guided-steps {
+    padding: 16px;
+  }
+
+  body[data-ui-mode="advanced"] .pro-guided-content {
+    display: block;
+    padding-bottom: 18px;
+    margin-bottom: 18px;
+  }
+
+  body[data-ui-mode="advanced"] .pro-guided-help {
+    margin-bottom: 12px;
+  }
+
+  body[data-ui-mode="advanced"] .pro-adapter-row,
   body[data-ui-mode="advanced"] .pro-performance-picker .btn-group,
-  body[data-ui-mode="advanced"] .pro-hotspot-fields,
   body[data-ui-mode="advanced"] .pro-guided-action {
     grid-template-columns: minmax(0, 1fr);
   }
+
+  body[data-ui-mode="advanced"] .pro-adapter-badge {
+    justify-self: start;
+  }
+
+  body[data-ui-mode="advanced"] .pro-adapter-rescan {
+    justify-self: start;
+  }
+
+  body[data-ui-mode="advanced"] .pro-password-row {
+    grid-template-columns: minmax(0, 1fr) 50px 50px;
+  }
+
   body[data-ui-mode="advanced"] .troubleshooting-header {
     align-items: flex-start;
     flex-direction: column;

--- a/tests/test_pro_guided_workflow.py
+++ b/tests/test_pro_guided_workflow.py
@@ -113,6 +113,66 @@ def test_setup_navigation_uses_vector_wifi_icon_not_emoji() -> None:
     assert "📡" not in source
 
 
+def test_density_pass_compacts_header_and_uses_horizontal_step_space() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
+
+    assert "polishProSetupDensity" in loader
+    assert "pro-guided-header-meta" in loader
+    assert "proHeaderStatus" in loader
+    assert "width: min(1280px, 100%)" in style
+    assert "grid-template-columns: minmax(190px, 238px) minmax(0, 1fr)" in style
+    assert "padding: 14px 18px" in style
+
+
+def test_density_pass_removes_legacy_essentials_and_duplicate_qos_ui() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
+
+    assert "removeLegacyEssentials" in loader
+    assert "document.querySelectorAll('.pro-config-essentials')" in loader
+    assert "qosField.hidden = true" in loader
+    assert "hiddenControls.appendChild(qosField)" in loader
+    assert '[data-field="qos_preset"]' in style
+    assert ".pro-config-essentials" in style
+
+
+def test_performance_mode_is_the_only_visible_profile_control() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
+
+    assert "PROFILE_COPY" in loader
+    assert "proPerformanceDescription" in loader
+    assert "aria-pressed" in loader
+    assert "is-selected" in loader
+    assert ".pro-performance-picker .btn-group" in style
+    assert "repeat(4, minmax(0, 1fr))" in style
+
+
+def test_pro_password_row_matches_basic_three_control_pattern() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
+
+    assert "function compactPassword()" in loader
+    assert "row.append(input, reveal, qr)" in loader
+    assert "qr.textContent = 'QR'" in loader
+    assert "Show or hide password" in loader
+    assert ".pro-password-row" in style
+    assert "grid-template-columns: minmax(0, 1fr) 50px 50px" in style
+    assert "height: 50px" in style
+
+
+def test_adapter_controls_are_one_compact_row() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    style = STYLE.read_text(encoding="utf-8")
+
+    assert "proAdapterRecommendedBadge" in loader
+    assert "Rescan adapters" in loader
+    assert "recommended.hidden = true" in loader
+    assert ".pro-adapter-row" in style
+    assert "grid-template-columns: minmax(0, 1fr) auto auto" in style
+
+
 @pytest.mark.parametrize("asset", [LOADER, SOURCE, SESSION])
 def test_portal_extensions_parse_with_node(asset: Path) -> None:
     node = shutil.which("node")


### PR DESCRIPTION
## Goal

Tighten the upper half of Pro mode without changing hotspot behavior.

## Changes

- Reduce the Pro setup working width from 1540px to 1280px.
- Replace stacked step content with a horizontal desktop layout that uses available width efficiently.
- Compact the page header and move current service state plus autosave state into it.
- Remove the legacy Essentials wrapper from the rendered Pro path.
- Keep the raw `qos_preset` field as a hidden backing control only.
- Present one visible Performance Mode selector with selected-state styling and a concise explanation.
- Rebuild the adapter area into one row with the selector, Recommended badge, and Rescan action.
- Rename Step 3 to Hotspot name and password.
- Rebuild the Pro password controls into the same three-control pattern as Basic: password, reveal, QR.
- Place internet sharing directly beneath the hotspot fields.
- Tighten Connection Quality spacing to match the new setup density.

## Safety

- No daemon, networking, firewall, authentication, adapter, or lifecycle changes.
- Existing control IDs and event listeners are preserved by moving the live DOM nodes.
- The hidden QoS backing control remains available to existing profile handlers and autosave.

## Validation

- Added contracts for compact header and horizontal steps.
- Added contracts preventing visible legacy Essentials and duplicate QoS controls.
- Added contracts for selected Performance Mode state.
- Added contracts for Basic/Pro password-control parity and compact adapter controls.
- Full installer and Python 3.11–3.13 matrix required before merge.