### PR TITLE
Restore Pro five-step workflow after density pass

### DIFF
--- a/assets/devhub_upload.js
+++ b/assets/devhub_upload.js
@@ -278,7 +278,7 @@
 
   const assets = [
     '/assets/browser_session.js?v=139-session-hotfix',
-    '/assets/pro_guided_workflow.js?v=139-pro-hotfix',
+    '/assets/pro_guided_workflow.js?v=141-pro-guided-recovery',
   ];
   for (const src of assets) {
     const script = document.createElement('script');

--- a/assets/pro_guided_workflow.js
+++ b/assets/pro_guided_workflow.js
@@ -3,7 +3,7 @@
 
   const AUTOSAVE_DELAY_MS = 650;
   const SAVE_TIMEOUT_MS = 12000;
-  const RETRY_LIMIT = 120;
+  const RETRY_LIMIT = 600;
   let initialized = false;
   let guidedReady = false;
   let qualityReady = false;
@@ -53,7 +53,7 @@
     if (document.querySelector('link[data-pro-guided-styles]')) return;
     const stylesheet = document.createElement('link');
     stylesheet.rel = 'stylesheet';
-    stylesheet.href = '/assets/pro_guided_workflow.css?v=139-pro-hotfix';
+    stylesheet.href = '/assets/pro_guided_workflow.css?v=141-pro-guided-recovery';
     stylesheet.dataset.proGuidedStyles = '1';
     document.head.appendChild(stylesheet);
   }
@@ -187,13 +187,38 @@
     if (diagnosticsPane) diagnosticsPane.id = 'tab-troubleshooting';
   }
 
-  function buildGuidedSetup() {
-    if (el('proGuidedWorkflow')) return true;
+  function guidedPrerequisitesReady() {
     const overview = el('tab-overview');
-    const oldShell = overview?.querySelector('.pro-setup-shell');
     const configuration = el('proHotspotConfiguration');
     const serviceCard = overview?.querySelector('.pro-service-card');
-    if (!overview || !oldShell || !configuration || !serviceCard) return false;
+    const requiredIds = [
+      'ap_adapter',
+      'btnReloadAdapters',
+      'btnApplyVrProfileUltra',
+      'btnApplyVrProfile',
+      'btnApplyVrProfileHigh',
+      'btnApplyVrProfileStable',
+      'qos_preset',
+      'ssid',
+      'wpa2_passphrase',
+      'enable_internet',
+      'btnStart',
+      'btnSaveConfig',
+      'btnSaveRestart',
+    ];
+    return !!overview
+      && !!configuration
+      && !!serviceCard
+      && !!configuration.querySelector('.preset-bar')
+      && requiredIds.every((id) => !!el(id));
+  }
+
+  function buildGuidedSetup() {
+    if (el('proGuidedWorkflow')) return true;
+    if (!guidedPrerequisitesReady()) return false;
+    const overview = el('tab-overview');
+    const configuration = el('proHotspotConfiguration');
+    const serviceCard = overview.querySelector('.pro-service-card');
 
     const shell = make('div', 'pro-guided-shell');
     shell.id = 'proGuidedWorkflow';
@@ -215,43 +240,38 @@
     shell.appendChild(card);
 
     const adapter = document.querySelector('[data-field="ap_adapter"]');
-    if (adapter) {
-      const label = adapter.querySelector('label');
-      if (label) label.textContent = 'Wi-Fi adapter';
-      el('proStepAdapter').appendChild(adapter);
-    }
+    const adapterLabel = adapter.querySelector('label');
+    if (adapterLabel) adapterLabel.textContent = 'Wi-Fi adapter';
+    el('proStepAdapter').appendChild(adapter);
 
     const preset = configuration.querySelector('.preset-bar');
-    if (preset) {
-      preset.classList.add('pro-performance-picker');
-      const group = preset.querySelector('.btn-group');
-      const order = [
-        el('btnApplyVrProfileUltra'),
-        el('btnApplyVrProfile'),
-        el('btnApplyVrProfileHigh'),
-        el('btnApplyVrProfileStable'),
-      ].filter(Boolean);
-      if (group) order.forEach((button) => group.appendChild(button));
-      el('proStepPerformance').appendChild(preset);
-    }
+    preset.classList.add('pro-performance-picker');
+    const group = preset.querySelector('.btn-group');
+    const order = [
+      el('btnApplyVrProfileUltra'),
+      el('btnApplyVrProfile'),
+      el('btnApplyVrProfileHigh'),
+      el('btnApplyVrProfileStable'),
+    ];
+    if (group) order.forEach((button) => group.appendChild(button));
+    el('proStepPerformance').appendChild(preset);
+
     const qos = document.querySelector('[data-field="qos_preset"]');
-    if (qos) {
-      qos.classList.add('pro-guided-hidden');
-      el('proStepPerformance').appendChild(qos);
-    }
+    qos.classList.add('pro-guided-hidden');
+    el('proStepPerformance').appendChild(qos);
 
     const hotspotFields = make('div', 'pro-hotspot-fields');
     for (const key of ['ssid', 'wpa2_passphrase', 'enable_internet']) {
       const field = document.querySelector(`[data-field="${key}"]`);
-      if (field && key === 'ssid') {
+      if (key === 'ssid') {
         const label = field.querySelector('label');
         if (label) label.textContent = 'Hotspot name';
       }
-      if (field && key === 'wpa2_passphrase') {
+      if (key === 'wpa2_passphrase') {
         const label = field.querySelector('label');
         if (label) label.textContent = 'Password';
       }
-      if (field) hotspotFields.appendChild(field);
+      hotspotFields.appendChild(field);
     }
     el('proStepHotspot').appendChild(hotspotFields);
 
@@ -266,7 +286,7 @@
     const stateCopy = serviceCard.querySelector('.pro-service-state-copy');
     const primary = el('btnStart');
     if (stateCopy) action.appendChild(stateCopy);
-    if (primary) action.appendChild(primary);
+    action.appendChild(primary);
     const actionSlot = el('proStepAction');
     const saveState = make('div', 'pro-save-state', 'All changes saved.');
     saveState.id = 'proSaveState';
@@ -287,7 +307,7 @@
     wireAutosave(card);
     updateDependencies();
 
-    if (primary && primary.dataset.proGuidedWired !== '1') {
+    if (primary.dataset.proGuidedWired !== '1') {
       primary.dataset.proGuidedWired = '1';
       primary.addEventListener('click', async (event) => {
         if (primary.dataset.proGuidedAction !== 'apply') return;
@@ -433,15 +453,29 @@
       if (guidedReady && !qualityReady) qualityReady = buildConnectionQuality();
       if (!troubleshootingReady) troubleshootingReady = buildTroubleshooting();
       initialized = guidedReady && qualityReady && troubleshootingReady;
-      if (initialized && document.body) delete document.body.dataset.proGuidedError;
+      if (document.body) {
+        document.body.dataset.proGuidedStage = initialized
+          ? 'ready'
+          : guidedReady
+            ? 'guided-ready'
+            : 'waiting-for-base';
+        if (initialized) delete document.body.dataset.proGuidedError;
+      }
       return initialized;
     } catch (error) {
       if (document.body) {
+        document.body.dataset.proGuidedStage = 'error';
         document.body.dataset.proGuidedError = String(error && error.message ? error.message : error);
       }
       console.error('VRhotspot Pro workflow retrying after UI error.', error);
       return false;
     }
+  }
+
+  function resetRetryBudget() {
+    if (initialized) return;
+    retryCount = 0;
+    scheduleRetry();
   }
 
   function scheduleRetry() {
@@ -462,8 +496,21 @@
   function start() {
     enforceNavigation();
     if (initialize()) return;
-    observer = new MutationObserver(scheduleRetry);
-    observer.observe(document.documentElement, { childList: true, subtree: true });
+    observer = new MutationObserver((records) => {
+      if (records.some((record) => record.type === 'attributes')) retryCount = 0;
+      scheduleRetry();
+    });
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-auth-state', 'data-ui-mode'],
+    });
+    window.addEventListener('pageshow', resetRetryBudget);
+    window.addEventListener('load', resetRetryBudget, { once: true });
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) resetRetryBudget();
+    });
     scheduleRetry();
   }
 

--- a/tests/test_pro_guided_workflow.py
+++ b/tests/test_pro_guided_workflow.py
@@ -16,7 +16,7 @@ def test_pro_runtime_is_loaded_as_versioned_dedicated_assets() -> None:
     source = LOADER.read_text(encoding="utf-8")
 
     assert "/assets/browser_session.js?v=139-session-hotfix" in source
-    assert "/assets/pro_guided_workflow.js?v=139-pro-hotfix" in source
+    assert "/assets/pro_guided_workflow.js?v=141-pro-guided-recovery" in source
     assert "script.async = false" in source
 
 

--- a/tests/test_pro_guided_workflow.py
+++ b/tests/test_pro_guided_workflow.py
@@ -75,8 +75,35 @@ def test_navigation_cleanup_runs_before_optional_dom_transforms() -> None:
     assert enforce < initialize
     assert first_call < guided_call
     assert "RETRY_LIMIT" in source
-    assert "MutationObserver(scheduleRetry)" in source
+    assert "new MutationObserver((records) =>" in source
     assert "catch (error)" in source
+
+
+def test_guided_builder_recovers_from_post_login_base_layout() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "function guidedPrerequisitesReady()" in source
+    assert "proHotspotConfiguration" in source
+    assert "pro-service-card" in source
+    assert "configuration.querySelector('.preset-bar')" in source
+    assert "requiredIds.every" in source
+    assert "oldShell" not in source
+    assert "RETRY_LIMIT = 600" in source
+    assert "resetRetryBudget" in source
+    assert "data-auth-state" in source
+    assert "data-ui-mode" in source
+    assert "pageshow" in source
+    assert "visibilitychange" in source
+
+
+def test_guided_runtime_exposes_stage_and_error_state() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "dataset.proGuidedStage" in source
+    assert "waiting-for-base" in source
+    assert "guided-ready" in source
+    assert "dataset.proGuidedError" in source
+    assert "/assets/pro_guided_workflow.css?v=141-pro-guided-recovery" in source
 
 
 def test_connection_quality_is_pro_only_and_not_a_sidebar_tab() -> None:


### PR DESCRIPTION
## Problem

Real-system validation after #140 showed the legacy Pro base layout instead of the intended guided 1–5 workflow. The density CSS loaded, but the guided builder never transitioned the post-login base DOM.

## Fix

- Remove the brittle `.pro-setup-shell` prerequisite from the guided builder.
- Wait for the actual live controls required by the five-step workflow: adapter, profile buttons, QoS backing field, hotspot fields, and service/save actions.
- Increase the retry window and reset it on authentication state, UI mode, page-show, page-load, and visibility changes.
- Observe the post-login DOM attributes as well as child mutations.
- Expose `data-pro-guided-stage` and `data-pro-guided-error` for deterministic runtime diagnosis.
- Version-bump the guided JavaScript and stylesheet URLs so browsers cannot reuse the failed runtime.
- Preserve the #140 density treatment once the five-step shell is ready.

## Expected result

Pro mode keeps the same visible five steps as Basic mode, while Step 4 exposes the advanced Wireless, Network, and System & Performance controls.

## Safety

- No daemon, adapter, hotspot, firewall, authentication, or networking behavior changes.
- Existing live control IDs and event handlers remain in place.

## Validation

- Added contracts for exact post-login base-layout prerequisites.
- Added contracts preventing the old wrapper from becoming a required condition.
- Added retry/recovery and runtime-stage contracts.
- Full installer and Python 3.11–3.13 matrix required before merge.